### PR TITLE
GitHub Actions Node.js 24 사용

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-release:
     name: Build and publish Windows release


### PR DESCRIPTION
## 작업 내용
- GitHub Actions JavaScript 액션 실행 런타임을 Node.js 24로 강제하도록 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`를 추가했습니다.
- v1.0.8-alpha 자동 릴리즈 실행 중 표시된 Node.js 20 deprecation 경고를 선제적으로 제거하기 위한 변경입니다.

## 검증
```text
git diff --check
dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
Build succeeded.
0 Warning(s)
0 Error(s)
```

## 참고
- 앱 코드 변경은 없습니다.
- 실제 GitHub Actions 경고 제거 여부는 다음 태그 릴리즈 실행 시 확인됩니다.