### PR TITLE
OCR 핵심 로직 테스트 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,10 @@ jobs:
         shell: pwsh
         run: dotnet build $env:SOLUTION_PATH -c Release -p:EnableWindowsTargeting=true --no-restore
 
+      - name: Test
+        shell: pwsh
+        run: dotnet test $env:SOLUTION_PATH -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
+
       - name: Publish win-x64 self-contained package
         shell: pwsh
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ x86/
 bld/
 [Bb]in/
 [Oo]bj/
+**/[Bb]in/
+**/[Oo]bj/
 [Oo]ut/
 [Ll]og/
 [Ll]ogs/

--- a/GameChatTranslator.Tests/ChatTextAnalyzerTests.cs
+++ b/GameChatTranslator.Tests/ChatTextAnalyzerTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class ChatTextAnalyzerTests
+    {
+        private static readonly HashSet<string> KnownCharacters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "미셸",
+            "오드리",
+            "Maddelena"
+        };
+
+        [Theory]
+        [InlineData("[미셸]: hello", "미셸", "hello")]
+        [InlineData("(오드리)：你好", "오드리", "你好")]
+        [InlineData("prefix [Maddelena]! attack now", "Maddelena", "attack now")]
+        public void TryParseChatLine_ExtractsCharacterAndMessage(string rawText, string expectedName, string expectedMessage)
+        {
+            bool parsed = ChatTextAnalyzer.TryParseChatLine(rawText, out ChatTextAnalyzer.ChatLine line);
+
+            Assert.True(parsed);
+            Assert.Equal(expectedName, line.CharacterName);
+            Assert.Equal(expectedMessage, line.Message);
+            Assert.Equal($"[{expectedName}]: ", line.CharacterLabel);
+        }
+
+        [Theory]
+        [InlineData("시스템: 전투가 시작됩니다")]
+        [InlineData("[미셸] hello")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TryParseChatLine_RejectsNonChatFormat(string rawText)
+        {
+            bool parsed = ChatTextAnalyzer.TryParseChatLine(rawText, out ChatTextAnalyzer.ChatLine line);
+
+            Assert.False(parsed);
+            Assert.Null(line);
+        }
+
+        [Fact]
+        public void TryParseKnownCharacterChatLine_RequiresKnownCharacterAndMessage()
+        {
+            Assert.True(ChatTextAnalyzer.TryParseKnownCharacterChatLine("[미셸]: push", KnownCharacters, out ChatTextAnalyzer.ChatLine knownLine));
+            Assert.Equal("미셸", knownLine.CharacterName);
+            Assert.Equal("push", knownLine.Message);
+
+            Assert.False(ChatTextAnalyzer.TryParseKnownCharacterChatLine("[Unknown]: push", KnownCharacters, out _));
+            Assert.False(ChatTextAnalyzer.TryParseKnownCharacterChatLine("[미셸]:   ", KnownCharacters, out _));
+        }
+
+        [Theory]
+        [InlineData("12345 !!!", false)]
+        [InlineData("[미셸]: 你好", true)]
+        [InlineData("[오드리]: hello", true)]
+        [InlineData("[미셸]: атакуй", true)]
+        public void ContainsReadableLetter_DetectsTranslatableLetters(string text, bool expected)
+        {
+            Assert.Equal(expected, ChatTextAnalyzer.ContainsReadableLetter(text));
+        }
+
+        [Fact]
+        public void ScoreOcrCandidate_PrioritizesKnownCharacterChatLines()
+        {
+            int knownScore = ChatTextAnalyzer.ScoreOcrCandidate(new[] { "[미셸]: attack now" }, KnownCharacters);
+            int unknownScore = ChatTextAnalyzer.ScoreOcrCandidate(new[] { "[Unknown]: attack now" }, KnownCharacters);
+            int systemScore = ChatTextAnalyzer.ScoreOcrCandidate(new[] { "시스템 메시지 attack now" }, KnownCharacters);
+
+            Assert.True(knownScore > 10000);
+            Assert.True(knownScore > unknownScore);
+            Assert.True(unknownScore > systemScore);
+        }
+
+        [Fact]
+        public void ScoreOcrCandidate_PenalizesNoiseHeavyLines()
+        {
+            int cleanScore = ChatTextAnalyzer.ScoreOcrCandidate(new[] { "[오드리]: hello world" }, KnownCharacters);
+            int noisyScore = ChatTextAnalyzer.ScoreOcrCandidate(new[] { "###@@@%%%" }, KnownCharacters);
+
+            Assert.True(cleanScore > 0);
+            Assert.True(noisyScore < 0);
+            Assert.True(cleanScore > noisyScore);
+        }
+    }
+}

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../GameChatTranslator/Core/ChatTextAnalyzer.cs" Link="Core/ChatTextAnalyzer.cs" />
+    <Compile Include="../GameChatTranslator/Core/SettingsValueNormalizer.cs" Link="Core/SettingsValueNormalizer.cs" />
+  </ItemGroup>
+
+</Project>

--- a/GameChatTranslator.Tests/SettingsValueNormalizerTests.cs
+++ b/GameChatTranslator.Tests/SettingsValueNormalizerTests.cs
@@ -1,0 +1,34 @@
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class SettingsValueNormalizerTests
+    {
+        [Theory]
+        [InlineData(null, 5)]
+        [InlineData("", 5)]
+        [InlineData("not-number", 5)]
+        [InlineData("0", 1)]
+        [InlineData("-10", 1)]
+        [InlineData("5", 5)]
+        [InlineData("10", 10)]
+        [InlineData("11", 10)]
+        [InlineData("100", 10)]
+        public void NormalizeResultHistoryLimit_ClampsStringValues(string rawValue, int expected)
+        {
+            Assert.Equal(expected, SettingsValueNormalizer.NormalizeResultHistoryLimit(rawValue));
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(1, 1)]
+        [InlineData(7, 7)]
+        [InlineData(10, 10)]
+        [InlineData(15, 10)]
+        public void NormalizeResultHistoryLimit_ClampsIntegerValues(int rawValue, int expected)
+        {
+            Assert.Equal(expected, SettingsValueNormalizer.NormalizeResultHistoryLimit(rawValue));
+        }
+    }
+}

--- a/GameChatTranslator.sln
+++ b/GameChatTranslator.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.37111.16 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameChatTranslator", "GameChatTranslator\GameChatTranslator.csproj", "{4E4915E7-63EF-47B8-86F9-E9ADC6657CFE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameChatTranslator.Tests", "GameChatTranslator.Tests\GameChatTranslator.Tests.csproj", "{1976CBCF-3FE0-4091-9689-8FFF2216D823}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{4E4915E7-63EF-47B8-86F9-E9ADC6657CFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E4915E7-63EF-47B8-86F9-E9ADC6657CFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E4915E7-63EF-47B8-86F9-E9ADC6657CFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1976CBCF-3FE0-4091-9689-8FFF2216D823}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1976CBCF-3FE0-4091-9689-8FFF2216D823}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1976CBCF-3FE0-4091-9689-8FFF2216D823}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1976CBCF-3FE0-4091-9689-8FFF2216D823}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GameChatTranslator/Core/ChatTextAnalyzer.cs
+++ b/GameChatTranslator/Core/ChatTextAnalyzer.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// OCR 결과 문자열에서 게임 채팅 라인을 판별하고 후보 신뢰도를 계산하는 순수 로직입니다.
+    /// WPF/Windows OCR 타입에 의존하지 않으므로 단위 테스트에서 직접 검증할 수 있습니다.
+    /// </summary>
+    public static class ChatTextAnalyzer
+    {
+        private const string ReadableLetterPattern = @"[a-zA-Z가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ]";
+        private const string AllowedNoisePattern = @"[^a-zA-Z0-9가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\[\]\(\):;：!\.,\?\-]";
+        private const string ChatLinePattern = @"^(.*[\[\(]([^\]\)]+)[\]\)]\s*[:;：!])\s*(.*)$";
+
+        /// <summary>
+        /// OCR 문자열에서 추출한 채팅 한 줄입니다.
+        /// CharacterName은 대괄호/괄호를 제거한 캐릭터명이고, Message는 구분자 뒤 채팅 본문입니다.
+        /// </summary>
+        public sealed class ChatLine
+        {
+            public ChatLine(string characterName, string message)
+            {
+                CharacterName = characterName ?? "";
+                Message = message ?? "";
+            }
+
+            public string CharacterName { get; }
+            public string Message { get; }
+            public string CharacterLabel => $"[{CharacterName}]: ";
+        }
+
+        /// <summary>
+        /// 텍스트에 OCR 번역 대상으로 볼 만한 문자가 하나 이상 포함되어 있는지 확인합니다.
+        /// 숫자/기호만 있는 라인은 번역 후보에서 제외하기 위한 1차 필터입니다.
+        /// </summary>
+        public static bool ContainsReadableLetter(string text)
+        {
+            return Regex.IsMatch(text ?? "", ReadableLetterPattern);
+        }
+
+        /// <summary>
+        /// "[캐릭터명]: 내용" 또는 "(캐릭터명): 내용" 형태의 OCR 문자열을 캐릭터명과 본문으로 분리합니다.
+        /// characters.txt 포함 여부는 검사하지 않고, 문자열 형식만 검사합니다.
+        /// </summary>
+        public static bool TryParseChatLine(string rawText, out ChatLine chatLine)
+        {
+            chatLine = null;
+
+            string text = rawText?.Trim() ?? "";
+            if (string.IsNullOrWhiteSpace(text)) return false;
+
+            Match match = Regex.Match(text, ChatLinePattern);
+            if (!match.Success) return false;
+
+            string characterName = match.Groups[2].Value.Trim();
+            string message = match.Groups[3].Value.Trim();
+            if (string.IsNullOrWhiteSpace(characterName)) return false;
+
+            chatLine = new ChatLine(characterName, message);
+            return true;
+        }
+
+        /// <summary>
+        /// OCR 문자열이 채팅 형식이고 characters.txt에 등록된 캐릭터명인지 확인합니다.
+        /// 본문이 비어 있으면 실제 번역 대상이 아니므로 false를 반환합니다.
+        /// </summary>
+        public static bool TryParseKnownCharacterChatLine(string rawText, ISet<string> characterNames, out ChatLine chatLine)
+        {
+            chatLine = null;
+            if (!TryParseChatLine(rawText, out ChatLine parsedLine)) return false;
+            if (characterNames == null || !characterNames.Contains(parsedLine.CharacterName)) return false;
+            if (string.IsNullOrWhiteSpace(parsedLine.Message)) return false;
+
+            chatLine = parsedLine;
+            return true;
+        }
+
+        /// <summary>
+        /// OCR 후보 라인 목록의 신뢰도를 점수화합니다.
+        /// 채팅 포맷, characters.txt 캐릭터명 일치, 본문 길이, 외국어 문자 포함은 가산하고 노이즈는 감산합니다.
+        /// </summary>
+        public static int ScoreOcrCandidate(IEnumerable<string> lineTexts, ISet<string> characterNames)
+        {
+            int score = 0;
+
+            foreach (string rawText in lineTexts ?? Enumerable.Empty<string>())
+            {
+                string text = rawText?.Trim() ?? "";
+                if (string.IsNullOrWhiteSpace(text)) continue;
+
+                int letterCount = Regex.Matches(text, ReadableLetterPattern).Count;
+                int noiseCount = Regex.Matches(text, AllowedNoisePattern).Count;
+                score += letterCount * 2;
+                score -= noiseCount * 18;
+
+                if (!TryParseChatLine(text, out ChatLine chatLine))
+                {
+                    score -= 80;
+                    continue;
+                }
+
+                if (characterNames != null && characterNames.Contains(chatLine.CharacterName))
+                {
+                    score += 10000;
+                    score += Math.Min(chatLine.Message.Length, 80) * 40;
+                }
+                else
+                {
+                    score -= 200;
+                }
+
+                if (Regex.IsMatch(chatLine.Message, @"[\u4e00-\u9fa5]")) score += 400;
+                if (Regex.IsMatch(chatLine.Message, @"[a-zA-Z]{2,}")) score += 300;
+                if (Regex.IsMatch(chatLine.Message, @"[ぁ-んァ-ヶ]")) score += 200;
+                if (Regex.IsMatch(chatLine.Message, @"[а-яА-ЯёЁ]")) score += 100;
+            }
+
+            return score;
+        }
+    }
+}

--- a/GameChatTranslator/Core/SettingsValueNormalizer.cs
+++ b/GameChatTranslator/Core/SettingsValueNormalizer.cs
@@ -1,0 +1,33 @@
+namespace GameTranslator
+{
+    /// <summary>
+    /// config.ini와 프리셋에서 읽은 숫자 설정값을 런타임 허용 범위로 보정하는 순수 로직입니다.
+    /// UI 입력, 프리셋, 런타임 읽기 경로가 같은 기준을 쓰도록 모읍니다.
+    /// </summary>
+    public static class SettingsValueNormalizer
+    {
+        public const int DefaultResultHistoryLimit = 5;
+        public const int MinResultHistoryLimit = 1;
+        public const int MaxResultHistoryLimit = 10;
+
+        /// <summary>
+        /// 번역 결과 누적 표시 줄 수를 1~10 범위로 보정합니다.
+        /// 숫자가 아니거나 비어 있으면 기본값 5를 사용합니다.
+        /// </summary>
+        public static int NormalizeResultHistoryLimit(string rawValue)
+        {
+            int value = int.TryParse(rawValue, out int parsed) ? parsed : DefaultResultHistoryLimit;
+            return NormalizeResultHistoryLimit(value);
+        }
+
+        /// <summary>
+        /// 번역 결과 누적 표시 줄 수를 1~10 범위로 보정합니다.
+        /// </summary>
+        public static int NormalizeResultHistoryLimit(int value)
+        {
+            if (value < MinResultHistoryLimit) return MinResultHistoryLimit;
+            if (value > MaxResultHistoryLimit) return MaxResultHistoryLimit;
+            return value;
+        }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.ResultDisplay.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.ResultDisplay.cs
@@ -12,7 +12,6 @@ namespace GameTranslator
     public partial class MainWindow
     {
         private const string ResultDisplayModeHistory = "History";
-        private const int DefaultResultHistoryLimit = 5;
         private readonly List<TranslationDisplayLine> translationDisplayHistory = new List<TranslationDisplayLine>();
 
         /// <summary>
@@ -127,10 +126,7 @@ namespace GameTranslator
         /// </summary>
         private int ReadResultHistoryLimit()
         {
-            int limit = int.TryParse(ini.Read("ResultHistoryLimit"), out int parsed) ? parsed : DefaultResultHistoryLimit;
-            if (limit < 1) limit = 1;
-            if (limit > 10) limit = 10;
-            return limit;
+            return SettingsValueNormalizer.NormalizeResultHistoryLimit(ini.Read("ResultHistoryLimit"));
         }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
@@ -99,7 +99,7 @@ namespace GameTranslator
 
             if (string.IsNullOrWhiteSpace(ini.Read("ResultHistoryLimit")))
             {
-                ini.Write("ResultHistoryLimit", "5");
+                ini.Write("ResultHistoryLimit", SettingsValueNormalizer.DefaultResultHistoryLimit.ToString());
             }
         }
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -414,22 +414,21 @@ namespace GameTranslator
 
                     AppendLog("DEBUG", $"OCR 원본: {krRawText}", "System");
 
-                    if (!Regex.IsMatch(krRawText, @"[a-zA-Z가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ]"))
+                    if (!ChatTextAnalyzer.ContainsReadableLetter(krRawText))
                     {
                         AppendLog("DEBUG", "글자 없음으로 스킵", "System");
                         performanceStats.SkippedLineCount++;
                         continue;
                     }
 
-                    var strictMatch = Regex.Match(krRawText, @"^(.*[\[\(]([^\]\)]+)[\]\)]\s*[:;：!])\s*(.*)$");
-                    if (!strictMatch.Success)
+                    if (!ChatTextAnalyzer.TryParseChatLine(krRawText, out ChatTextAnalyzer.ChatLine parsedChatLine))
                     {
                         AppendLog("DEBUG", "정규식(strictMatch) 불일치로 스킵됨", "System");
                         performanceStats.SkippedLineCount++;
                         continue;
                     }
 
-                    string characterNameOnly = strictMatch.Groups[2].Value.Trim();
+                    string characterNameOnly = parsedChatLine.CharacterName;
 
                     if (!characterNames.Contains(characterNameOnly))
                     {
@@ -438,8 +437,8 @@ namespace GameTranslator
                         continue;
                     }
 
-                    string characterNameGold = $"[{characterNameOnly}]: ";
-                    string bestMessage = strictMatch.Groups[3].Value.Trim();
+                    string characterNameGold = parsedChatLine.CharacterLabel;
+                    string bestMessage = parsedChatLine.Message;
                     int bestScore = -1;
 
                     double mTop = chatLine.Top - 5;
@@ -729,31 +728,7 @@ namespace GameTranslator
             if (candidate == null || candidate.Score <= 0 || candidate.Lines == null) return false;
 
             return candidate.Lines.Any(line =>
-                TryExtractKnownCharacterChatLine(line.Text, out _, out string message) &&
-                !string.IsNullOrWhiteSpace(message));
-        }
-
-        /// <summary>
-        /// OCR 문자열이 "[캐릭터명]: 내용" 형식이고 캐릭터 목록에 있는 이름인지 검사합니다.
-        /// <paramref name="rawText"/>는 OCR에서 얻은 한 줄 원문,
-        /// <paramref name="characterNameOnly"/>는 성공 시 추출된 캐릭터명,
-        /// <paramref name="message"/>는 성공 시 추출된 채팅 본문입니다.
-        /// </summary>
-        private bool TryExtractKnownCharacterChatLine(string rawText, out string characterNameOnly, out string message)
-        {
-            characterNameOnly = "";
-            message = "";
-
-            string text = rawText?.Trim() ?? "";
-            if (string.IsNullOrWhiteSpace(text)) return false;
-
-            Match strictMatch = Regex.Match(text, @"^(.*[\[\(]([^\]\)]+)[\]\)]\s*[:;：!])\s*(.*)$");
-            if (!strictMatch.Success) return false;
-
-            characterNameOnly = strictMatch.Groups[2].Value.Trim();
-            message = strictMatch.Groups[3].Value.Trim();
-
-            return characterNames.Contains(characterNameOnly) && !string.IsNullOrWhiteSpace(message);
+                ChatTextAnalyzer.TryParseKnownCharacterChatLine(line.Text, characterNames, out _));
         }
 
         /// <summary>
@@ -1178,45 +1153,7 @@ namespace GameTranslator
         /// </summary>
         private int ScoreOcrCandidate(List<MergedLine> lines)
         {
-            int score = 0;
-
-            foreach (MergedLine line in lines)
-            {
-                string text = line.Text?.Trim() ?? "";
-                if (string.IsNullOrWhiteSpace(text)) continue;
-
-                int letterCount = Regex.Matches(text, @"[a-zA-Z가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ]").Count;
-                int noiseCount = Regex.Matches(text, @"[^a-zA-Z0-9가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\[\]\(\):;：!\.,\?\-]").Count;
-                score += letterCount * 2;
-                score -= noiseCount * 18;
-
-                Match strictMatch = Regex.Match(text, @"^(.*[\[\(]([^\]\)]+)[\]\)]\s*[:;：!])\s*(.*)$");
-                if (!strictMatch.Success)
-                {
-                    score -= 80;
-                    continue;
-                }
-
-                string characterNameOnly = strictMatch.Groups[2].Value.Trim();
-                string message = strictMatch.Groups[3].Value.Trim();
-
-                if (characterNames.Contains(characterNameOnly))
-                {
-                    score += 10000;
-                    score += Math.Min(message.Length, 80) * 40;
-                }
-                else
-                {
-                    score -= 200;
-                }
-
-                if (Regex.IsMatch(message, @"[\u4e00-\u9fa5]")) score += 400;
-                if (Regex.IsMatch(message, @"[a-zA-Z]{2,}")) score += 300;
-                if (Regex.IsMatch(message, @"[ぁ-んァ-ヶ]")) score += 200;
-                if (Regex.IsMatch(message, @"[а-яА-ЯёЁ]")) score += 100;
-            }
-
-            return score;
+            return ChatTextAnalyzer.ScoreOcrCandidate(lines?.Select(line => line.Text), characterNames);
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
@@ -228,7 +228,7 @@ namespace GameTranslator
             _ini.Write("Threshold", string.IsNullOrWhiteSpace(TxtThreshold?.Text) ? "120" : TxtThreshold.Text.Trim(), section);
             _ini.Write("AutoTranslateInterval", string.IsNullOrWhiteSpace(TxtInterval?.Text) ? "5" : TxtInterval.Text.Trim(), section);
             _ini.Write("ResultDisplayMode", GetSelectedTag(ComboResultDisplayMode, "Latest"), section);
-            _ini.Write("ResultHistoryLimit", string.IsNullOrWhiteSpace(TxtResultHistoryLimit?.Text) ? "5" : TxtResultHistoryLimit.Text.Trim(), section);
+            _ini.Write("ResultHistoryLimit", SettingsValueNormalizer.NormalizeResultHistoryLimit(TxtResultHistoryLimit?.Text).ToString(), section);
             _ini.Write("SaveDebugImages", CheckSaveDebugImages?.IsChecked == true ? "true" : "false", section);
             _ini.Write("GeminiModel", string.IsNullOrWhiteSpace(TxtGeminiModel?.Text) ? MainWindow.DefaultGeminiModel : TxtGeminiModel.Text.Trim(), section);
             _ini.Write("Key_MoveLock", TxtKeyMove.Text, section);
@@ -265,7 +265,7 @@ namespace GameTranslator
             TxtThreshold.Text = ReadPresetValue(section, "Threshold", "120");
             TxtInterval.Text = ReadPresetValue(section, "AutoTranslateInterval", "5");
             SetComboByTag(ComboResultDisplayMode, ReadPresetValue(section, "ResultDisplayMode", "Latest"));
-            TxtResultHistoryLimit.Text = ReadPresetValue(section, "ResultHistoryLimit", "5");
+            TxtResultHistoryLimit.Text = SettingsValueNormalizer.NormalizeResultHistoryLimit(ReadPresetValue(section, "ResultHistoryLimit", "5")).ToString();
             CheckSaveDebugImages.IsChecked = IsTruthy(ReadPresetValue(section, "SaveDebugImages", "false"));
             TxtGeminiModel.Text = ReadPresetValue(section, "GeminiModel", MainWindow.DefaultGeminiModel);
             TxtKeyMove.Text = ReadPresetValue(section, "Key_MoveLock", DefaultKeyMoveLock);

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -107,7 +107,10 @@ namespace GameTranslator
             if (TxtThreshold != null) TxtThreshold.Text = _ini.Read("Threshold") ?? "120";
             if (TxtInterval != null) TxtInterval.Text = _ini.Read("AutoTranslateInterval") ?? "5";
             if (ComboResultDisplayMode != null) SetComboByTag(ComboResultDisplayMode, _ini.Read("ResultDisplayMode") ?? "Latest");
-            if (TxtResultHistoryLimit != null) TxtResultHistoryLimit.Text = _ini.Read("ResultHistoryLimit") ?? "5";
+            if (TxtResultHistoryLimit != null)
+            {
+                TxtResultHistoryLimit.Text = SettingsValueNormalizer.NormalizeResultHistoryLimit(_ini.Read("ResultHistoryLimit")).ToString();
+            }
 
             string geminiKey = _ini.Read("GeminiKey") ?? "";
             if (string.IsNullOrWhiteSpace(geminiKey))
@@ -338,18 +341,9 @@ namespace GameTranslator
             }
 
             _ini.Write("ResultDisplayMode", GetSelectedTag(ComboResultDisplayMode, "Latest"));
-            if (TxtResultHistoryLimit != null && int.TryParse(TxtResultHistoryLimit.Text, out int historyLimit))
-            {
-                if (historyLimit < 1) historyLimit = 1;
-                if (historyLimit > 10) historyLimit = 10;
-                _ini.Write("ResultHistoryLimit", historyLimit.ToString());
-                TxtResultHistoryLimit.Text = historyLimit.ToString();
-            }
-            else
-            {
-                _ini.Write("ResultHistoryLimit", "5");
-                if (TxtResultHistoryLimit != null) TxtResultHistoryLimit.Text = "5";
-            }
+            int historyLimit = SettingsValueNormalizer.NormalizeResultHistoryLimit(TxtResultHistoryLimit?.Text);
+            _ini.Write("ResultHistoryLimit", historyLimit.ToString());
+            if (TxtResultHistoryLimit != null) TxtResultHistoryLimit.Text = historyLimit.ToString();
 
             _ini.Write("SaveDebugImages", CheckSaveDebugImages?.IsChecked == true ? "true" : "false");
             _ini.Write("CheckUpdatesOnStartup", CheckUpdatesOnStartup?.IsChecked == true ? "true" : "false");


### PR DESCRIPTION
## 작업 내용
- GameChatTranslator.Tests xUnit 테스트 프로젝트 추가
- OCR 채팅 라인 파싱/캐릭터명 검증/후보 점수화 순수 로직을 ChatTextAnalyzer로 분리
- ResultHistoryLimit 범위 보정 로직을 SettingsValueNormalizer로 분리
- MainWindow/OptionSelector가 분리된 Core 로직을 사용하도록 연결
- 릴리즈 workflow에 dotnet test 단계를 추가해 태그 배포 전 테스트를 실행
- 중첩 bin/obj 폴더가 추적되지 않도록 .gitignore 보강

## 테스트 범위
- [캐릭터명]: 채팅내용 파싱
- 괄호/전각 콜론/느낌표 구분자 파싱
- 시스템 메시지/잘못된 형식 제외
- characters.txt 캐릭터명 일치 여부
- OCR 후보 점수화에서 정상 채팅 우선순위 확인
- 노이즈 라인 감점 확인
- ResultHistoryLimit 기본값 5, 허용 범위 1~10 보정

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
  - Passed: 28, Failed: 0
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
  - 0 Warning, 0 Error
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
  - 0 Warning, 0 Error
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
- publish 산출물에 GameChatTranslator.exe, GameChatTranslator.pdb, characters.txt, LangInstall.bat, readme.txt 포함 확인