### PR TITLE
설정값 해석 서비스 분리

### DIFF
--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="../GameChatTranslator/Core/ChatTextAnalyzer.cs" Link="Core/ChatTextAnalyzer.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
+    <Compile Include="../GameChatTranslator/Core/SettingsService.cs" Link="Core/SettingsService.cs" />
     <Compile Include="../GameChatTranslator/Core/SettingsValueNormalizer.cs" Link="Core/SettingsValueNormalizer.cs" />
   </ItemGroup>
 

--- a/GameChatTranslator.Tests/SettingsServiceTests.cs
+++ b/GameChatTranslator.Tests/SettingsServiceTests.cs
@@ -1,0 +1,127 @@
+using System.Linq;
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class SettingsServiceTests
+    {
+        private readonly SettingsService _service = new SettingsService();
+
+        [Fact]
+        public void SelectGeminiKey_UsesCurrentSettingsKeyFirst()
+        {
+            GeminiKeySelection selection = _service.SelectGeminiKey("  current-key  ", "legacy-key");
+
+            Assert.Equal("current-key", selection.Key);
+            Assert.False(selection.ShouldMigrateLegacyKey);
+        }
+
+        [Fact]
+        public void SelectGeminiKey_UsesLegacyKeyWhenCurrentKeyIsEmpty()
+        {
+            GeminiKeySelection selection = _service.SelectGeminiKey("   ", "  legacy-key  ");
+
+            Assert.Equal("legacy-key", selection.Key);
+            Assert.True(selection.ShouldMigrateLegacyKey);
+        }
+
+        [Fact]
+        public void SelectGeminiKey_ReturnsEmptyWhenNoKeyExists()
+        {
+            GeminiKeySelection selection = _service.SelectGeminiKey(null, "");
+
+            Assert.Equal("", selection.Key);
+            Assert.False(selection.ShouldMigrateLegacyKey);
+        }
+
+        [Theory]
+        [InlineData(null, SettingsService.DefaultGeminiModel)]
+        [InlineData("", SettingsService.DefaultGeminiModel)]
+        [InlineData("   ", SettingsService.DefaultGeminiModel)]
+        [InlineData("  gemini-custom  ", "gemini-custom")]
+        public void NormalizeGeminiModel_UsesDefaultForBlankValues(string rawValue, string expected)
+        {
+            Assert.Equal(expected, _service.NormalizeGeminiModel(rawValue));
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("TRUE")]
+        [InlineData("1")]
+        [InlineData("yes")]
+        [InlineData("Y")]
+        [InlineData("on")]
+        [InlineData("  on  ")]
+        public void IsEnabled_AcceptsTruthyValues(string rawValue)
+        {
+            Assert.True(_service.IsEnabled(rawValue));
+        }
+
+        [Theory]
+        [InlineData("false")]
+        [InlineData("FALSE")]
+        [InlineData("0")]
+        [InlineData("no")]
+        [InlineData("N")]
+        [InlineData("off")]
+        [InlineData("  off  ")]
+        public void IsDisabled_AcceptsFalsyValues(string rawValue)
+        {
+            Assert.True(_service.IsDisabled(rawValue));
+        }
+
+        [Theory]
+        [InlineData(null, true, true)]
+        [InlineData("", false, false)]
+        [InlineData("unknown", true, true)]
+        [InlineData("unknown", false, false)]
+        [InlineData("true", false, true)]
+        [InlineData("false", true, false)]
+        public void IsEnabledOrDefault_UsesDefaultOnlyForUnknownValues(string rawValue, bool defaultValue, bool expected)
+        {
+            Assert.Equal(expected, _service.IsEnabledOrDefault(rawValue, defaultValue));
+        }
+
+        [Theory]
+        [InlineData(null, "Ctrl+7")]
+        [InlineData("", "Ctrl+7")]
+        [InlineData("   ", "Ctrl+7")]
+        [InlineData("  Ctrl+8  ", "Ctrl+8")]
+        public void NormalizeHotkey_UsesDefaultForBlankValues(string rawValue, string expected)
+        {
+            Assert.Equal(expected, _service.NormalizeHotkey(rawValue, SettingsService.DefaultKeyMoveLock));
+        }
+
+        [Fact]
+        public void GetDefaultHotkeys_ReturnsSharedDefaultHotkeyValues()
+        {
+            DefaultHotkeys hotkeys = _service.GetDefaultHotkeys();
+
+            Assert.Equal("Ctrl+7", hotkeys.MoveLock);
+            Assert.Equal("Ctrl+8", hotkeys.AreaSelect);
+            Assert.Equal("Ctrl+9", hotkeys.Translate);
+            Assert.Equal("Ctrl+0", hotkeys.AutoTranslate);
+            Assert.Equal("Ctrl+-", hotkeys.ToggleEngine);
+            Assert.Equal("Ctrl+6", hotkeys.CopyResult);
+            Assert.Equal("Ctrl+=", hotkeys.LogViewer);
+        }
+
+        [Fact]
+        public void SettingsService_DoesNotReferenceIniFileOrSystemIoTypes()
+        {
+            string settingsTypeNames = string.Join(
+                "\n",
+                typeof(SettingsService).Assembly
+                    .GetTypes()
+                    .Where(type =>
+                        type == typeof(SettingsService) ||
+                        type == typeof(GeminiKeySelection) ||
+                        type == typeof(DefaultHotkeys))
+                    .Select(type => type.AssemblyQualifiedName));
+
+            Assert.DoesNotContain("IniFile", settingsTypeNames);
+            Assert.DoesNotContain("System.IO", settingsTypeNames);
+        }
+    }
+}

--- a/GameChatTranslator/Core/SettingsService.cs
+++ b/GameChatTranslator/Core/SettingsService.cs
@@ -1,0 +1,161 @@
+using System;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// config.ini에서 읽은 문자열 설정값을 런타임 기본값과 UI 기본값으로 해석하는 순수 서비스입니다.
+    /// 실제 파일 읽기/쓰기는 호출자가 담당하고, 이 클래스는 값 선택/보정/마이그레이션 판단만 수행합니다.
+    /// </summary>
+    public sealed class SettingsService
+    {
+        public const string DefaultGeminiModel = "gemini-2.5-flash";
+        public const string DefaultResultDisplayMode = "Latest";
+
+        public const string DefaultKeyMoveLock = "Ctrl+7";
+        public const string DefaultKeyAreaSelect = "Ctrl+8";
+        public const string DefaultKeyTranslate = "Ctrl+9";
+        public const string DefaultKeyAutoTranslate = "Ctrl+0";
+        public const string DefaultKeyToggleEngine = "Ctrl+-";
+        public const string DefaultKeyCopyResult = "Ctrl+6";
+        public const string DefaultKeyLogViewer = "Ctrl+=";
+
+        /// <summary>
+        /// Gemini API 키를 선택합니다.
+        /// currentSectionKey가 있으면 우선 사용하고, 없으면 legacySectionKey를 사용합니다.
+        /// </summary>
+        public GeminiKeySelection SelectGeminiKey(string currentSectionKey, string legacySectionKey)
+        {
+            if (!string.IsNullOrWhiteSpace(currentSectionKey))
+            {
+                return new GeminiKeySelection(currentSectionKey.Trim(), false);
+            }
+
+            if (!string.IsNullOrWhiteSpace(legacySectionKey))
+            {
+                return new GeminiKeySelection(legacySectionKey.Trim(), true);
+            }
+
+            return new GeminiKeySelection("", false);
+        }
+
+        /// <summary>
+        /// Gemini 모델명이 비어 있으면 기본 모델명을 반환합니다.
+        /// </summary>
+        public string NormalizeGeminiModel(string modelName)
+        {
+            return string.IsNullOrWhiteSpace(modelName) ? DefaultGeminiModel : modelName.Trim();
+        }
+
+        /// <summary>
+        /// true/1/yes/y/on 값을 true로 해석합니다.
+        /// </summary>
+        public bool IsEnabled(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return false;
+
+            string normalized = value.Trim();
+            return normalized.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("y", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("on", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// false/0/no/n/off 값을 false로 해석합니다.
+        /// 그 외 값은 defaultValue로 처리합니다.
+        /// </summary>
+        public bool IsEnabledOrDefault(string value, bool defaultValue)
+        {
+            if (IsEnabled(value)) return true;
+            if (IsDisabled(value)) return false;
+            return defaultValue;
+        }
+
+        /// <summary>
+        /// false/0/no/n/off 값을 명시적 꺼짐으로 해석합니다.
+        /// </summary>
+        public bool IsDisabled(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return false;
+
+            string normalized = value.Trim();
+            return normalized.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("0", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("no", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("n", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("off", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// 저장된 단축키 문자열이 비어 있으면 기본 단축키를 반환합니다.
+        /// </summary>
+        public string NormalizeHotkey(string configuredHotkey, string defaultHotkey)
+        {
+            return string.IsNullOrWhiteSpace(configuredHotkey) ? defaultHotkey : configuredHotkey.Trim();
+        }
+
+        /// <summary>
+        /// 기본 단축키 묶음을 반환합니다.
+        /// </summary>
+        public DefaultHotkeys GetDefaultHotkeys()
+        {
+            return new DefaultHotkeys(
+                DefaultKeyMoveLock,
+                DefaultKeyAreaSelect,
+                DefaultKeyTranslate,
+                DefaultKeyAutoTranslate,
+                DefaultKeyToggleEngine,
+                DefaultKeyCopyResult,
+                DefaultKeyLogViewer);
+        }
+    }
+
+    /// <summary>
+    /// Gemini API 키 선택 결과입니다.
+    /// ShouldMigrateLegacyKey가 true이면 구버전 [GeminiKey] 섹션 값을 현재 [Settings] 섹션에 저장해야 합니다.
+    /// </summary>
+    public sealed class GeminiKeySelection
+    {
+        public GeminiKeySelection(string key, bool shouldMigrateLegacyKey)
+        {
+            Key = key ?? "";
+            ShouldMigrateLegacyKey = shouldMigrateLegacyKey;
+        }
+
+        public string Key { get; }
+        public bool ShouldMigrateLegacyKey { get; }
+    }
+
+    /// <summary>
+    /// 환경설정창과 전역 단축키 등록에서 공유하는 기본 단축키 묶음입니다.
+    /// </summary>
+    public sealed class DefaultHotkeys
+    {
+        public DefaultHotkeys(
+            string moveLock,
+            string areaSelect,
+            string translate,
+            string autoTranslate,
+            string toggleEngine,
+            string copyResult,
+            string logViewer)
+        {
+            MoveLock = moveLock;
+            AreaSelect = areaSelect;
+            Translate = translate;
+            AutoTranslate = autoTranslate;
+            ToggleEngine = toggleEngine;
+            CopyResult = copyResult;
+            LogViewer = logViewer;
+        }
+
+        public string MoveLock { get; }
+        public string AreaSelect { get; }
+        public string Translate { get; }
+        public string AutoTranslate { get; }
+        public string ToggleEngine { get; }
+        public string CopyResult { get; }
+        public string LogViewer { get; }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
@@ -47,13 +47,14 @@ namespace GameTranslator
             hotkeyWarningMessage = "";
             var failedHotkeys = new List<string>();
 
-            string moveHotkey = ini.Read("Key_MoveLock") ?? "Ctrl+7";
-            string areaHotkey = ini.Read("Key_AreaSelect") ?? "Ctrl+8";
-            string translateHotkey = ini.Read("Key_Translate") ?? "Ctrl+9";
-            string autoHotkey = ini.Read("Key_AutoTranslate") ?? "Ctrl+0";
-            string toggleHotkey = ini.Read("Key_ToggleEngine") ?? "Ctrl+-";
-            string copyHotkey = ini.Read("Key_CopyResult") ?? "Ctrl+6";
-            string logHotkey = ini.Read("Key_LogViewer") ?? "Ctrl+=";
+            DefaultHotkeys defaults = settingsService.GetDefaultHotkeys();
+            string moveHotkey = settingsService.NormalizeHotkey(ini.Read("Key_MoveLock"), defaults.MoveLock);
+            string areaHotkey = settingsService.NormalizeHotkey(ini.Read("Key_AreaSelect"), defaults.AreaSelect);
+            string translateHotkey = settingsService.NormalizeHotkey(ini.Read("Key_Translate"), defaults.Translate);
+            string autoHotkey = settingsService.NormalizeHotkey(ini.Read("Key_AutoTranslate"), defaults.AutoTranslate);
+            string toggleHotkey = settingsService.NormalizeHotkey(ini.Read("Key_ToggleEngine"), defaults.ToggleEngine);
+            string copyHotkey = settingsService.NormalizeHotkey(ini.Read("Key_CopyResult"), defaults.CopyResult);
+            string logHotkey = settingsService.NormalizeHotkey(ini.Read("Key_LogViewer"), defaults.LogViewer);
 
             ParseHotkey(moveHotkey, out modMove, out keyMove);
             ParseHotkey(areaHotkey, out modArea, out keyArea);
@@ -123,13 +124,14 @@ namespace GameTranslator
         /// </summary>
         private void UpdateYellowHotkeyGuideText()
         {
-            string m = ini.Read("Key_MoveLock") ?? "Ctrl+7";
-            string a = ini.Read("Key_AreaSelect") ?? "Ctrl+8";
-            string t = ini.Read("Key_Translate") ?? "Ctrl+9";
-            string au = ini.Read("Key_AutoTranslate") ?? "Ctrl+0";
-            string tg = ini.Read("Key_ToggleEngine") ?? "Ctrl+-";
-            string copy = ini.Read("Key_CopyResult") ?? "Ctrl+6";
-            string log = ini.Read("Key_LogViewer") ?? "Ctrl+=";
+            DefaultHotkeys defaults = settingsService.GetDefaultHotkeys();
+            string m = settingsService.NormalizeHotkey(ini.Read("Key_MoveLock"), defaults.MoveLock);
+            string a = settingsService.NormalizeHotkey(ini.Read("Key_AreaSelect"), defaults.AreaSelect);
+            string t = settingsService.NormalizeHotkey(ini.Read("Key_Translate"), defaults.Translate);
+            string au = settingsService.NormalizeHotkey(ini.Read("Key_AutoTranslate"), defaults.AutoTranslate);
+            string tg = settingsService.NormalizeHotkey(ini.Read("Key_ToggleEngine"), defaults.ToggleEngine);
+            string copy = settingsService.NormalizeHotkey(ini.Read("Key_CopyResult"), defaults.CopyResult);
+            string log = settingsService.NormalizeHotkey(ini.Read("Key_LogViewer"), defaults.LogViewer);
 
             // 🌟 안내 문구에 엔진 전환 추가
             string engineStr = useGeminiEngine ? "Gemini" : "Google";

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Native.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Native.cs
@@ -66,6 +66,6 @@ namespace GameTranslator
         private const int ID_HOTKEY_TOGGLE_ENGINE = 9005;
         private const int ID_HOTKEY_COPY_RESULT = 9006;
         private const int ID_HOTKEY_LOG_VIEWER = 9007;
-        internal const string DefaultGeminiModel = "gemini-2.5-flash";
+        internal const string DefaultGeminiModel = SettingsService.DefaultGeminiModel;
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.ResultDisplay.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.ResultDisplay.cs
@@ -116,7 +116,7 @@ namespace GameTranslator
         /// </summary>
         private bool ShouldAccumulateTranslationResults()
         {
-            string displayMode = ini.Read("ResultDisplayMode") ?? "Latest";
+            string displayMode = ini.Read("ResultDisplayMode") ?? SettingsService.DefaultResultDisplayMode;
             return displayMode.Equals(ResultDisplayModeHistory, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
@@ -69,7 +69,7 @@ namespace GameTranslator
 
             if (string.IsNullOrWhiteSpace(ini.Read("GeminiModel")))
             {
-                ini.Write("GeminiModel", DefaultGeminiModel);
+                ini.Write("GeminiModel", SettingsService.DefaultGeminiModel);
             }
 
             if (string.IsNullOrWhiteSpace(ini.Read("SaveDebugImages")))
@@ -84,17 +84,17 @@ namespace GameTranslator
 
             if (string.IsNullOrWhiteSpace(ini.Read("Key_CopyResult")))
             {
-                ini.Write("Key_CopyResult", "Ctrl+6");
+                ini.Write("Key_CopyResult", SettingsService.DefaultKeyCopyResult);
             }
 
             if (string.IsNullOrWhiteSpace(ini.Read("Key_LogViewer")))
             {
-                ini.Write("Key_LogViewer", "Ctrl+=");
+                ini.Write("Key_LogViewer", SettingsService.DefaultKeyLogViewer);
             }
 
             if (string.IsNullOrWhiteSpace(ini.Read("ResultDisplayMode")))
             {
-                ini.Write("ResultDisplayMode", "Latest");
+                ini.Write("ResultDisplayMode", SettingsService.DefaultResultDisplayMode);
             }
 
             if (string.IsNullOrWhiteSpace(ini.Read("ResultHistoryLimit")))
@@ -109,22 +109,16 @@ namespace GameTranslator
         /// </summary>
         private string ReadGeminiKey()
         {
-            string settingsKey = ini.Read("GeminiKey");
-            if (!string.IsNullOrWhiteSpace(settingsKey))
+            GeminiKeySelection selectedKey = settingsService.SelectGeminiKey(
+                ini.Read("GeminiKey"),
+                ini.Read("GeminiKey", "GeminiKey"));
+            if (selectedKey.ShouldMigrateLegacyKey)
             {
-                return settingsKey.Trim();
-            }
-
-            string legacySectionKey = ini.Read("GeminiKey", "GeminiKey");
-            if (!string.IsNullOrWhiteSpace(legacySectionKey))
-            {
-                string trimmedKey = legacySectionKey.Trim();
-                ini.Write("GeminiKey", trimmedKey);
+                ini.Write("GeminiKey", selectedKey.Key);
                 AppendLog("기존 [GeminiKey] 섹션의 API 키를 [Settings] 섹션으로 이전했습니다.");
-                return trimmedKey;
             }
 
-            return "";
+            return selectedKey.Key;
         }
 
         /// <summary>
@@ -133,8 +127,7 @@ namespace GameTranslator
         /// </summary>
         private string ReadGeminiModel()
         {
-            string modelName = ini.Read("GeminiModel");
-            return string.IsNullOrWhiteSpace(modelName) ? DefaultGeminiModel : modelName.Trim();
+            return settingsService.NormalizeGeminiModel(ini.Read("GeminiModel"));
         }
 
         /// <summary>
@@ -143,11 +136,7 @@ namespace GameTranslator
         /// </summary>
         private bool ShouldSaveDebugImages()
         {
-            string value = ini.Read("SaveDebugImages") ?? "false";
-            return value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("y", StringComparison.OrdinalIgnoreCase);
+            return settingsService.IsEnabled(ini.Read("SaveDebugImages"));
         }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Update.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Update.cs
@@ -273,10 +273,7 @@ namespace GameTranslator
         /// </summary>
         private bool IsDisabledSetting(string value)
         {
-            return value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("0", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("no", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("n", StringComparison.OrdinalIgnoreCase);
+            return settingsService.IsDisabled(value);
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -61,6 +61,7 @@ namespace GameTranslator
 
         private HttpClient httpClient = new HttpClient();
         private readonly OcrService ocrService = new OcrService();
+        private readonly SettingsService settingsService = new SettingsService();
         private Dictionary<string, OcrEngine> ocrEngines = new Dictionary<string, OcrEngine>();
         private IntPtr _windowHandle;
         private LogViewerWindow logViewerWindow;

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
@@ -227,10 +227,10 @@ namespace GameTranslator
             _ini.Write("ScaleFactor", GetSelectedTag(ComboScale, "3"), section);
             _ini.Write("Threshold", string.IsNullOrWhiteSpace(TxtThreshold?.Text) ? "120" : TxtThreshold.Text.Trim(), section);
             _ini.Write("AutoTranslateInterval", string.IsNullOrWhiteSpace(TxtInterval?.Text) ? "5" : TxtInterval.Text.Trim(), section);
-            _ini.Write("ResultDisplayMode", GetSelectedTag(ComboResultDisplayMode, "Latest"), section);
+            _ini.Write("ResultDisplayMode", GetSelectedTag(ComboResultDisplayMode, SettingsService.DefaultResultDisplayMode), section);
             _ini.Write("ResultHistoryLimit", SettingsValueNormalizer.NormalizeResultHistoryLimit(TxtResultHistoryLimit?.Text).ToString(), section);
             _ini.Write("SaveDebugImages", CheckSaveDebugImages?.IsChecked == true ? "true" : "false", section);
-            _ini.Write("GeminiModel", string.IsNullOrWhiteSpace(TxtGeminiModel?.Text) ? MainWindow.DefaultGeminiModel : TxtGeminiModel.Text.Trim(), section);
+            _ini.Write("GeminiModel", _settingsService.NormalizeGeminiModel(TxtGeminiModel?.Text), section);
             _ini.Write("Key_MoveLock", TxtKeyMove.Text, section);
             _ini.Write("Key_AreaSelect", TxtKeyArea.Text, section);
             _ini.Write("Key_Translate", TxtKeyTrans.Text, section);
@@ -264,17 +264,18 @@ namespace GameTranslator
 
             TxtThreshold.Text = ReadPresetValue(section, "Threshold", "120");
             TxtInterval.Text = ReadPresetValue(section, "AutoTranslateInterval", "5");
-            SetComboByTag(ComboResultDisplayMode, ReadPresetValue(section, "ResultDisplayMode", "Latest"));
+            SetComboByTag(ComboResultDisplayMode, ReadPresetValue(section, "ResultDisplayMode", SettingsService.DefaultResultDisplayMode));
             TxtResultHistoryLimit.Text = SettingsValueNormalizer.NormalizeResultHistoryLimit(ReadPresetValue(section, "ResultHistoryLimit", "5")).ToString();
-            CheckSaveDebugImages.IsChecked = IsTruthy(ReadPresetValue(section, "SaveDebugImages", "false"));
-            TxtGeminiModel.Text = ReadPresetValue(section, "GeminiModel", MainWindow.DefaultGeminiModel);
-            TxtKeyMove.Text = ReadPresetValue(section, "Key_MoveLock", DefaultKeyMoveLock);
-            TxtKeyArea.Text = ReadPresetValue(section, "Key_AreaSelect", DefaultKeyAreaSelect);
-            TxtKeyTrans.Text = ReadPresetValue(section, "Key_Translate", DefaultKeyTranslate);
-            TxtKeyAuto.Text = ReadPresetValue(section, "Key_AutoTranslate", DefaultKeyAutoTranslate);
-            TxtKeyToggle.Text = ReadPresetValue(section, "Key_ToggleEngine", DefaultKeyToggleEngine);
-            TxtKeyCopy.Text = ReadPresetValue(section, "Key_CopyResult", DefaultKeyCopyResult);
-            TxtKeyLog.Text = ReadPresetValue(section, "Key_LogViewer", DefaultKeyLogViewer);
+            CheckSaveDebugImages.IsChecked = _settingsService.IsEnabled(ReadPresetValue(section, "SaveDebugImages", "false"));
+            TxtGeminiModel.Text = _settingsService.NormalizeGeminiModel(ReadPresetValue(section, "GeminiModel", SettingsService.DefaultGeminiModel));
+            DefaultHotkeys defaults = _settingsService.GetDefaultHotkeys();
+            TxtKeyMove.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_MoveLock", defaults.MoveLock), defaults.MoveLock);
+            TxtKeyArea.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_AreaSelect", defaults.AreaSelect), defaults.AreaSelect);
+            TxtKeyTrans.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_Translate", defaults.Translate), defaults.Translate);
+            TxtKeyAuto.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_AutoTranslate", defaults.AutoTranslate), defaults.AutoTranslate);
+            TxtKeyToggle.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_ToggleEngine", defaults.ToggleEngine), defaults.ToggleEngine);
+            TxtKeyCopy.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_CopyResult", defaults.CopyResult), defaults.CopyResult);
+            TxtKeyLog.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_LogViewer", defaults.LogViewer), defaults.LogViewer);
 
             foreach (string key in PresetSettingKeys)
             {
@@ -303,18 +304,6 @@ namespace GameTranslator
         private string GetSelectedTag(System.Windows.Controls.ComboBox combo, string defaultValue)
         {
             return (combo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? defaultValue;
-        }
-
-        /// <summary>
-        /// INI 문자열 값을 bool true 여부로 해석합니다.
-        /// <paramref name="value"/>는 true/1/yes/y 중 하나일 수 있는 설정 문자열입니다.
-        /// </summary>
-        private bool IsTruthy(string value)
-        {
-            return value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
-                   value.Equals("y", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -16,14 +16,8 @@ namespace GameTranslator
         private MainWindow _mainWindow;
         // 환경설정 파일(config.ini)을 읽고 쓰기 위한 객체
         private IniFile _ini;
+        private readonly SettingsService _settingsService = new SettingsService();
 
-        private const string DefaultKeyMoveLock = "Ctrl+7";
-        private const string DefaultKeyAreaSelect = "Ctrl+8";
-        private const string DefaultKeyTranslate = "Ctrl+9";
-        private const string DefaultKeyAutoTranslate = "Ctrl+0";
-        private const string DefaultKeyToggleEngine = "Ctrl+-";
-        private const string DefaultKeyCopyResult = "Ctrl+6";
-        private const string DefaultKeyLogViewer = "Ctrl+=";
         private static readonly (string Label, string Tag)[] OcrLanguageStatusTargets =
         {
             ("한국어", "ko"),
@@ -73,13 +67,14 @@ namespace GameTranslator
 
             // [단축키 세팅]
             // 각 텍스트박스에 기존에 저장된 단축키 문자열을 넣어줍니다. (없으면 기본값 적용)
-            TxtKeyMove.Text = _ini.Read("Key_MoveLock") ?? DefaultKeyMoveLock;
-            TxtKeyArea.Text = _ini.Read("Key_AreaSelect") ?? DefaultKeyAreaSelect;
-            TxtKeyTrans.Text = _ini.Read("Key_Translate") ?? DefaultKeyTranslate;
-            TxtKeyAuto.Text = _ini.Read("Key_AutoTranslate") ?? DefaultKeyAutoTranslate;
-            TxtKeyToggle.Text = _ini.Read("Key_ToggleEngine") ?? DefaultKeyToggleEngine;
-            TxtKeyCopy.Text = _ini.Read("Key_CopyResult") ?? DefaultKeyCopyResult;
-            TxtKeyLog.Text = _ini.Read("Key_LogViewer") ?? DefaultKeyLogViewer;
+            DefaultHotkeys defaults = _settingsService.GetDefaultHotkeys();
+            TxtKeyMove.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_MoveLock"), defaults.MoveLock);
+            TxtKeyArea.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_AreaSelect"), defaults.AreaSelect);
+            TxtKeyTrans.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_Translate"), defaults.Translate);
+            TxtKeyAuto.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_AutoTranslate"), defaults.AutoTranslate);
+            TxtKeyToggle.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_ToggleEngine"), defaults.ToggleEngine);
+            TxtKeyCopy.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_CopyResult"), defaults.CopyResult);
+            TxtKeyLog.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_LogViewer"), defaults.LogViewer);
 
             // [캡처 영역 세팅]
             // 메인 폼에서 사용자가 드래그하여 저장했던 X, Y 좌표와 넓이, 높이를 읽어옵니다.
@@ -106,35 +101,27 @@ namespace GameTranslator
             // UI에 TxtThreshold, TxtInterval 텍스트박스가 있다고 가정합니다.
             if (TxtThreshold != null) TxtThreshold.Text = _ini.Read("Threshold") ?? "120";
             if (TxtInterval != null) TxtInterval.Text = _ini.Read("AutoTranslateInterval") ?? "5";
-            if (ComboResultDisplayMode != null) SetComboByTag(ComboResultDisplayMode, _ini.Read("ResultDisplayMode") ?? "Latest");
+            if (ComboResultDisplayMode != null) SetComboByTag(ComboResultDisplayMode, _ini.Read("ResultDisplayMode") ?? SettingsService.DefaultResultDisplayMode);
             if (TxtResultHistoryLimit != null)
             {
                 TxtResultHistoryLimit.Text = SettingsValueNormalizer.NormalizeResultHistoryLimit(_ini.Read("ResultHistoryLimit")).ToString();
             }
 
-            string geminiKey = _ini.Read("GeminiKey") ?? "";
-            if (string.IsNullOrWhiteSpace(geminiKey))
-            {
-                geminiKey = _ini.Read("GeminiKey", "GeminiKey") ?? "";
-            }
+            GeminiKeySelection geminiKey = _settingsService.SelectGeminiKey(
+                _ini.Read("GeminiKey"),
+                _ini.Read("GeminiKey", "GeminiKey"));
 
-            if (PasswordGeminiKey != null) PasswordGeminiKey.Password = geminiKey.Trim();
-            if (TxtGeminiModel != null) TxtGeminiModel.Text = _ini.Read("GeminiModel") ?? MainWindow.DefaultGeminiModel;
+            if (PasswordGeminiKey != null) PasswordGeminiKey.Password = geminiKey.Key;
+            if (TxtGeminiModel != null) TxtGeminiModel.Text = _settingsService.NormalizeGeminiModel(_ini.Read("GeminiModel"));
 
-            string saveDebugImages = _ini.Read("SaveDebugImages") ?? "false";
             if (CheckSaveDebugImages != null)
             {
-                CheckSaveDebugImages.IsChecked =
-                    saveDebugImages.Equals("true", System.StringComparison.OrdinalIgnoreCase) ||
-                    saveDebugImages == "1";
+                CheckSaveDebugImages.IsChecked = _settingsService.IsEnabled(_ini.Read("SaveDebugImages"));
             }
 
-            string checkUpdatesOnStartup = _ini.Read("CheckUpdatesOnStartup") ?? "true";
             if (CheckUpdatesOnStartup != null)
             {
-                CheckUpdatesOnStartup.IsChecked =
-                    !checkUpdatesOnStartup.Equals("false", System.StringComparison.OrdinalIgnoreCase) &&
-                    checkUpdatesOnStartup != "0";
+                CheckUpdatesOnStartup.IsChecked = _settingsService.IsEnabledOrDefault(_ini.Read("CheckUpdatesOnStartup"), true);
             }
         }
 
@@ -251,13 +238,14 @@ namespace GameTranslator
         /// </summary>
         private void ApplyDefaultHotkeyValues()
         {
-            TxtKeyMove.Text = DefaultKeyMoveLock;
-            TxtKeyArea.Text = DefaultKeyAreaSelect;
-            TxtKeyTrans.Text = DefaultKeyTranslate;
-            TxtKeyAuto.Text = DefaultKeyAutoTranslate;
-            TxtKeyToggle.Text = DefaultKeyToggleEngine;
-            TxtKeyCopy.Text = DefaultKeyCopyResult;
-            TxtKeyLog.Text = DefaultKeyLogViewer;
+            DefaultHotkeys defaults = _settingsService.GetDefaultHotkeys();
+            TxtKeyMove.Text = defaults.MoveLock;
+            TxtKeyArea.Text = defaults.AreaSelect;
+            TxtKeyTrans.Text = defaults.Translate;
+            TxtKeyAuto.Text = defaults.AutoTranslate;
+            TxtKeyToggle.Text = defaults.ToggleEngine;
+            TxtKeyCopy.Text = defaults.CopyResult;
+            TxtKeyLog.Text = defaults.LogViewer;
         }
 
         /// <summary>
@@ -340,7 +328,7 @@ namespace GameTranslator
                 _ini.Write("AutoTranslateInterval", "5"); // 숫자가 아니면 기본값 5 강제 지정
             }
 
-            _ini.Write("ResultDisplayMode", GetSelectedTag(ComboResultDisplayMode, "Latest"));
+            _ini.Write("ResultDisplayMode", GetSelectedTag(ComboResultDisplayMode, SettingsService.DefaultResultDisplayMode));
             int historyLimit = SettingsValueNormalizer.NormalizeResultHistoryLimit(TxtResultHistoryLimit?.Text);
             _ini.Write("ResultHistoryLimit", historyLimit.ToString());
             if (TxtResultHistoryLimit != null) TxtResultHistoryLimit.Text = historyLimit.ToString();
@@ -349,8 +337,7 @@ namespace GameTranslator
             _ini.Write("CheckUpdatesOnStartup", CheckUpdatesOnStartup?.IsChecked == true ? "true" : "false");
             _ini.Write("GeminiKey", PasswordGeminiKey?.Password?.Trim() ?? "");
 
-            string geminiModel = TxtGeminiModel?.Text?.Trim();
-            _ini.Write("GeminiModel", string.IsNullOrWhiteSpace(geminiModel) ? MainWindow.DefaultGeminiModel : geminiModel);
+            _ini.Write("GeminiModel", _settingsService.NormalizeGeminiModel(TxtGeminiModel?.Text));
 
             // DialogResult를 true로 설정하여 메인 창(MainWindow)에 정상 종료되었음을 알리고 창을 닫습니다.
             this.DialogResult = true;


### PR DESCRIPTION
## 작업 내용
- config.ini에서 읽은 문자열 설정값을 해석하는 순수 SettingsService 추가
- Gemini Key 선택/구버전 섹션 마이그레이션 판단, Gemini Model 기본값, bool 설정 해석, 단축키 기본값을 공통 서비스로 정리
- MainWindow / OptionSelector / Preset 로직에서 중복된 기본값과 bool 해석 로직 제거
- SettingsService 단위 테스트 추가

## 검증
- SettingsService에 IniFile / System.IO 참조 없음 확인
- git diff --check 통과
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true: 68 passed
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true: 0 Warning, 0 Error
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true: 0 Warning, 0 Error
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore: 68 passed
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true: 성공
- publish 산출물 확인: GameChatTranslator.exe, GameChatTranslator.pdb, LangInstall.bat, characters.txt, readme.txt