### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,174 @@
+name: Release Build
+
+on:
+  push:
+    tags:
+      - "v.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build, for example v.1.0.8-alpha"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    name: Build and publish Windows release
+    runs-on: windows-latest
+
+    env:
+      DOTNET_NOLOGO: true
+      SOLUTION_PATH: GameChatTranslator.sln
+      PROJECT_PATH: GameChatTranslator/GameChatTranslator.csproj
+      PUBLISH_DIR: ${{ github.workspace }}\artifacts\publish
+      DIST_DIR: ${{ github.workspace }}\artifacts\dist
+
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve release metadata
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $tag = "${{ inputs.tag }}".Trim()
+          } else {
+            $tag = "${{ github.ref_name }}".Trim()
+          }
+
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            throw "Release tag is empty."
+          }
+
+          if ($tag -notmatch '^v\.\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$') {
+            throw "Release tag must look like v.1.0.8 or v.1.0.8-alpha. Actual: $tag"
+          }
+
+          [xml]$project = Get-Content $env:PROJECT_PATH
+          $version = ($project.Project.PropertyGroup | Where-Object { $_.Version } | Select-Object -First 1).Version
+          $expectedTag = "v.$version"
+
+          if ($tag -ne $expectedTag) {
+            throw "Tag and project version do not match. Tag: $tag, expected from .csproj: $expectedTag"
+          }
+
+          $assetVersion = $tag -replace '^v\.', 'v'
+          $zipName = "GameChatTranslator_$assetVersion.zip"
+
+          "RELEASE_TAG=$tag" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "RELEASE_TITLE=GameChatTranslator $tag" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "ASSET_VERSION=$assetVersion" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "ZIP_NAME=$zipName" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        shell: pwsh
+        run: dotnet restore $env:SOLUTION_PATH
+
+      - name: Build
+        shell: pwsh
+        run: dotnet build $env:SOLUTION_PATH -c Release -p:EnableWindowsTargeting=true --no-restore
+
+      - name: Publish win-x64 self-contained package
+        shell: pwsh
+        run: |
+          if (Test-Path $env:PUBLISH_DIR) {
+            Remove-Item $env:PUBLISH_DIR -Recurse -Force
+          }
+
+          dotnet publish $env:PROJECT_PATH `
+            -c Release `
+            -r win-x64 `
+            --self-contained true `
+            -p:EnableWindowsTargeting=true `
+            -p:PublishSingleFile=true `
+            -p:IncludeNativeLibrariesForSelfExtract=true `
+            -o $env:PUBLISH_DIR
+
+      - name: Compress release files and calculate checksum
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path $env:DIST_DIR | Out-Null
+
+          $zipPath = Join-Path $env:DIST_DIR $env:ZIP_NAME
+          if (Test-Path $zipPath) {
+            Remove-Item $zipPath -Force
+          }
+
+          Compress-Archive -Path (Join-Path $env:PUBLISH_DIR '*') -DestinationPath $zipPath -Force
+
+          $hash = (Get-FileHash $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          $checksumPath = Join-Path $env:DIST_DIR "sha256.txt"
+          "$hash  $env:ZIP_NAME" | Set-Content -Path $checksumPath -Encoding utf8
+
+          "ZIP_PATH=$zipPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CHECKSUM_PATH=$checksumPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "SHA256=$hash" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Create or update GitHub release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $repo = $env:GITHUB_REPOSITORY
+          $targetCommit = git rev-parse HEAD
+          $body = @"
+          $env:RELEASE_TITLE 자동 릴리즈 빌드입니다.
+
+          변경 내역은 README.md의 최신 업데이트 내역을 확인해 주세요.
+
+          Build:
+          - Runtime: win-x64
+          - Publish: self-contained single-file
+          - Commit: $targetCommit
+
+          SHA256:
+          $env:SHA256  $env:ZIP_NAME
+          "@
+
+          $payload = @{
+            tag_name = $env:RELEASE_TAG
+            target_commitish = $targetCommit
+            name = $env:RELEASE_TITLE
+            body = $body
+            draft = $false
+            prerelease = $false
+            make_latest = "true"
+          }
+
+          $payloadPath = Join-Path $env:RUNNER_TEMP "release-payload.json"
+          $payload | ConvertTo-Json -Depth 4 | Set-Content -Path $payloadPath -Encoding utf8
+
+          $release = $null
+          try {
+            $release = gh api "repos/$repo/releases/tags/$env:RELEASE_TAG" | ConvertFrom-Json
+          } catch {
+            $release = $null
+          }
+
+          if ($null -eq $release) {
+            gh api -X POST "repos/$repo/releases" --input $payloadPath | Out-Null
+          } else {
+            gh api -X PATCH "repos/$repo/releases/$($release.id)" --input $payloadPath | Out-Null
+          }
+
+          gh release upload $env:RELEASE_TAG $env:ZIP_PATH $env:CHECKSUM_PATH --repo $repo --clobber
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-package
+          path: |
+            artifacts/dist/*.zip
+            artifacts/dist/sha256.txt
+          if-no-files-found: error

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,70 @@
+# Release Automation
+
+GameChatTranslator 릴리즈는 GitHub Actions의 `Release Build` workflow로 자동 빌드할 수 있습니다.
+
+## 릴리즈 순서
+
+1. `GameChatTranslator/GameChatTranslator.csproj`의 버전을 새 버전으로 변경합니다.
+
+   예:
+
+   ```xml
+   <Version>1.0.8-alpha</Version>
+   <AssemblyVersion>1.0.8.0</AssemblyVersion>
+   <FileVersion>1.0.8.0</FileVersion>
+   ```
+
+2. `README.md`의 다운로드 링크와 최신 업데이트 내역을 새 버전으로 변경합니다.
+
+3. `GameChatTranslator/readme.txt`의 버전 표기를 새 버전으로 변경합니다.
+
+4. 변경사항을 `master`에 머지합니다.
+
+5. `master` 최신 커밋에 릴리즈 태그를 생성하고 push합니다.
+
+   ```bash
+   git checkout master
+   git pull --ff-only origin master
+   git tag v.1.0.8-alpha
+   git push origin v.1.0.8-alpha
+   ```
+
+6. GitHub Actions의 `Release Build` workflow가 자동으로 실행됩니다.
+
+## 자동 처리 내용
+
+workflow는 태그 push를 감지하면 아래 작업을 수행합니다.
+
+- Windows `windows-latest` 환경에서 .NET 8 설치
+- `GameChatTranslator.sln` Release 빌드
+- `win-x64` self-contained single-file publish
+- `GameChatTranslator_v1.0.8-alpha.zip` 생성
+- `sha256.txt` 체크섬 생성
+- GitHub Release 생성 또는 기존 Release 갱신
+- zip과 checksum asset 업로드
+- `make_latest=true`로 최신 릴리즈 지정
+
+## 태그와 버전 검증
+
+workflow는 태그와 `.csproj`의 `<Version>` 값이 일치하는지 검사합니다.
+
+예:
+
+```text
+<Version>1.0.8-alpha</Version>
+tag v.1.0.8-alpha
+```
+
+두 값이 다르면 릴리즈를 중단합니다.
+
+## 실패 후 재실행
+
+태그 push 후 workflow가 실패했다면 GitHub Actions 화면에서 `Release Build`를 수동 실행할 수 있습니다.
+
+수동 실행 시 `tag` 입력칸에 기존 태그를 입력합니다.
+
+```text
+v.1.0.8-alpha
+```
+
+workflow는 같은 태그의 Release가 이미 있으면 내용을 갱신하고 asset을 `--clobber`로 다시 업로드합니다.


### PR DESCRIPTION
## Summary
- Add `Release Build` GitHub Actions workflow for tag-based releases
- Build Release on `windows-latest` with .NET 8
- Publish `win-x64` self-contained single-file package
- Compress publish output into `GameChatTranslator_vX.Y.Z[-alpha].zip`
- Generate `sha256.txt` and upload both files as release assets
- Create or update the GitHub Release and set `make_latest=true`
- Add `RELEASE.md` with the release automation process

## How to use
1. Update `.csproj`, `README.md`, and `GameChatTranslator/readme.txt` version entries
2. Merge the release prep commit to `master`
3. Push a matching tag, for example `v.1.0.8-alpha`
4. The workflow builds, zips, uploads assets, and marks the release as latest

## Verification
- `git diff --cached --check`
- Workflow text checks for required release/build/upload steps
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`

Debug and Release builds completed with 0 warnings and 0 errors.

## Notes
- Local environment does not have `pwsh` or `actionlint`, so the first real workflow execution must be verified on GitHub Actions after merge/tag push.