### PR TITLE
Increase option selector height

### DIFF
--- a/GameChatTranslator/OptionSelector.xaml
+++ b/GameChatTranslator/OptionSelector.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="GameTranslator.OptionSelector"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="GameChatTranslator 환경 설정" Width="500" Height="740"
+        Title="GameChatTranslator 환경 설정" Width="500" Height="780"
         WindowStartupLocation="CenterScreen" Topmost="True" Background="#1E1E1E" Foreground="White" ResizeMode="NoResize">
 
     <Grid Margin="20">


### PR DESCRIPTION
## Summary
- Increase `OptionSelector.xaml` window height from 740 to 780
- Prevent the lower settings area from being clipped at the existing window size

## Verification
- `git diff --check` passed
- `dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true` passed with 1 existing warning (`WFAC010` high DPI manifest setting) and 0 errors