### PR TITLE
OCR 후보 선택 서비스 분리

### DIFF
--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <Compile Include="../GameChatTranslator/Core/ChatTextAnalyzer.cs" Link="Core/ChatTextAnalyzer.cs" />
+    <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/SettingsValueNormalizer.cs" Link="Core/SettingsValueNormalizer.cs" />
   </ItemGroup>
 

--- a/GameChatTranslator.Tests/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/OcrServiceTests.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class OcrServiceTests
+    {
+        private readonly OcrService _service = new OcrService();
+        private static readonly HashSet<string> KnownCharacters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "미셸",
+            "오드리"
+        };
+
+        [Fact]
+        public void CreateEvaluationPlan_Fast_UsesOnlyColorGameLanguageStep()
+        {
+            IReadOnlyList<OcrEvaluationStep> plan = _service.CreateEvaluationPlan(OcrProcessingMode.Fast);
+
+            Assert.Single(plan);
+            Assert.True(plan[0].IsFastPathStep);
+            Assert.False(plan[0].RecognizeAllLanguages);
+            Assert.Equal(new[] { OcrPreprocessKind.Color }, plan[0].PreprocessKinds);
+        }
+
+        [Fact]
+        public void CreateEvaluationPlan_Auto_UsesFastPathThenFallback()
+        {
+            IReadOnlyList<OcrEvaluationStep> plan = _service.CreateEvaluationPlan(OcrProcessingMode.Auto);
+
+            Assert.Equal(2, plan.Count);
+            Assert.True(plan[0].IsFastPathStep);
+            Assert.False(plan[0].RecognizeAllLanguages);
+            Assert.Equal(new[] { OcrPreprocessKind.Color }, plan[0].PreprocessKinds);
+
+            Assert.False(plan[1].IsFastPathStep);
+            Assert.True(plan[1].RecognizeAllLanguages);
+            Assert.Equal(new[] { OcrPreprocessKind.ColorThick, OcrPreprocessKind.Adaptive }, plan[1].PreprocessKinds);
+        }
+
+        [Fact]
+        public void CreateEvaluationPlan_Accurate_UsesAllCandidatesAndLanguages()
+        {
+            IReadOnlyList<OcrEvaluationStep> plan = _service.CreateEvaluationPlan(OcrProcessingMode.Accurate);
+
+            Assert.Single(plan);
+            Assert.False(plan[0].IsFastPathStep);
+            Assert.True(plan[0].RecognizeAllLanguages);
+            Assert.Equal(new[] { OcrPreprocessKind.Color, OcrPreprocessKind.ColorThick, OcrPreprocessKind.Adaptive }, plan[0].PreprocessKinds);
+        }
+
+        [Fact]
+        public void IsFastPathSuccess_RequiresPositiveScoreKnownCharacterAndMessage()
+        {
+            var validCandidate = new OcrCandidate<string>
+            {
+                Score = 10,
+                Lines = new List<OcrLine> { new OcrLine { Text = "[미셸]: attack" } }
+            };
+
+            var unknownCharacterCandidate = new OcrCandidate<string>
+            {
+                Score = 10,
+                Lines = new List<OcrLine> { new OcrLine { Text = "[Unknown]: attack" } }
+            };
+
+            var zeroScoreCandidate = new OcrCandidate<string>
+            {
+                Score = 0,
+                Lines = new List<OcrLine> { new OcrLine { Text = "[미셸]: attack" } }
+            };
+
+            var emptyMessageCandidate = new OcrCandidate<string>
+            {
+                Score = 10,
+                Lines = new List<OcrLine> { new OcrLine { Text = "[미셸]:   " } }
+            };
+
+            Assert.True(_service.IsFastPathSuccess(validCandidate, KnownCharacters));
+            Assert.False(_service.IsFastPathSuccess(unknownCharacterCandidate, KnownCharacters));
+            Assert.False(_service.IsFastPathSuccess(zeroScoreCandidate, KnownCharacters));
+            Assert.False(_service.IsFastPathSuccess(emptyMessageCandidate, KnownCharacters));
+            Assert.False(_service.IsFastPathSuccess<string>(null, KnownCharacters));
+        }
+
+        [Fact]
+        public void SelectHigherScore_KeepsHigherScoredCandidate()
+        {
+            var low = new OcrCandidate<string> { PreprocessName = "Color", Score = 10 };
+            var high = new OcrCandidate<string> { PreprocessName = "Adaptive", Score = 20 };
+
+            Assert.Same(low, _service.SelectHigherScore<string>(null, low));
+            Assert.Same(high, _service.SelectHigherScore(low, high));
+            Assert.Same(high, _service.SelectHigherScore(high, low));
+            Assert.Same(high, _service.SelectHigherScore(high, null));
+        }
+
+        [Fact]
+        public void ScoreLines_DelegatesKnownCharacterScoring()
+        {
+            var lines = new[]
+            {
+                new OcrLine { Text = "[미셸]: hello" },
+                new OcrLine { Text = "시스템 메시지" }
+            };
+
+            int score = _service.ScoreLines(lines, KnownCharacters);
+
+            Assert.True(score > 10000);
+        }
+
+        [Fact]
+        public void OcrService_DoesNotReferenceWinRtOrBitmapTypes()
+        {
+            string assemblyQualifiedNames = string.Join(
+                "\n",
+                typeof(OcrService).Assembly
+                    .GetTypes()
+                    .Where(type => type.Namespace == "GameTranslator" && type.Name.StartsWith("Ocr"))
+                    .Select(type => type.AssemblyQualifiedName));
+
+            Assert.DoesNotContain("Windows.Media.Ocr", assemblyQualifiedNames);
+            Assert.DoesNotContain("SoftwareBitmap", assemblyQualifiedNames);
+            Assert.DoesNotContain("System.Drawing.Bitmap", assemblyQualifiedNames);
+        }
+    }
+}

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// OCR 처리 모드에 따른 후보 선택 정책과 후보 점수 비교를 담당하는 순수 서비스입니다.
+    /// 플랫폼 의존 타입을 참조하지 않아 단위 테스트에서 검증할 수 있습니다.
+    /// </summary>
+    public sealed class OcrService
+    {
+        /// <summary>
+        /// 처리 모드별 OCR 평가 순서를 만듭니다.
+        /// Fast/Auto의 첫 단계는 Color + 게임 언어 OCR만 실행하는 fast path입니다.
+        /// </summary>
+        public IReadOnlyList<OcrEvaluationStep> CreateEvaluationPlan(OcrProcessingMode processingMode)
+        {
+            return processingMode switch
+            {
+                OcrProcessingMode.Fast => new[]
+                {
+                    OcrEvaluationStep.FastPath(OcrPreprocessKind.Color)
+                },
+                OcrProcessingMode.Auto => new[]
+                {
+                    OcrEvaluationStep.FastPath(OcrPreprocessKind.Color),
+                    OcrEvaluationStep.Fallback(true, OcrPreprocessKind.ColorThick, OcrPreprocessKind.Adaptive)
+                },
+                _ => new[]
+                {
+                    OcrEvaluationStep.Fallback(true, OcrPreprocessKind.Color, OcrPreprocessKind.ColorThick, OcrPreprocessKind.Adaptive)
+                }
+            };
+        }
+
+        /// <summary>
+        /// OCR 후보가 빠른 경로에서 즉시 번역해도 될 정도로 신뢰 가능한지 판단합니다.
+        /// 후보 점수가 양수이고, known character 채팅 라인이 하나 이상 있어야 true입니다.
+        /// </summary>
+        public bool IsFastPathSuccess<TResults>(OcrCandidate<TResults> candidate, ISet<string> characterNames)
+        {
+            if (candidate == null || candidate.Score <= 0 || candidate.Lines == null) return false;
+
+            return candidate.Lines.Any(line =>
+                ChatTextAnalyzer.TryParseKnownCharacterChatLine(line.Text, characterNames, out _));
+        }
+
+        /// <summary>
+        /// 두 후보 중 점수가 더 높은 후보를 반환합니다.
+        /// 기존 후보가 없으면 새 후보를 그대로 반환하고, 새 후보가 없으면 기존 후보를 유지합니다.
+        /// </summary>
+        public OcrCandidate<TResults> SelectHigherScore<TResults>(OcrCandidate<TResults> currentBest, OcrCandidate<TResults> nextCandidate)
+        {
+            if (nextCandidate == null) return currentBest;
+            if (currentBest == null || nextCandidate.Score > currentBest.Score) return nextCandidate;
+            return currentBest;
+        }
+
+        /// <summary>
+        /// OCR 라인 목록을 ChatTextAnalyzer 기준으로 점수화합니다.
+        /// </summary>
+        public int ScoreLines(IEnumerable<OcrLine> lines, ISet<string> characterNames)
+        {
+            return ChatTextAnalyzer.ScoreOcrCandidate(lines?.Select(line => line.Text), characterNames);
+        }
+    }
+
+    /// <summary>
+    /// 자동/수동 번역에서 실제 OCR 후보 실행 범위를 결정하는 모드입니다.
+    /// </summary>
+    public enum OcrProcessingMode
+    {
+        Fast,
+        Auto,
+        Accurate
+    }
+
+    /// <summary>
+    /// 캡처 이미지를 OCR에 넣기 전 적용할 전처리 후보 종류입니다.
+    /// </summary>
+    public enum OcrPreprocessKind
+    {
+        Color,
+        ColorThick,
+        Adaptive
+    }
+
+    /// <summary>
+    /// 한 번의 OCR 후보 평가 단계입니다.
+    /// RecognizeAllLanguages가 false이면 게임 언어 우선 OCR만 실행하고, true이면 설치된 모든 OCR 언어를 실행합니다.
+    /// </summary>
+    public sealed class OcrEvaluationStep
+    {
+        private OcrEvaluationStep(bool recognizeAllLanguages, bool isFastPathStep, params OcrPreprocessKind[] preprocessKinds)
+        {
+            RecognizeAllLanguages = recognizeAllLanguages;
+            IsFastPathStep = isFastPathStep;
+            PreprocessKinds = preprocessKinds?.ToArray() ?? new OcrPreprocessKind[0];
+        }
+
+        public bool RecognizeAllLanguages { get; }
+        public bool IsFastPathStep { get; }
+        public IReadOnlyList<OcrPreprocessKind> PreprocessKinds { get; }
+
+        public static OcrEvaluationStep FastPath(params OcrPreprocessKind[] preprocessKinds)
+        {
+            return new OcrEvaluationStep(false, true, preprocessKinds);
+        }
+
+        public static OcrEvaluationStep Fallback(bool recognizeAllLanguages, params OcrPreprocessKind[] preprocessKinds)
+        {
+            return new OcrEvaluationStep(recognizeAllLanguages, false, preprocessKinds);
+        }
+    }
+
+    /// <summary>
+    /// OCR 결과의 한 줄을 병합한 순수 모델입니다.
+    /// Top/Bottom은 화면상 세로 위치이고, Text는 병합된 OCR 문자열입니다.
+    /// </summary>
+    public sealed class OcrLine
+    {
+        public double Top { get; set; }
+        public double Bottom { get; set; }
+        public string Text { get; set; }
+    }
+
+    /// <summary>
+    /// 하나의 전처리 후보에 대한 OCR 결과, 병합 라인, 품질 점수를 묶는 모델입니다.
+    /// TResults는 실제 앱에서는 언어별 Windows OCR 결과 딕셔너리이고, 테스트에서는 가짜 결과를 넣을 수 있습니다.
+    /// </summary>
+    public sealed class OcrCandidate<TResults>
+    {
+        public string PreprocessName { get; set; }
+        public TResults Results { get; set; }
+        public List<OcrLine> Lines { get; set; }
+        public int Score { get; set; }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -126,7 +126,7 @@ namespace GameTranslator
                     OcrResult masterResult = SelectMasterOcrResult(ocrResults);
                     if (masterResult != null)
                     {
-                        List<MergedLine> mergedLines = MergeOcrLines(masterResult);
+                        List<OcrLine> mergedLines = MergeOcrLines(masterResult);
                         diagnosticCandidate.MergedLines.AddRange(mergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
                         diagnosticCandidate.Score = ScoreOcrCandidate(mergedLines);
                     }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -21,6 +21,7 @@ using Windows.Media.Ocr;
 using Application = System.Windows.Application;
 using Brushes = System.Windows.Media.Brushes;
 using ColorConverter = System.Windows.Media.ColorConverter;
+using OcrResultCandidate = GameTranslator.OcrCandidate<System.Collections.Generic.Dictionary<string, Windows.Media.Ocr.OcrResult>>;
 using PixelFormat = System.Drawing.Imaging.PixelFormat;
 
 namespace GameTranslator
@@ -41,28 +42,6 @@ namespace GameTranslator
             Fast,
             Auto,
             Accurate
-        }
-
-        /// <summary>
-        /// 실제 OCR 후보 실행 범위를 결정하는 내부 처리 모드입니다.
-        /// 수동 번역은 항상 Accurate를 사용하고, 자동 번역은 AutoTranslateMode에서 변환됩니다.
-        /// </summary>
-        private enum OcrProcessingMode
-        {
-            Fast,
-            Auto,
-            Accurate
-        }
-
-        /// <summary>
-        /// 캡처 이미지를 OCR에 넣기 전 적용할 전처리 후보 종류입니다.
-        /// Color는 기본 색상 필터, ColorThick은 글자 굵기 보정, Adaptive는 로컬 밝기 기반 이진화입니다.
-        /// </summary>
-        private enum OcrPreprocessKind
-        {
-            Color,
-            ColorThick,
-            Adaptive
         }
 
         /// <summary>
@@ -188,17 +167,6 @@ namespace GameTranslator
         }
 
         /// <summary>
-        /// OCR 결과의 한 줄을 병합한 내부 모델입니다.
-        /// Top/Bottom은 화면상 세로 위치이고, Text는 병합된 OCR 문자열입니다.
-        /// </summary>
-        private class MergedLine
-        {
-            public double Top;
-            public double Bottom;
-            public string Text;
-        }
-
-        /// <summary>
         /// 전처리된 OCR 입력 이미지를 이름과 함께 관리하는 disposable 모델입니다.
         /// Bitmap은 unmanaged 리소스를 포함하므로 사용 후 Dispose로 해제합니다.
         /// </summary>
@@ -214,18 +182,6 @@ namespace GameTranslator
             {
                 Bitmap?.Dispose();
             }
-        }
-
-        /// <summary>
-        /// 하나의 전처리 후보에 대해 OCR 결과, 병합 라인, 품질 점수를 묶어 보관합니다.
-        /// 후보 간 Score를 비교해 최종 번역에 사용할 OCR 결과를 선택합니다.
-        /// </summary>
-        private class OcrCandidate
-        {
-            public string PreprocessName;
-            public Dictionary<string, OcrResult> Results;
-            public List<MergedLine> Lines;
-            public int Score;
         }
 
         /// <summary>
@@ -380,7 +336,7 @@ namespace GameTranslator
                 }
 
                 // 3. 모드별 후보 전략으로 OCR을 수행하고 가장 점수가 높은 후보를 선택합니다.
-                OcrCandidate bestCandidate = await SelectBestOcrCandidateAsync(resizedBitmap, threshold, processingMode, performanceStats);
+                OcrResultCandidate bestCandidate = await SelectBestOcrCandidateAsync(resizedBitmap, threshold, processingMode, performanceStats);
 
                 if (bestCandidate == null || bestCandidate.Lines.Count == 0 || bestCandidate.Score <= 0)
                 {
@@ -592,53 +548,28 @@ namespace GameTranslator
         /// <paramref name="processingMode"/>는 빠름/자동/정확 중 이번 실행 전략입니다.
         /// <paramref name="performanceStats"/>는 후보 선택 과정의 단계별 시간을 누적하는 진단 객체입니다.
         /// </summary>
-        private async Task<OcrCandidate> SelectBestOcrCandidateAsync(Bitmap resizedBitmap, int threshold, OcrProcessingMode processingMode, OcrPerformanceStats performanceStats)
+        private async Task<OcrResultCandidate> SelectBestOcrCandidateAsync(Bitmap resizedBitmap, int threshold, OcrProcessingMode processingMode, OcrPerformanceStats performanceStats)
         {
-            if (processingMode == OcrProcessingMode.Fast)
+            foreach (OcrEvaluationStep step in ocrService.CreateEvaluationPlan(processingMode))
             {
-                OcrCandidate fastCandidate = await EvaluateOcrCandidatesAsync(
+                OcrResultCandidate candidate = await EvaluateOcrCandidatesAsync(
                     resizedBitmap,
                     threshold,
                     performanceStats,
-                    false,
-                    OcrPreprocessKind.Color);
+                    step.RecognizeAllLanguages,
+                    step.PreprocessKinds.ToArray());
 
-                return IsFastPathSuccess(fastCandidate) ? fastCandidate : null;
-            }
-
-            if (processingMode == OcrProcessingMode.Auto)
-            {
-                OcrCandidate fastCandidate = await EvaluateOcrCandidatesAsync(
-                    resizedBitmap,
-                    threshold,
-                    performanceStats,
-                    false,
-                    OcrPreprocessKind.Color);
-
-                if (IsFastPathSuccess(fastCandidate))
+                if (step.IsFastPathStep)
                 {
-                    return fastCandidate;
+                    if (ocrService.IsFastPathSuccess(candidate, characterNames)) return candidate;
+                    if (processingMode == OcrProcessingMode.Fast) return null;
+                    continue;
                 }
 
-                OcrCandidate fallbackCandidate = await EvaluateOcrCandidatesAsync(
-                    resizedBitmap,
-                    threshold,
-                    performanceStats,
-                    true,
-                    OcrPreprocessKind.ColorThick,
-                    OcrPreprocessKind.Adaptive);
-
-                return fallbackCandidate;
+                return candidate;
             }
 
-            return await EvaluateOcrCandidatesAsync(
-                resizedBitmap,
-                threshold,
-                performanceStats,
-                true,
-                OcrPreprocessKind.Color,
-                OcrPreprocessKind.ColorThick,
-                OcrPreprocessKind.Adaptive);
+            return null;
         }
 
         /// <summary>
@@ -649,9 +580,9 @@ namespace GameTranslator
         /// <paramref name="recognizeAllLanguages"/>가 true이면 설치된 모든 OCR 언어를 실행하고 false이면 게임 언어만 실행합니다.
         /// <paramref name="preprocessKinds"/>는 평가할 전처리 후보 목록입니다.
         /// </summary>
-        private async Task<OcrCandidate> EvaluateOcrCandidatesAsync(Bitmap resizedBitmap, int threshold, OcrPerformanceStats performanceStats, bool recognizeAllLanguages, params OcrPreprocessKind[] preprocessKinds)
+        private async Task<OcrResultCandidate> EvaluateOcrCandidatesAsync(Bitmap resizedBitmap, int threshold, OcrPerformanceStats performanceStats, bool recognizeAllLanguages, params OcrPreprocessKind[] preprocessKinds)
         {
-            OcrCandidate bestCandidate = null;
+            OcrResultCandidate bestCandidate = null;
             Stopwatch preprocessStopwatch = Stopwatch.StartNew();
             List<PreprocessedOcrImage> preprocessedImages = CreatePreprocessedOcrImages(resizedBitmap, threshold, preprocessKinds);
             preprocessStopwatch.Stop();
@@ -690,21 +621,18 @@ namespace GameTranslator
                         continue;
                     }
 
-                    List<MergedLine> candidateLines = MergeOcrLines(candidateMasterResult);
+                    List<OcrLine> candidateLines = MergeOcrLines(candidateMasterResult);
                     int candidateScore = ScoreOcrCandidate(candidateLines);
                     scoringStopwatch.Stop();
                     performanceStats.ScoringMs += scoringStopwatch.ElapsedMilliseconds;
 
-                    if (bestCandidate == null || candidateScore > bestCandidate.Score)
+                    bestCandidate = ocrService.SelectHigherScore(bestCandidate, new OcrResultCandidate
                     {
-                        bestCandidate = new OcrCandidate
-                        {
-                            PreprocessName = preprocessedImage.Name,
-                            Results = candidateResults,
-                            Lines = candidateLines,
-                            Score = candidateScore
-                        };
-                    }
+                        PreprocessName = preprocessedImage.Name,
+                        Results = candidateResults,
+                        Lines = candidateLines,
+                        Score = candidateScore
+                    });
                 }
             }
             finally
@@ -716,19 +644,6 @@ namespace GameTranslator
             }
 
             return bestCandidate;
-        }
-
-        /// <summary>
-        /// 빠른 경로 결과가 바로 번역해도 될 정도로 신뢰 가능한지 판단합니다.
-        /// <paramref name="candidate"/>는 Color 전처리 + 게임 언어 OCR만 수행한 후보입니다.
-        /// 반환값은 캐릭터명과 채팅 포맷이 모두 확인된 경우에만 true입니다.
-        /// </summary>
-        private bool IsFastPathSuccess(OcrCandidate candidate)
-        {
-            if (candidate == null || candidate.Score <= 0 || candidate.Lines == null) return false;
-
-            return candidate.Lines.Any(line =>
-                ChatTextAnalyzer.TryParseKnownCharacterChatLine(line.Text, characterNames, out _));
         }
 
         /// <summary>
@@ -1120,11 +1035,11 @@ namespace GameTranslator
         /// <summary>
         /// Windows OCR이 여러 조각으로 나눈 라인을 세로 위치 기준으로 다시 합칩니다.
         /// <paramref name="masterResult"/>는 기준 언어 OCR 결과입니다.
-        /// 반환값은 채팅 한 줄 단위에 가깝게 병합된 MergedLine 목록입니다.
+        /// 반환값은 채팅 한 줄 단위에 가깝게 병합된 OcrLine 목록입니다.
         /// </summary>
-        private List<MergedLine> MergeOcrLines(OcrResult masterResult)
+        private List<OcrLine> MergeOcrLines(OcrResult masterResult)
         {
-            var mergedLines = new List<MergedLine>();
+            var mergedLines = new List<OcrLine>();
 
             foreach (var mLine in masterResult.Lines)
             {
@@ -1140,7 +1055,7 @@ namespace GameTranslator
                     existing.Top = Math.Min(existing.Top, top);
                     existing.Bottom = Math.Max(existing.Bottom, bot);
                 }
-                else mergedLines.Add(new MergedLine { Top = top, Bottom = bot, Text = text });
+                else mergedLines.Add(new OcrLine { Top = top, Bottom = bot, Text = text });
             }
 
             return mergedLines;
@@ -1151,9 +1066,9 @@ namespace GameTranslator
         /// <paramref name="lines"/>는 후보 전처리에서 얻은 병합 라인 목록입니다.
         /// 채팅 포맷, 캐릭터명 일치, 본문 길이, 언어별 문자 포함 여부는 가산하고 노이즈 문자는 감산합니다.
         /// </summary>
-        private int ScoreOcrCandidate(List<MergedLine> lines)
+        private int ScoreOcrCandidate(List<OcrLine> lines)
         {
-            return ChatTextAnalyzer.ScoreOcrCandidate(lines?.Select(line => line.Text), characterNames);
+            return ocrService.ScoreLines(lines, characterNames);
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -60,6 +60,7 @@ namespace GameTranslator
         private string hotkeyWarningMessage = "";
 
         private HttpClient httpClient = new HttpClient();
+        private readonly OcrService ocrService = new OcrService();
         private Dictionary<string, OcrEngine> ocrEngines = new Dictionary<string, OcrEngine>();
         private IntPtr _windowHandle;
         private LogViewerWindow logViewerWindow;


### PR DESCRIPTION
## 작업 내용
- WinRT/Bitmap 의존이 없는 Core/OcrService 추가
- OcrProcessingMode, OcrPreprocessKind, OcrEvaluationStep, OcrLine, OcrCandidate 순수 모델 추가
- 빠름/자동/정확 모드별 OCR 후보 평가 계획을 OcrService로 분리
- fast path 성공 판단과 후보 점수 비교를 OcrService로 분리
- MainWindow는 기존처럼 Bitmap 전처리, Windows OCR 호출, UI 출력 담당 유지
- OcrServiceTests 7개 추가

## 테스트 범위
- Fast 모드: Color + 게임 언어 OCR 1단계 계획
- Auto 모드: Color fast path 후 ColorThick/Adaptive fallback 계획
- Accurate 모드: 모든 전처리 후보 + 모든 언어 OCR 계획
- fast path 성공 조건: 양수 점수 + 등록 캐릭터명 + 비어 있지 않은 메시지
- 후보 점수 비교
- OcrService가 Windows.Media.Ocr / SoftwareBitmap / System.Drawing.Bitmap 타입에 의존하지 않는지 확인

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
  - Passed: 35, Failed: 0
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
  - Passed: 35, Failed: 0
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
  - 0 Warning, 0 Error
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
  - 0 Warning, 0 Error
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
- publish 산출물에 GameChatTranslator.exe, GameChatTranslator.pdb, characters.txt, LangInstall.bat, readme.txt 포함 확인

## 범위 제한
- Windows.Media.Ocr.OcrEngine 호출은 MainWindow에 유지했습니다. 이번 PR은 후보 선택 정책과 점수 비교 흐름만 서비스로 분리합니다.