### PR TITLE
Improve capture runtime behavior

### DIFF
--- a/GameChatTranslator/AreaSelector.xaml.cs
+++ b/GameChatTranslator/AreaSelector.xaml.cs
@@ -23,6 +23,17 @@ namespace GameTranslator
         public AreaSelector()
         {
             InitializeComponent();
+            ConfigureVirtualScreenBounds();
+        }
+
+        private void ConfigureVirtualScreenBounds()
+        {
+            WindowStartupLocation = WindowStartupLocation.Manual;
+            WindowState = WindowState.Normal;
+            Left = SystemParameters.VirtualScreenLeft;
+            Top = SystemParameters.VirtualScreenTop;
+            Width = SystemParameters.VirtualScreenWidth;
+            Height = SystemParameters.VirtualScreenHeight;
         }
 
         // ==========================================
@@ -87,7 +98,21 @@ namespace GameTranslator
                 MainWindow mainWindow = Owner as MainWindow;
 
                 // 메인 창의 SetCaptureArea 함수를 실행하여 방금 그린 캡처 영역 데이터를 전달
-                mainWindow.SetCaptureArea(selectionArea);
+                Rectangle screenArea = new Rectangle(
+                    (int)(Left + selectionArea.X),
+                    (int)(Top + selectionArea.Y),
+                    selectionArea.Width,
+                    selectionArea.Height);
+
+                System.Windows.Point topLeft = PointToScreen(new System.Windows.Point(selectionArea.X, selectionArea.Y));
+                System.Windows.Point bottomRight = PointToScreen(new System.Windows.Point(selectionArea.Right, selectionArea.Bottom));
+                Rectangle pixelArea = new Rectangle(
+                    (int)Math.Round(Math.Min(topLeft.X, bottomRight.X)),
+                    (int)Math.Round(Math.Min(topLeft.Y, bottomRight.Y)),
+                    Math.Max(1, (int)Math.Round(Math.Abs(bottomRight.X - topLeft.X))),
+                    Math.Max(1, (int)Math.Round(Math.Abs(bottomRight.Y - topLeft.Y))));
+
+                mainWindow.SetCaptureArea(screenArea, pixelArea);
 
                 // 영역 지정이 끝났으므로 반투명 캡처 창은 닫음
                 this.Close();

--- a/GameChatTranslator/MainWindow.Capture.cs
+++ b/GameChatTranslator/MainWindow.Capture.cs
@@ -35,7 +35,12 @@ namespace GameTranslator
         }
         public void SetCaptureArea(Rectangle area)
         {
+            SetCaptureArea(area, ConvertDisplayAreaToPixels(area));
+        }
+        public void SetCaptureArea(Rectangle area, Rectangle pixelArea)
+        {
             gameChatArea = area;
+            gameChatCaptureArea = pixelArea;
             this.Top = area.Y + area.Height + 50;
             this.Left = area.X - 5;
             this.SizeToContent = SizeToContent.Manual;
@@ -50,10 +55,40 @@ namespace GameTranslator
             ini.Write("CaptureY", area.Y.ToString());
             ini.Write("CaptureW", area.Width.ToString());
             ini.Write("CaptureH", area.Height.ToString());
+            ini.Write("CapturePixelX", pixelArea.X.ToString());
+            ini.Write("CapturePixelY", pixelArea.Y.ToString());
+            ini.Write("CapturePixelW", pixelArea.Width.ToString());
+            ini.Write("CapturePixelH", pixelArea.Height.ToString());
             ini.Write("WindowW", this.ActualWidth.ToString());
             ini.Write("WindowH", this.ActualHeight.ToString());
 
+            ResetTranslationCache("캡처 영역 변경");
             UpdateCaptureBorder(!isLocked);
+        }
+        private Rectangle ConvertDisplayAreaToPixels(Rectangle area)
+        {
+            PresentationSource source = PresentationSource.FromVisual(this);
+            Matrix transform = source?.CompositionTarget?.TransformToDevice ?? Matrix.Identity;
+
+            System.Windows.Point topLeft = transform.Transform(new System.Windows.Point(area.X, area.Y));
+            System.Windows.Point bottomRight = transform.Transform(new System.Windows.Point(area.Right, area.Bottom));
+
+            return new Rectangle(
+                (int)Math.Round(Math.Min(topLeft.X, bottomRight.X)),
+                (int)Math.Round(Math.Min(topLeft.Y, bottomRight.Y)),
+                Math.Max(1, (int)Math.Round(Math.Abs(bottomRight.X - topLeft.X))),
+                Math.Max(1, (int)Math.Round(Math.Abs(bottomRight.Y - topLeft.Y))));
+        }
+        private Rectangle GetCapturePixelArea()
+        {
+            if (gameChatCaptureArea != Rectangle.Empty &&
+                gameChatCaptureArea.Width > 0 &&
+                gameChatCaptureArea.Height > 0)
+            {
+                return gameChatCaptureArea;
+            }
+
+            return ConvertDisplayAreaToPixels(gameChatArea);
         }
         private void UpdateCaptureBorder(bool show)
         {

--- a/GameChatTranslator/MainWindow.Lifecycle.cs
+++ b/GameChatTranslator/MainWindow.Lifecycle.cs
@@ -108,12 +108,25 @@ namespace GameTranslator
             string cy = ini.Read("CaptureY");
             string cw = ini.Read("CaptureW");
             string ch = ini.Read("CaptureH");
+            string cpx = ini.Read("CapturePixelX");
+            string cpy = ini.Read("CapturePixelY");
+            string cpw = ini.Read("CapturePixelW");
+            string cph = ini.Read("CapturePixelH");
             double screenH = SystemParameters.PrimaryScreenHeight;
 
             if (int.TryParse(cx, out int x) && int.TryParse(cy, out int y) &&
                 int.TryParse(cw, out int w) && int.TryParse(ch, out int h) && w > 0 && h > 0)
             {
                 gameChatArea = new Rectangle(x, y, w, h);
+                if (int.TryParse(cpx, out int px) && int.TryParse(cpy, out int py) &&
+                    int.TryParse(cpw, out int pw) && int.TryParse(cph, out int ph) && pw > 0 && ph > 0)
+                {
+                    gameChatCaptureArea = new Rectangle(px, py, pw, ph);
+                }
+                else
+                {
+                    gameChatCaptureArea = ConvertDisplayAreaToPixels(gameChatArea);
+                }
                 this.SizeToContent = SizeToContent.Manual;
                 this.Width = w;
                 this.MinWidth = w;
@@ -130,6 +143,7 @@ namespace GameTranslator
                 this.Left = 20;
                 this.Top = screenH - this.Height - 10;
                 gameChatArea = new Rectangle((int)this.Left, (int)(this.Top - 250 - 10), 500, 250);
+                gameChatCaptureArea = ConvertDisplayAreaToPixels(gameChatArea);
 
                 string missingLangs = "";
                 if (!ocrEngines.ContainsKey("ru")) missingLangs += "러시아어 ";

--- a/GameChatTranslator/MainWindow.Settings.cs
+++ b/GameChatTranslator/MainWindow.Settings.cs
@@ -58,6 +58,11 @@ namespace GameTranslator
             {
                 ini.Write("GeminiModel", DefaultGeminiModel);
             }
+
+            if (string.IsNullOrWhiteSpace(ini.Read("SaveDebugImages")))
+            {
+                ini.Write("SaveDebugImages", "false");
+            }
         }
         private string ReadGeminiKey()
         {
@@ -82,6 +87,15 @@ namespace GameTranslator
         {
             string modelName = ini.Read("GeminiModel");
             return string.IsNullOrWhiteSpace(modelName) ? DefaultGeminiModel : modelName.Trim();
+        }
+
+        private bool ShouldSaveDebugImages()
+        {
+            string value = ini.Read("SaveDebugImages") ?? "false";
+            return value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("y", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/GameChatTranslator/MainWindow.Translation.cs
+++ b/GameChatTranslator/MainWindow.Translation.cs
@@ -50,6 +50,7 @@ namespace GameTranslator
 
             // 엔진 상태 반전 (true <-> false)
             useGeminiEngine = !useGeminiEngine;
+            ResetTranslationCache("번역 엔진 변경");
             string currentEngine = useGeminiEngine ? "Gemini AI" : "Google 무료";
 
             AppendLog($"번역 엔진이 '{currentEngine}'(으)로 실시간 변경되었습니다.");
@@ -59,6 +60,11 @@ namespace GameTranslator
             TxtResult.Inlines.Add(new Run($"🔄 번역 엔진 변경됨: [ {currentEngine} ]") { Foreground = Brushes.Cyan, FontWeight = FontWeights.Bold });
 
             UpdateYellowHotkeyGuideText(); // 노란색 안내문구도 업데이트
+        }
+        private void ResetTranslationCache(string reason)
+        {
+            lastRawTextCombined = "";
+            AppendLog($"재번역 캐시 초기화: {reason}");
         }
         private class MergedLine
         {
@@ -93,12 +99,13 @@ namespace GameTranslator
 
             try
             {
-                using Bitmap rawBitmap = new Bitmap(gameChatArea.Width, gameChatArea.Height);
+                Rectangle captureArea = GetCapturePixelArea();
+                using Bitmap rawBitmap = new Bitmap(captureArea.Width, captureArea.Height);
                 using (Graphics g = Graphics.FromImage(rawBitmap))
                 {
                     IntPtr hdcSrc = GetWindowDC(IntPtr.Zero);
                     IntPtr hdcDest = g.GetHdc();
-                    BitBlt(hdcDest, 0, 0, gameChatArea.Width, gameChatArea.Height, hdcSrc, gameChatArea.X, gameChatArea.Y, 0x00CC0020);
+                    BitBlt(hdcDest, 0, 0, captureArea.Width, captureArea.Height, hdcSrc, captureArea.X, captureArea.Y, 0x00CC0020);
                     g.ReleaseHdc(hdcDest);
                     ReleaseDC(IntPtr.Zero, hdcSrc);
                 }
@@ -141,14 +148,17 @@ namespace GameTranslator
                 Marshal.Copy(rgbValues, 0, bmpData.Scan0, bytes);
                 resizedBitmap.UnlockBits(bmpData);
 
-                // 🌟 [프레임 방어 최적화] 메인 스레드 대기 방지를 위해 복사본을 만들어 백그라운드 저장
-                Bitmap rawClone = new Bitmap(rawBitmap);
-                Bitmap resizeClone = new Bitmap(resizedBitmap);
-                _ = Task.Run(() =>
+                if (ShouldSaveDebugImages())
                 {
-                    using (rawClone) SaveDebugImage(rawClone, "[Origin]");
-                    using (resizeClone) SaveDebugImage(resizeClone, "[Resize]");
-                });
+                    // 🌟 [프레임 방어 최적화] 메인 스레드 대기 방지를 위해 복사본을 만들어 백그라운드 저장
+                    Bitmap rawClone = new Bitmap(rawBitmap);
+                    Bitmap resizeClone = new Bitmap(resizedBitmap);
+                    _ = Task.Run(() =>
+                    {
+                        using (rawClone) SaveDebugImage(rawClone, "[Origin]");
+                        using (resizeClone) SaveDebugImage(resizeClone, "[Resize]");
+                    });
+                }
 
                 int cropTop = 0;
                 int cropBottom = (int)(resizedBitmap.Height * 0.05);
@@ -163,9 +173,12 @@ namespace GameTranslator
                                 new Rectangle(0, cropTop, resizedBitmap.Width, newH), GraphicsUnit.Pixel);
                 }
 
-                // 🌟 [프레임 방어 최적화] 백그라운드 저장
-                Bitmap cropClone = new Bitmap(croppedBitmap);
-                _ = Task.Run(() => { using (cropClone) SaveDebugImage(cropClone, "[Cropped]"); });
+                if (ShouldSaveDebugImages())
+                {
+                    // 🌟 [프레임 방어 최적화] 백그라운드 저장
+                    Bitmap cropClone = new Bitmap(croppedBitmap);
+                    _ = Task.Run(() => { using (cropClone) SaveDebugImage(cropClone, "[Cropped]"); });
+                }
 
                 using MemoryStream ms = new MemoryStream();
                 croppedBitmap.Save(ms, ImageFormat.Png);

--- a/GameChatTranslator/MainWindow.xaml.cs
+++ b/GameChatTranslator/MainWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace GameTranslator
         // ==========================================
         private AreaSelector areaSelector;
         private Rectangle gameChatArea;
+        private Rectangle gameChatCaptureArea;
         private Window captureBorderWindow;
 
         private bool isTranslating = false;

--- a/GameChatTranslator/OptionSelector.xaml
+++ b/GameChatTranslator/OptionSelector.xaml
@@ -60,10 +60,12 @@
                     <TextBox x:Name="TxtThreshold" Width="120" TextAlignment="Center" Background="#333" Foreground="White" BorderBrush="#555"/>
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal">
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                     <TextBlock Text="자동 번역 주기 (초):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
                     <TextBox x:Name="TxtInterval" Width="120" TextAlignment="Center" Background="#333" Foreground="White" BorderBrush="#555"/>
                 </StackPanel>
+
+                <CheckBox x:Name="CheckSaveDebugImages" Content="디버그 캡처 이미지 저장" Foreground="#CCC"/>
 
             </StackPanel>
         </GroupBox>

--- a/GameChatTranslator/OptionSelector.xaml.cs
+++ b/GameChatTranslator/OptionSelector.xaml.cs
@@ -82,6 +82,14 @@ namespace GameTranslator
             // UI에 TxtThreshold, TxtInterval 텍스트박스가 있다고 가정합니다.
             if (TxtThreshold != null) TxtThreshold.Text = _ini.Read("Threshold") ?? "120";
             if (TxtInterval != null) TxtInterval.Text = _ini.Read("AutoTranslateInterval") ?? "5";
+
+            string saveDebugImages = _ini.Read("SaveDebugImages") ?? "false";
+            if (CheckSaveDebugImages != null)
+            {
+                CheckSaveDebugImages.IsChecked =
+                    saveDebugImages.Equals("true", System.StringComparison.OrdinalIgnoreCase) ||
+                    saveDebugImages == "1";
+            }
         }
 
         // ==========================================
@@ -191,6 +199,8 @@ namespace GameTranslator
             {
                 _ini.Write("AutoTranslateInterval", "5"); // 숫자가 아니면 기본값 5 강제 지정
             }
+
+            _ini.Write("SaveDebugImages", CheckSaveDebugImages?.IsChecked == true ? "true" : "false");
 
             // DialogResult를 true로 설정하여 메인 창(MainWindow)에 정상 종료되었음을 알리고 창을 닫습니다.
             this.DialogResult = true;

--- a/GameChatTranslator/readme.txt
+++ b/GameChatTranslator/readme.txt
@@ -56,6 +56,7 @@
 - Opacity: 번역창의 불투명도 조절 (0~100)
 - AutoTranslateInterval: 자동 번역 간격(초)
 - Key_... : 사용자 편의에 맞는 단축키 변경
+- SaveDebugImages: 디버그 캡처 이미지 저장 여부 (true/false, 기본 false)
 
 ------------------------------------------
 6. 주의 사항

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - `ScaleFactor`: 캡처 이미지 확대 배율입니다. 3 배 이상일 때 한자 및 일본어 인식률이 가장 좋습니다.
 - `GeminiKey`: Gemini API 키입니다. `[Settings]` 섹션에 저장합니다.
 - `GeminiModel`: Gemini 호출 모델입니다. 기본값은 `gemini-2.5-flash`입니다.
+- `SaveDebugImages`: 디버그용 캡처 이미지를 저장할지 설정합니다. 기본값은 `false`입니다.
 ---
 
 ## 👨‍💻 기여 및 문의


### PR DESCRIPTION
## Summary
- Track WPF display coordinates separately from physical pixel coordinates for DPI-aware `BitBlt` capture
- Expand area selection overlay to the virtual screen and persist `CapturePixel*` values for future runs
- Reset duplicate translation cache when the translation engine or capture area changes
- Add `SaveDebugImages` config/default and settings UI checkbox so debug capture files are opt-in
- Document `SaveDebugImages` in README files

## Verification
- `git diff --check` passed
- `dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true` passed with 1 existing warning (`WFAC010` high DPI manifest setting) and 0 errors

## Runtime Follow-up
- Windows / Visual Studio 2022 환경에서 실제 캡처 영역 정렬 확인 필요
- 특히 125%/150% DPI, 보조 모니터, 영역 재설정 후 번역 재실행, `SaveDebugImages` 체크박스 동작 확인 필요