### PR TITLE
게시 산출물에 보조 파일 포함

### DIFF
--- a/GameChatTranslator/GameChatTranslator.csproj
+++ b/GameChatTranslator/GameChatTranslator.csproj
@@ -27,14 +27,17 @@
 	  <!-- OCR 캐릭터명 검증 파일입니다. 실행 폴더에 반드시 복사되어야 합니다. -->
 	  <None Update="characters.txt">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	  </None>
 	  <!-- Windows OCR 언어팩 설치 보조 스크립트입니다. 배포 zip에 포함합니다. -->
 	  <None Update="LangInstall.bat">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	  </None>
 	  <!-- 배포 zip에 들어가는 사용자용 간단 설명서입니다. 실제 파일명은 readme.txt입니다. -->
-	  <None Update="README.txt">
+	  <None Update="readme.txt">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	  </None>
 	</ItemGroup>
 


### PR DESCRIPTION
## 원인
- 기존 `.csproj`는 `characters.txt`, `LangInstall.bat`, `readme.txt`에 `CopyToOutputDirectory`만 지정되어 있었습니다.
- 이 설정은 일반 빌드 출력에는 복사되지만, Visual Studio 게시(publish) 산출물에는 누락될 수 있습니다.
- 또한 설명서 항목이 실제 파일명 `readme.txt`가 아니라 `README.txt`로 지정되어 있어 Linux/Actions 같은 대소문자 구분 환경에서는 더 취약했습니다.

## 작업 내용
- `characters.txt`, `LangInstall.bat`, `readme.txt`에 `CopyToPublishDirectory=Always` 추가
- `README.txt` 항목을 실제 파일명인 `readme.txt`로 수정

## 검증
```text
git diff --check
dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
Build succeeded.
0 Warning(s)
0 Error(s)

dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-check
Publish succeeded.
```

게시 산출물 확인:
```text
GameChatTranslator.exe
GameChatTranslator.pdb
LangInstall.bat
characters.txt
readme.txt
```