### PR TITLE
번역 의사결정 서비스 분리

### DIFF
--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -23,6 +23,7 @@
     <Compile Include="../GameChatTranslator/Core/SettingsValueNormalizer.cs" Link="Core/SettingsValueNormalizer.cs" />
     <Compile Include="../GameChatTranslator/Core/TranslationPromptBuilder.cs" Link="Core/TranslationPromptBuilder.cs" />
     <Compile Include="../GameChatTranslator/Core/TranslationResultParser.cs" Link="Core/TranslationResultParser.cs" />
+    <Compile Include="../GameChatTranslator/Core/TranslationService.cs" Link="Core/TranslationService.cs" />
   </ItemGroup>
 
 </Project>

--- a/GameChatTranslator.Tests/TranslationServiceTests.cs
+++ b/GameChatTranslator.Tests/TranslationServiceTests.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class TranslationServiceTests
+    {
+        private readonly TranslationService _service = new TranslationService();
+
+        [Fact]
+        public void CreatePlan_SkipsApiWhenTextAlreadyMatchesTargetLanguage()
+        {
+            TranslationPlan plan = _service.CreatePlan("이미 한국어입니다", "ko", true);
+
+            Assert.Equal(TranslationRequestKind.None, plan.RequestKind);
+            Assert.True(plan.HasImmediateResult);
+            Assert.Equal("이미 한국어입니다", plan.ImmediateResult.TranslatedText);
+            Assert.Equal("Skip", plan.ImmediateResult.EngineName);
+            Assert.True(plan.ImmediateResult.Skipped);
+            Assert.False(plan.ImmediateResult.FallbackUsed);
+        }
+
+        [Fact]
+        public void CreatePlan_UsesGeminiWhenGeminiIsAvailableAndTranslationIsNeeded()
+        {
+            TranslationPlan plan = _service.CreatePlan("hello squad", "ko", true);
+            TranslationDecisionResult result = _service.CreateGeminiResult("안녕 팀", "gemini-test");
+
+            Assert.Equal(TranslationRequestKind.Gemini, plan.RequestKind);
+            Assert.False(plan.HasImmediateResult);
+            Assert.Equal("안녕 팀", result.TranslatedText);
+            Assert.Equal("Gemini gemini-test", result.EngineName);
+            Assert.False(result.Skipped);
+            Assert.False(result.FallbackUsed);
+        }
+
+        [Fact]
+        public void ShouldFallbackToGoogle_AndGoogleFallbackResult_HandleEmptyGeminiResult()
+        {
+            Assert.True(_service.ShouldFallbackToGoogle(""));
+
+            TranslationDecisionResult result = _service.CreateGoogleResult("구글 결과", true);
+
+            Assert.Equal("[Gemini 에러 - 구글 전환됨] 구글 결과", result.TranslatedText);
+            Assert.Equal("Google (Fallback)", result.EngineName);
+            Assert.False(result.Skipped);
+            Assert.True(result.FallbackUsed);
+        }
+
+        [Fact]
+        public void CreatePlan_UsesGoogleWhenGeminiIsDisabled()
+        {
+            TranslationPlan plan = _service.CreatePlan("hello squad", "ko", false);
+            TranslationDecisionResult result = _service.CreateGoogleResult("안녕 팀", false);
+
+            Assert.Equal(TranslationRequestKind.Google, plan.RequestKind);
+            Assert.False(plan.HasImmediateResult);
+            Assert.Equal("안녕 팀", result.TranslatedText);
+            Assert.Equal("Google", result.EngineName);
+            Assert.False(result.Skipped);
+            Assert.False(result.FallbackUsed);
+        }
+
+        [Fact]
+        public void CreateGoogleResult_AllowsEmptyGoogleResultWithoutFallbackPrefix()
+        {
+            TranslationDecisionResult result = _service.CreateGoogleResult("", false);
+
+            Assert.Equal("", result.TranslatedText);
+            Assert.Equal("Google", result.EngineName);
+            Assert.False(result.Skipped);
+            Assert.False(result.FallbackUsed);
+        }
+
+        [Fact]
+        public void CreatePlan_PreservesSymbolOnlyTextWithoutApiCall()
+        {
+            TranslationPlan plan = _service.CreatePlan("123 !!", "ko", true);
+
+            Assert.Equal(TranslationRequestKind.None, plan.RequestKind);
+            Assert.Equal("123 !!", plan.ImmediateResult.TranslatedText);
+            Assert.Equal("Google", plan.ImmediateResult.EngineName);
+            Assert.False(plan.ImmediateResult.Skipped);
+        }
+
+        [Theory]
+        [InlineData("hello", "en-US", true)]
+        [InlineData("Привет", "ru", true)]
+        [InlineData("こんにちは", "ja", true)]
+        [InlineData("你好", "zh-Hans-CN", true)]
+        [InlineData("hello 안녕", "en-US", false)]
+        public void IsSameLanguage_DetectsTargetLanguageText(string text, string targetLanguageCode, bool expected)
+        {
+            Assert.Equal(expected, _service.IsSameLanguage(text, targetLanguageCode));
+        }
+
+        [Fact]
+        public void TranslationService_DoesNotReferenceHttpOrUiTypes()
+        {
+            string serviceTypeNames = string.Join(
+                "\n",
+                typeof(TranslationService).Assembly
+                    .GetTypes()
+                    .Where(type =>
+                        type == typeof(TranslationService) ||
+                        type == typeof(TranslationPlan) ||
+                        type == typeof(TranslationDecisionResult) ||
+                        type == typeof(TranslationRequestKind))
+                    .Select(type => type.AssemblyQualifiedName));
+
+            Assert.DoesNotContain("HttpClient", serviceTypeNames);
+            Assert.DoesNotContain("System.Net", serviceTypeNames);
+            Assert.DoesNotContain("System.Windows", serviceTypeNames);
+        }
+    }
+}

--- a/GameChatTranslator/Core/TranslationService.cs
+++ b/GameChatTranslator/Core/TranslationService.cs
@@ -1,0 +1,152 @@
+using System.Text.RegularExpressions;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// 번역 엔진 선택, 동일 언어 스킵, Gemini 실패 시 Google fallback 같은 번역 의사결정을 담당하는 순수 서비스입니다.
+    /// 실제 HTTP 호출과 UI 출력은 호출자가 담당하고, 이 클래스는 어떤 경로를 사용할지와 결과 표기만 결정합니다.
+    /// </summary>
+    public sealed class TranslationService
+    {
+        /// <summary>
+        /// 번역할 문장과 현재 엔진 상태를 바탕으로 첫 실행 경로를 결정합니다.
+        /// <paramref name="text"/>는 최종 OCR 후처리 문장,
+        /// <paramref name="targetLanguageCode"/>는 ko, en-US 같은 목표 언어 코드,
+        /// <paramref name="canUseGemini"/>는 Gemini 엔진이 켜져 있고 API 키도 있는 상태인지 여부입니다.
+        /// </summary>
+        public TranslationPlan CreatePlan(string text, string targetLanguageCode, bool canUseGemini)
+        {
+            string normalizedText = text ?? "";
+
+            if (IsSymbolOnly(normalizedText))
+            {
+                return TranslationPlan.Immediate(
+                    new TranslationDecisionResult(normalizedText, "Google", false, false));
+            }
+
+            if (IsSameLanguage(normalizedText, targetLanguageCode))
+            {
+                return TranslationPlan.Immediate(
+                    new TranslationDecisionResult(normalizedText, "Skip", true, false));
+            }
+
+            return new TranslationPlan(canUseGemini ? TranslationRequestKind.Gemini : TranslationRequestKind.Google, null);
+        }
+
+        /// <summary>
+        /// Gemini 결과가 비어 있어 Google fallback이 필요한지 판단합니다.
+        /// </summary>
+        public bool ShouldFallbackToGoogle(string geminiResult)
+        {
+            return string.IsNullOrEmpty(geminiResult);
+        }
+
+        /// <summary>
+        /// 성공한 Gemini 번역 결과를 UI/로그에 사용할 공통 결과 모델로 변환합니다.
+        /// <paramref name="geminiResult"/>는 Gemini 응답에서 추출한 번역문,
+        /// <paramref name="modelName"/>은 사용한 Gemini 모델명입니다.
+        /// </summary>
+        public TranslationDecisionResult CreateGeminiResult(string geminiResult, string modelName)
+        {
+            return new TranslationDecisionResult(geminiResult ?? "", $"Gemini {modelName}", false, false);
+        }
+
+        /// <summary>
+        /// Google 번역 결과를 UI/로그에 사용할 공통 결과 모델로 변환합니다.
+        /// <paramref name="googleResult"/>는 Google 응답에서 추출한 번역문,
+        /// <paramref name="isFallback"/>은 Gemini 실패 후 fallback으로 호출한 결과인지 여부입니다.
+        /// </summary>
+        public TranslationDecisionResult CreateGoogleResult(string googleResult, bool isFallback)
+        {
+            string translatedText = googleResult ?? "";
+            if (isFallback)
+            {
+                translatedText = "[Gemini 에러 - 구글 전환됨] " + translatedText;
+            }
+
+            return new TranslationDecisionResult(
+                translatedText,
+                isFallback ? "Google (Fallback)" : "Google",
+                false,
+                isFallback);
+        }
+
+        /// <summary>
+        /// 번역 대상 문장이 이미 목표 언어인지 문자 범위 기준으로 판단합니다.
+        /// true이면 API 호출 없이 원문을 그대로 표시합니다.
+        /// </summary>
+        public bool IsSameLanguage(string text, string targetLanguageCode)
+        {
+            string value = text ?? "";
+            if (targetLanguageCode == "ko" && Regex.IsMatch(value, @"[가-힣]{2,}")) return true;
+            if (targetLanguageCode == "ru" && Regex.IsMatch(value, @"[а-яА-ЯёЁ]")) return true;
+            if (targetLanguageCode == "ja" && Regex.IsMatch(value, @"[ぁ-んァ-ヶ]")) return true;
+            if (targetLanguageCode == "zh-Hans-CN" && Regex.IsMatch(value, @"[\u4e00-\u9fa5]")) return true;
+            if (targetLanguageCode == "en-US" &&
+                Regex.IsMatch(value, @"[a-zA-Z]") &&
+                !Regex.IsMatch(value, @"[가-힣а-яА-ЯёЁぁ-んァ-ヶ\u4e00-\u9fa5]"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool IsSymbolOnly(string text)
+        {
+            return Regex.IsMatch(text ?? "", @"^[0-9\W]+$");
+        }
+    }
+
+    /// <summary>
+    /// 이번 번역에서 첫 번째로 호출해야 하는 API 경로입니다.
+    /// None은 API 호출 없이 ImmediateResult를 그대로 사용한다는 뜻입니다.
+    /// </summary>
+    public enum TranslationRequestKind
+    {
+        None,
+        Google,
+        Gemini
+    }
+
+    /// <summary>
+    /// TranslationService가 결정한 번역 실행 계획입니다.
+    /// ImmediateResult가 있으면 API 호출 없이 바로 표시할 수 있습니다.
+    /// </summary>
+    public sealed class TranslationPlan
+    {
+        public TranslationPlan(TranslationRequestKind requestKind, TranslationDecisionResult immediateResult)
+        {
+            RequestKind = requestKind;
+            ImmediateResult = immediateResult;
+        }
+
+        public TranslationRequestKind RequestKind { get; }
+        public TranslationDecisionResult ImmediateResult { get; }
+        public bool HasImmediateResult => ImmediateResult != null;
+
+        public static TranslationPlan Immediate(TranslationDecisionResult result)
+        {
+            return new TranslationPlan(TranslationRequestKind.None, result);
+        }
+    }
+
+    /// <summary>
+    /// 최종 번역 출력과 로그에 사용할 엔진 정보를 묶은 결과 모델입니다.
+    /// </summary>
+    public sealed class TranslationDecisionResult
+    {
+        public TranslationDecisionResult(string translatedText, string engineName, bool skipped, bool fallbackUsed)
+        {
+            TranslatedText = translatedText ?? "";
+            EngineName = engineName ?? "";
+            Skipped = skipped;
+            FallbackUsed = fallbackUsed;
+        }
+
+        public string TranslatedText { get; }
+        public string EngineName { get; }
+        public bool Skipped { get; }
+        public bool FallbackUsed { get; }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -240,22 +240,6 @@ namespace GameTranslator
         }
 
         /// <summary>
-        /// 번역 대상 문장이 이미 목표 언어인지 간단한 문자 범위 검사로 판단합니다.
-        /// <paramref name="text"/>는 번역 전 원문 또는 OCR 후처리된 문자열,
-        /// <paramref name="tLang"/>은 목표 언어 코드입니다. 예: ko, en-US, ja.
-        /// 반환값이 true이면 API 번역 호출을 생략할 수 있습니다.
-        /// </summary>
-        private bool IsSameLanguage(string text, string tLang)
-        {
-            if (tLang == "ko" && Regex.IsMatch(text, @"[가-힣]{2,}")) return true;
-            if (tLang == "ru" && Regex.IsMatch(text, @"[а-яА-ЯёЁ]")) return true;
-            if (tLang == "ja" && Regex.IsMatch(text, @"[ぁ-んァ-ヶ]")) return true;
-            if (tLang == "zh-Hans-CN" && Regex.IsMatch(text, @"[\u4e00-\u9fa5]")) return true;
-            if (tLang == "en-US" && Regex.IsMatch(text, @"[a-zA-Z]") && !Regex.IsMatch(text, @"[가-힣а-яА-ЯёЁぁ-んァ-ヶ\u4e00-\u9fa5]")) return true;
-            return false;
-        }
-
-        /// <summary>
         /// 수동 번역 단축키에서 호출하는 기본 번역 실행 함수입니다.
         /// 수동 번역은 속도보다 인식률을 우선하므로 정확 모드로 실행합니다.
         /// </summary>
@@ -468,45 +452,43 @@ namespace GameTranslator
                     usedEngine = "Google";
                     string translated = finalContent;
 
-                    if (!Regex.IsMatch(finalContent, @"^[0-9\W]+$"))
+                    TranslationPlan translationPlan = translationService.CreatePlan(finalContent, targetLang, willUseGemini);
+                    TranslationDecisionResult translationResult = translationPlan.ImmediateResult;
+
+                    if (!translationPlan.HasImmediateResult)
                     {
-                        if (IsSameLanguage(finalContent, targetLang))
+                        if (translationPlan.RequestKind == TranslationRequestKind.Gemini)
                         {
-                            translated = finalContent;
-                            usedEngine = "Skip";
-                        }
-                        else
-                        {
-                            // 🌟 이제 제미나이 키가 있어도, 상태(useGeminiEngine)가 켜져 있을 때만 사용!
-                            if (willUseGemini)
+                            Stopwatch translateStopwatch = Stopwatch.StartNew();
+                            string geminiTranslated = await CallGeminiAPI(finalContent, targetLang, geminiKey);
+                            translateStopwatch.Stop();
+                            performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
+
+                            if (translationService.ShouldFallbackToGoogle(geminiTranslated))
                             {
-                                Stopwatch translateStopwatch = Stopwatch.StartNew();
-                                translated = await CallGeminiAPI(finalContent, targetLang, geminiKey);
+                                translateStopwatch.Restart();
+                                string googleFallback = await CallGoogleAPI(finalContent, targetLang);
                                 translateStopwatch.Stop();
                                 performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
-                                usedEngine = $"Gemini {modelName}";
-
-                                if (string.IsNullOrEmpty(translated))
-                                {
-                                    translateStopwatch.Restart();
-                                    translated = await CallGoogleAPI(finalContent, targetLang);
-                                    translateStopwatch.Stop();
-                                    performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
-                                    translated = "[Gemini 에러 - 구글 전환됨] " + translated;
-                                    usedEngine = "Google (Fallback)";
-                                }
+                                translationResult = translationService.CreateGoogleResult(googleFallback, true);
                             }
                             else
                             {
-                                // 스위치를 꺼두면 무조건 구글님 호출
-                                Stopwatch translateStopwatch = Stopwatch.StartNew();
-                                translated = await CallGoogleAPI(finalContent, targetLang);
-                                translateStopwatch.Stop();
-                                performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
-                                usedEngine = "Google";
+                                translationResult = translationService.CreateGeminiResult(geminiTranslated, modelName);
                             }
                         }
+                        else
+                        {
+                            Stopwatch translateStopwatch = Stopwatch.StartNew();
+                            string googleTranslated = await CallGoogleAPI(finalContent, targetLang);
+                            translateStopwatch.Stop();
+                            performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
+                            translationResult = translationService.CreateGoogleResult(googleTranslated, false);
+                        }
                     }
+
+                    translated = translationResult.TranslatedText;
+                    usedEngine = translationResult.EngineName;
 
                     AppendLog(characterNameGold + finalContent, translated, usedEngine);
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace GameTranslator
         private readonly SettingsService settingsService = new SettingsService();
         private readonly TranslationPromptBuilder translationPromptBuilder = new TranslationPromptBuilder();
         private readonly TranslationResultParser translationResultParser = new TranslationResultParser();
+        private readonly TranslationService translationService = new TranslationService();
         private Dictionary<string, OcrEngine> ocrEngines = new Dictionary<string, OcrEngine>();
         private IntPtr _windowHandle;
         private LogViewerWindow logViewerWindow;


### PR DESCRIPTION
## 작업 내용
- TranslationService 추가
  - 동일 언어면 API 호출 없이 Skip 처리
  - Gemini 사용 가능 시 Gemini 우선 사용 계획 생성
  - Gemini 결과가 비어 있으면 Google fallback 판단
  - Google/Gemini/fallback 결과의 번역문과 엔진명을 공통 모델로 반환
- MainWindow.Translation.cs에서 번역 엔진 선택/스킵/fallback 의사결정 로직을 TranslationService로 이동
- HTTP 호출, 재시도, 성능 측정, UI/로그 반영은 기존 MainWindow에 유지
- TranslationService 단위 테스트 추가

## 검증
- TranslationService에 HttpClient / System.Net / System.Windows / Windows.* 참조 없음 확인
- git diff --check 통과
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true: 107 passed
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true: 0 Warning, 0 Error
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true: 0 Warning, 0 Error
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore: 107 passed
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true: 성공
- publish 산출물 확인: GameChatTranslator.exe, GameChatTranslator.pdb, LangInstall.bat, characters.txt, readme.txt