### PR TITLE
번역 문자열 처리 로직 분리

### DIFF
--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -21,6 +21,8 @@
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/SettingsService.cs" Link="Core/SettingsService.cs" />
     <Compile Include="../GameChatTranslator/Core/SettingsValueNormalizer.cs" Link="Core/SettingsValueNormalizer.cs" />
+    <Compile Include="../GameChatTranslator/Core/TranslationPromptBuilder.cs" Link="Core/TranslationPromptBuilder.cs" />
+    <Compile Include="../GameChatTranslator/Core/TranslationResultParser.cs" Link="Core/TranslationResultParser.cs" />
   </ItemGroup>
 
 </Project>

--- a/GameChatTranslator.Tests/TranslationPromptBuilderTests.cs
+++ b/GameChatTranslator.Tests/TranslationPromptBuilderTests.cs
@@ -1,0 +1,69 @@
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class TranslationPromptBuilderTests
+    {
+        private readonly TranslationPromptBuilder _builder = new TranslationPromptBuilder();
+
+        [Fact]
+        public void CleanGoogleTranslateInput_RemovesOcrNoiseAndNormalizesWhitespace()
+        {
+            string cleaned = _builder.CleanGoogleTranslateInput("[미셸] 12:34 hello@@@ ---   world");
+
+            Assert.Equal("미셸 hello - world", cleaned);
+        }
+
+        [Theory]
+        [InlineData("hello", true)]
+        [InlineData("안", true)]
+        [InlineData("你", true)]
+        [InlineData("a", false)]
+        [InlineData("123 !!", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void HasTranslatableContent_AppliesMinimumContentRules(string cleanedText, bool expected)
+        {
+            Assert.Equal(expected, _builder.HasTranslatableContent(cleanedText));
+        }
+
+        [Theory]
+        [InlineData("zh-Hans-CN", "zh-CN")]
+        [InlineData("en-US", "en")]
+        [InlineData("ko", "ko")]
+        [InlineData("ja", "ja")]
+        public void GetGoogleTranslateLanguageCode_MapsInternalCodes(string internalCode, string expected)
+        {
+            Assert.Equal(expected, _builder.GetGoogleTranslateLanguageCode(internalCode));
+        }
+
+        [Fact]
+        public void BuildGoogleTranslateUrl_EscapesTextAndMapsTargetLanguage()
+        {
+            string url = _builder.BuildGoogleTranslateUrl("hello world?", "en-US");
+
+            Assert.Contains("tl=en", url);
+            Assert.Contains("q=hello%20world%3F", url);
+        }
+
+        [Theory]
+        [InlineData("ko", "Korean")]
+        [InlineData("en-US", "English")]
+        [InlineData("ja", "ja")]
+        public void GetGeminiTargetLanguageName_MapsKnownLanguageNames(string internalCode, string expected)
+        {
+            Assert.Equal(expected, _builder.GetGeminiTargetLanguageName(internalCode));
+        }
+
+        [Fact]
+        public void BuildGeminiPrompt_IncludesTargetLanguageAndOriginalText()
+        {
+            string prompt = _builder.BuildGeminiPrompt("伽好", "ko");
+
+            Assert.Contains("Korean", prompt);
+            Assert.Contains("伽好", prompt);
+            Assert.Contains("Output ONLY the translation", prompt);
+        }
+    }
+}

--- a/GameChatTranslator.Tests/TranslationResultParserTests.cs
+++ b/GameChatTranslator.Tests/TranslationResultParserTests.cs
@@ -1,0 +1,50 @@
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class TranslationResultParserTests
+    {
+        private readonly TranslationResultParser _parser = new TranslationResultParser();
+
+        [Fact]
+        public void ParseGoogleTranslateResponse_CombinesTranslatedSegments()
+        {
+            string json = "[[[\"안녕\", \"hello\", null, null],[\" 세계\", \" world\", null, null]], null, \"en\"]";
+
+            string result = _parser.ParseGoogleTranslateResponse(json);
+
+            Assert.Equal("안녕 세계", result);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("{}")]
+        [InlineData("not-json")]
+        public void ParseGoogleTranslateResponse_ReturnsEmptyForInvalidResponses(string json)
+        {
+            Assert.Equal("", _parser.ParseGoogleTranslateResponse(json));
+        }
+
+        [Fact]
+        public void ParseGeminiTranslateResponse_ExtractsFirstCandidateText()
+        {
+            string json = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" 번역 결과 \\n\"}]}}]}";
+
+            string result = _parser.ParseGeminiTranslateResponse(json);
+
+            Assert.Equal("번역 결과", result);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("{}")]
+        [InlineData("not-json")]
+        public void ParseGeminiTranslateResponse_ReturnsEmptyForInvalidResponses(string json)
+        {
+            Assert.Equal("", _parser.ParseGeminiTranslateResponse(json));
+        }
+    }
+}

--- a/GameChatTranslator/Core/TranslationPromptBuilder.cs
+++ b/GameChatTranslator/Core/TranslationPromptBuilder.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// 번역 API 호출 전에 필요한 문자열 정리, 언어 코드 변환, Gemini 프롬프트 생성을 담당하는 순수 서비스입니다.
+    /// HTTP 호출이나 UI 상태에는 의존하지 않아 단위 테스트에서 직접 검증할 수 있습니다.
+    /// </summary>
+    public sealed class TranslationPromptBuilder
+    {
+        private const string TranslatableLetterPattern = @"[a-zA-Z가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ]";
+        private const string SingleCharacterAllowPattern = @"^[가-힣ぁ-んァ-ヶ\u4e00-\u9fa5]$";
+
+        /// <summary>
+        /// Google Translate API에 보내기 전 OCR 노이즈와 불필요한 기호를 제거합니다.
+        /// <paramref name="text"/>는 OCR 후처리 결과 또는 채팅 본문입니다.
+        /// 반환값은 API 요청에 사용할 정리된 문자열이며, 입력이 비어 있으면 빈 문자열입니다.
+        /// </summary>
+        public string CleanGoogleTranslateInput(string text)
+        {
+            string cleaned = text ?? "";
+            cleaned = Regex.Replace(cleaned, @"\d{1,2}:\d{2}", "");
+            cleaned = Regex.Replace(cleaned, @"[\[\]\(\)\{\}\<\>]", " ");
+            cleaned = Regex.Replace(cleaned, @"[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\.,!\?\-]", "");
+            cleaned = Regex.Replace(cleaned, @"([\-\=\.\/_])\1+", "$1");
+            cleaned = Regex.Replace(cleaned, @"\s+", " ").Trim();
+            return cleaned;
+        }
+
+        /// <summary>
+        /// 정리된 문자열이 번역 API를 호출할 만한 실제 문자인지 판단합니다.
+        /// 숫자/기호만 있으면 false이며, 한 글자 채팅은 한중일 문자일 때만 허용합니다.
+        /// </summary>
+        public bool HasTranslatableContent(string cleanedText)
+        {
+            string text = cleanedText ?? "";
+            if (text.Length == 1)
+            {
+                return Regex.IsMatch(text, SingleCharacterAllowPattern);
+            }
+
+            return text.Length >= 2 && Regex.IsMatch(text, TranslatableLetterPattern);
+        }
+
+        /// <summary>
+        /// 앱 내부 언어 코드를 Google Translate API의 tl 파라미터 언어 코드로 변환합니다.
+        /// <paramref name="targetLanguageCode"/>는 ko, en-US, zh-Hans-CN 같은 내부 언어 코드입니다.
+        /// </summary>
+        public string GetGoogleTranslateLanguageCode(string targetLanguageCode)
+        {
+            if (targetLanguageCode == "zh-Hans-CN") return "zh-CN";
+            if (targetLanguageCode == "en-US") return "en";
+            return targetLanguageCode;
+        }
+
+        /// <summary>
+        /// Google Translate 비공식 엔드포인트 호출 URL을 생성합니다.
+        /// <paramref name="cleanedText"/>는 CleanGoogleTranslateInput을 통과한 문자열,
+        /// <paramref name="targetLanguageCode"/>는 앱 내부 목표 언어 코드입니다.
+        /// </summary>
+        public string BuildGoogleTranslateUrl(string cleanedText, string targetLanguageCode)
+        {
+            string targetApiLang = GetGoogleTranslateLanguageCode(targetLanguageCode);
+            return $"https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl={targetApiLang}&dt=t&q={Uri.EscapeDataString(cleanedText ?? "")}";
+        }
+
+        /// <summary>
+        /// Gemini 프롬프트에 표시할 목표 언어명을 반환합니다.
+        /// 한국어/영어는 자연어 이름으로 바꾸고, 그 외 언어는 내부 코드를 그대로 사용합니다.
+        /// </summary>
+        public string GetGeminiTargetLanguageName(string targetLanguageCode)
+        {
+            if (targetLanguageCode == "ko") return "Korean";
+            if (targetLanguageCode == "en-US") return "English";
+            return targetLanguageCode;
+        }
+
+        /// <summary>
+        /// OCR 오타가 섞인 게임 채팅을 Gemini가 자연스럽게 복원/번역하도록 요청하는 프롬프트를 생성합니다.
+        /// <paramref name="text"/>는 번역할 채팅 본문,
+        /// <paramref name="targetLanguageCode"/>는 앱 내부 목표 언어 코드입니다.
+        /// </summary>
+        public string BuildGeminiPrompt(string text, string targetLanguageCode)
+        {
+            string targetLanguage = GetGeminiTargetLanguageName(targetLanguageCode);
+            return "You are an expert game translator. " +
+                   "The input text is from OCR and has many typos (e.g., '伽' instead of '你', 'カ' instead of '为'). " +
+                   "Your job: 1. Guess the original intended sentence by ignoring OCR noise. " +
+                   "2. Translate it naturally into " + targetLanguage + ". " +
+                   "3. If the text is just a name or nonsense, return an empty string. " +
+                   "Output ONLY the translation: \n\n" + (text ?? "");
+        }
+    }
+}

--- a/GameChatTranslator/Core/TranslationResultParser.cs
+++ b/GameChatTranslator/Core/TranslationResultParser.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Text.Json;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// 번역 API 응답 JSON에서 최종 번역 문자열만 추출하는 순수 파서입니다.
+    /// 네트워크 호출과 재시도 판단은 호출자가 담당하고, 이 클래스는 JSON 구조 해석만 수행합니다.
+    /// </summary>
+    public sealed class TranslationResultParser
+    {
+        /// <summary>
+        /// Google Translate 비공식 엔드포인트 응답에서 번역 조각을 순서대로 이어 붙입니다.
+        /// 파싱할 수 없는 응답이면 빈 문자열을 반환합니다.
+        /// </summary>
+        public string ParseGoogleTranslateResponse(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return "";
+
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(json);
+                JsonElement root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Array || root.GetArrayLength() == 0) return "";
+
+                JsonElement sentenceArray = root[0];
+                if (sentenceArray.ValueKind != JsonValueKind.Array) return "";
+
+                string result = "";
+                foreach (JsonElement item in sentenceArray.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.Array || item.GetArrayLength() == 0) continue;
+                    if (item[0].ValueKind == JsonValueKind.String)
+                    {
+                        result += item[0].GetString();
+                    }
+                }
+
+                return result.Trim();
+            }
+            catch
+            {
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// Gemini generateContent 응답에서 첫 번째 후보의 첫 번째 text part를 추출합니다.
+        /// 후보가 없거나 JSON 구조가 예상과 다르면 빈 문자열을 반환합니다.
+        /// </summary>
+        public string ParseGeminiTranslateResponse(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return "";
+
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(json);
+                JsonElement root = document.RootElement;
+                JsonElement parts = root
+                    .GetProperty("candidates")[0]
+                    .GetProperty("content")
+                    .GetProperty("parts");
+
+                if (parts.ValueKind != JsonValueKind.Array || parts.GetArrayLength() == 0) return "";
+                if (!parts[0].TryGetProperty("text", out JsonElement textElement)) return "";
+                if (textElement.ValueKind != JsonValueKind.String) return "";
+
+                return textElement.GetString()?.Trim() ?? "";
+            }
+            catch
+            {
+                return "";
+            }
+        }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -256,18 +256,6 @@ namespace GameTranslator
         }
 
         /// <summary>
-        /// 내부 언어 코드를 Google Translate API가 요구하는 언어 코드로 변환합니다.
-        /// <paramref name="lang"/>은 앱 내부에서 쓰는 언어 코드입니다.
-        /// 반환값은 Google API의 tl 파라미터에 넣을 코드입니다.
-        /// </summary>
-        private string GetGoogleTransLangCode(string lang)
-        {
-            if (lang == "zh-Hans-CN") return "zh-CN";
-            if (lang == "en-US") return "en";
-            return lang;
-        }
-
-        /// <summary>
         /// 수동 번역 단축키에서 호출하는 기본 번역 실행 함수입니다.
         /// 수동 번역은 속도보다 인식률을 우선하므로 정확 모드로 실행합니다.
         /// </summary>
@@ -1081,21 +1069,10 @@ namespace GameTranslator
         {
             if (string.IsNullOrWhiteSpace(text)) return "";
 
-            string cleaned = Regex.Replace(text, @"\d{1,2}:\d{2}", "");
-            cleaned = Regex.Replace(cleaned, @"[\[\]\(\)\{\}\<\>]", " ");
-            cleaned = Regex.Replace(cleaned, @"[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\.,!\?\-]", "");
-            cleaned = Regex.Replace(cleaned, @"([\-\=\.\/_])\1+", "$1");
-            cleaned = Regex.Replace(cleaned, @"\s+", " ").Trim();
-
-            if (cleaned.Length < 2 || !Regex.IsMatch(cleaned, @"[a-zA-Z가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ]"))
-            {
-                // 여기에도 1글자 예외 처리 허용
-                if (cleaned.Length == 1 && Regex.IsMatch(cleaned, @"^[가-힣ぁ-んァ-ヶ\u4e00-\u9fa5]$")) { /* 통과 */ }
-                else return "";
-            }
+            string cleaned = translationPromptBuilder.CleanGoogleTranslateInput(text);
+            if (!translationPromptBuilder.HasTranslatableContent(cleaned)) return "";
 
             int retryCount = 3;
-            string targetApiLang = GetGoogleTransLangCode(tLang);
             string result = "";
 
             httpClient.DefaultRequestHeaders.Clear();
@@ -1105,14 +1082,10 @@ namespace GameTranslator
             {
                 try
                 {
-                    string url = $"https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl={targetApiLang}&dt=t&q={Uri.EscapeDataString(cleaned)}";
+                    string url = translationPromptBuilder.BuildGoogleTranslateUrl(cleaned, tLang);
                     var res = await httpClient.GetStringAsync(url);
-                    using var doc = System.Text.Json.JsonDocument.Parse(res);
-
-                    foreach (var item in doc.RootElement[0].EnumerateArray())
-                    {
-                        result += item[0].GetString();
-                    }
+                    result = translationResultParser.ParseGoogleTranslateResponse(res);
+                    if (string.IsNullOrEmpty(result)) throw new Exception("Google 번역 응답 파싱 실패");
                     break;
                 }
                 catch
@@ -1164,14 +1137,7 @@ namespace GameTranslator
         {
             string modelName = ReadGeminiModel();
             string url = $"https://generativelanguage.googleapis.com/v1/models/{modelName}:generateContent?key={apiKey}";
-            string targetLanguage = tLang == "ko" ? "Korean" : (tLang == "en-US" ? "English" : tLang);
-
-            string prompt = "You are an expert game translator. " +
-                            "The input text is from OCR and has many typos (e.g., '伽' instead of '你', 'カ' instead of '为'). " +
-                            "Your job: 1. Guess the original intended sentence by ignoring OCR noise. " +
-                            "2. Translate it naturally into " + targetLanguage + ". " +
-                            "3. If the text is just a name or nonsense, return an empty string. " +
-                            "Output ONLY the translation: \n\n" + text;
+            string prompt = translationPromptBuilder.BuildGeminiPrompt(text, tLang);
 
             var requestBody = new { contents = new[] { new { parts = new[] { new { text = prompt } } } } };
             string jsonPayload = System.Text.Json.JsonSerializer.Serialize(requestBody);
@@ -1191,8 +1157,9 @@ namespace GameTranslator
                     }
 
                     string resJson = await response.Content.ReadAsStringAsync();
-                    using var doc = System.Text.Json.JsonDocument.Parse(resJson);
-                    return doc.RootElement.GetProperty("candidates")[0].GetProperty("content").GetProperty("parts")[0].GetProperty("text").GetString().Trim();
+                    string parsedText = translationResultParser.ParseGeminiTranslateResponse(resJson);
+                    if (string.IsNullOrWhiteSpace(parsedText)) throw new Exception("Gemini 응답 파싱 실패");
+                    return parsedText;
                 }
                 catch
                 {

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -62,6 +62,8 @@ namespace GameTranslator
         private HttpClient httpClient = new HttpClient();
         private readonly OcrService ocrService = new OcrService();
         private readonly SettingsService settingsService = new SettingsService();
+        private readonly TranslationPromptBuilder translationPromptBuilder = new TranslationPromptBuilder();
+        private readonly TranslationResultParser translationResultParser = new TranslationResultParser();
         private Dictionary<string, OcrEngine> ocrEngines = new Dictionary<string, OcrEngine>();
         private IntPtr _windowHandle;
         private LogViewerWindow logViewerWindow;


### PR DESCRIPTION
## 작업 내용
- TranslationPromptBuilder 추가
  - Google 번역 입력 정리
  - Google 언어 코드/URL 생성
  - Gemini 목표 언어명 및 프롬프트 생성
- TranslationResultParser 추가
  - Google Translate 응답 조각 병합
  - Gemini generateContent 응답 text 추출
- MainWindow.Translation.cs에서 문자열 조립/JSON 파싱 중복을 순수 서비스로 이동
- HTTP 호출, 재시도, UI 반영 흐름은 기존 MainWindow에 유지
- TranslationPromptBuilder / TranslationResultParser 단위 테스트 추가

## 검증
- git diff --check 통과
- 순수 클래스에 HttpClient / WPF / Windows 의존 참조 없음 확인
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true: 95 passed
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true: 0 Warning, 0 Error
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true: 0 Warning, 0 Error
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore: 95 passed
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true: 성공
- publish 산출물 확인: GameChatTranslator.exe, GameChatTranslator.pdb, LangInstall.bat, characters.txt, readme.txt