### PR TITLE
리팩터링: 번역 API 호출부 분리

### DIFF
--- a/GameChatTranslator.Tests/Core/Translation/TranslationApiClientTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationApiClientTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class TranslationApiClientTests
+    {
+        [Fact]
+        public async Task TranslateWithGoogleAsync_CleansInputAndParsesResponse()
+        {
+            var handler = new StubHttpMessageHandler(request =>
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.Contains("translate.googleapis.com", request.RequestUri.ToString());
+                Assert.Contains("tl=ko", request.RequestUri.Query);
+                Assert.Contains("hello", WebUtility.UrlDecode(request.RequestUri.Query));
+                return Task.FromResult(JsonResponse("[[[\"안녕\",\"hello\",null,null,3]],null,\"en\"]"));
+            });
+            TranslationApiClient client = CreateClient(handler);
+
+            string result = await client.TranslateWithGoogleAsync("[미셸] 12:34 hello@@@", "ko");
+
+            Assert.Equal("안녕", result);
+            Assert.Equal(1, handler.CallCount);
+        }
+
+        [Fact]
+        public async Task TranslateWithGoogleAsync_SkipsNonTranslatableContent()
+        {
+            var handler = new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP 호출이 없어야 합니다."));
+            TranslationApiClient client = CreateClient(handler);
+
+            string result = await client.TranslateWithGoogleAsync("123 !!!", "ko");
+
+            Assert.Equal("", result);
+            Assert.Equal(0, handler.CallCount);
+        }
+
+        [Fact]
+        public async Task ListGeminiModelsAsync_ReturnsModelNames()
+        {
+            var handler = new StubHttpMessageHandler(request =>
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.Contains("v1beta/models", request.RequestUri.ToString());
+                Assert.Contains("key=test-key", request.RequestUri.Query);
+                return Task.FromResult(JsonResponse("{\"models\":[{\"name\":\"models/gemini-2.5-flash\"},{\"name\":\"models/gemini-2.5-pro\"}]}"));
+            });
+            TranslationApiClient client = CreateClient(handler);
+
+            GeminiModelListApiResult result = await client.ListGeminiModelsAsync("test-key");
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(new[] { "gemini-2.5-flash", "gemini-2.5-pro" }, result.Models);
+        }
+
+        [Fact]
+        public async Task ListGeminiModelsAsync_ReturnsHttpFailure()
+        {
+            var handler = new StubHttpMessageHandler(_ => Task.FromResult(JsonResponse("{\"error\":\"denied\"}", HttpStatusCode.Forbidden)));
+            TranslationApiClient client = CreateClient(handler);
+
+            GeminiModelListApiResult result = await client.ListGeminiModelsAsync("bad-key");
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(403, result.StatusCode);
+            Assert.Contains("denied", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task TranslateWithGeminiAsync_BuildsPromptAndParsesResponse()
+        {
+            var handler = new StubHttpMessageHandler(async request =>
+            {
+                Assert.Equal(HttpMethod.Post, request.Method);
+                Assert.Contains("models/gemini-test:generateContent", request.RequestUri.ToString());
+                Assert.Contains("key=test-key", request.RequestUri.Query);
+
+                string payload = await request.Content.ReadAsStringAsync();
+                using JsonDocument document = JsonDocument.Parse(payload);
+                string prompt = document.RootElement
+                    .GetProperty("contents")[0]
+                    .GetProperty("parts")[0]
+                    .GetProperty("text")
+                    .GetString();
+                Assert.Contains("Korean", prompt);
+                Assert.Contains("伽好", prompt);
+
+                return JsonResponse("{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"안녕하세요\"}]}}]}");
+            });
+            TranslationApiClient client = CreateClient(handler);
+
+            GeminiTranslateApiResult result = await client.TranslateWithGeminiAsync("伽好", "ko", "test-key", "gemini-test");
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("안녕하세요", result.Text);
+        }
+
+        [Fact]
+        public async Task TranslateWithGeminiAsync_ReturnsErrorDetailForHttpFailure()
+        {
+            var handler = new StubHttpMessageHandler(_ => Task.FromResult(JsonResponse("{\"error\":\"bad model\"}", HttpStatusCode.BadRequest)));
+            TranslationApiClient client = CreateClient(handler);
+
+            GeminiTranslateApiResult result = await client.TranslateWithGeminiAsync("hello", "ko", "test-key", "bad-model");
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(400, result.StatusCode);
+            Assert.Contains("bad model", result.ErrorMessage);
+        }
+
+        private static TranslationApiClient CreateClient(HttpMessageHandler handler)
+        {
+            return new TranslationApiClient(
+                new HttpClient(handler),
+                new TranslationPromptBuilder(),
+                new TranslationResultParser());
+        }
+
+        private static HttpResponseMessage JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(json)
+            };
+        }
+
+        private sealed class StubHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _handler;
+
+            public StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+            {
+                _handler = handler;
+            }
+
+            public int CallCount { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                CallCount++;
+                return await _handler(request);
+            }
+        }
+    }
+}

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="../GameChatTranslator/Core/TranslationPromptBuilder.cs" Link="Core/TranslationPromptBuilder.cs" />
     <Compile Include="../GameChatTranslator/Core/TranslationResultParser.cs" Link="Core/TranslationResultParser.cs" />
     <Compile Include="../GameChatTranslator/Core/TranslationService.cs" Link="Core/TranslationService.cs" />
+    <Compile Include="../GameChatTranslator/Core/TranslationApiClient.cs" Link="Core/TranslationApiClient.cs" />
   </ItemGroup>
 
 </Project>

--- a/GameChatTranslator/Core/TranslationApiClient.cs
+++ b/GameChatTranslator/Core/TranslationApiClient.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// Google Translate와 Gemini API의 실제 HTTP 요청/응답 처리를 담당합니다.
+    /// 재시도, fallback, UI 로그, 엔진 선택은 호출자가 담당하고, 이 클래스는 네트워크 호출과 응답 파싱만 수행합니다.
+    /// </summary>
+    public sealed class TranslationApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly TranslationPromptBuilder _promptBuilder;
+        private readonly TranslationResultParser _resultParser;
+
+        /// <summary>
+        /// 번역 API 클라이언트를 생성합니다.
+        /// <paramref name="httpClient"/>는 외부에서 수명 관리하는 HTTP 클라이언트,
+        /// <paramref name="promptBuilder"/>는 요청 URL/프롬프트 생성기,
+        /// <paramref name="resultParser"/>는 API 응답 JSON 파서입니다.
+        /// </summary>
+        public TranslationApiClient(
+            HttpClient httpClient,
+            TranslationPromptBuilder promptBuilder,
+            TranslationResultParser resultParser)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _promptBuilder = promptBuilder ?? throw new ArgumentNullException(nameof(promptBuilder));
+            _resultParser = resultParser ?? throw new ArgumentNullException(nameof(resultParser));
+        }
+
+        /// <summary>
+        /// Google Translate API를 호출할 만큼 의미 있는 문자열인지 판단합니다.
+        /// OCR 노이즈 정리 후 숫자/기호뿐이면 API 호출을 하지 않도록 false를 반환합니다.
+        /// </summary>
+        public bool CanTranslateWithGoogle(string text)
+        {
+            string cleaned = _promptBuilder.CleanGoogleTranslateInput(text);
+            return _promptBuilder.HasTranslatableContent(cleaned);
+        }
+
+        /// <summary>
+        /// Google Translate 비공식 무료 엔드포인트를 1회 호출합니다.
+        /// <paramref name="text"/>는 OCR 후처리 문장이고,
+        /// <paramref name="targetLanguageCode"/>는 ko/en-US/zh-Hans-CN 같은 앱 내부 목표 언어 코드입니다.
+        /// 반환값은 파싱된 번역문이며, 의미 없는 입력이면 빈 문자열입니다.
+        /// </summary>
+        public async Task<string> TranslateWithGoogleAsync(string text, string targetLanguageCode)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return "";
+
+            string cleaned = _promptBuilder.CleanGoogleTranslateInput(text);
+            if (!_promptBuilder.HasTranslatableContent(cleaned)) return "";
+
+            string url = _promptBuilder.BuildGoogleTranslateUrl(cleaned, targetLanguageCode);
+            string responseJson = await _httpClient.GetStringAsync(url);
+            return _resultParser.ParseGoogleTranslateResponse(responseJson);
+        }
+
+        /// <summary>
+        /// Gemini API 키로 사용 가능한 모델 목록을 조회합니다.
+        /// <paramref name="apiKey"/>는 Google AI Studio에서 발급받은 Gemini API 키입니다.
+        /// </summary>
+        public async Task<GeminiModelListApiResult> ListGeminiModelsAsync(string apiKey)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                return GeminiModelListApiResult.Failed(null, "API 키가 비어 있습니다.");
+            }
+
+            string url = $"https://generativelanguage.googleapis.com/v1beta/models?key={apiKey}";
+            using HttpResponseMessage response = await _httpClient.GetAsync(url);
+            string responseJson = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return GeminiModelListApiResult.Failed((int)response.StatusCode, responseJson);
+            }
+
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(responseJson);
+                if (!document.RootElement.TryGetProperty("models", out JsonElement modelsElement) ||
+                    modelsElement.ValueKind != JsonValueKind.Array)
+                {
+                    return GeminiModelListApiResult.Failed(null, "models 배열이 없습니다.");
+                }
+
+                List<string> models = modelsElement
+                    .EnumerateArray()
+                    .Select(ReadGeminiModelName)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .ToList();
+
+                return GeminiModelListApiResult.Succeeded(models);
+            }
+            catch (Exception ex)
+            {
+                return GeminiModelListApiResult.Failed(null, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Gemini generateContent API를 1회 호출합니다.
+        /// <paramref name="text"/>는 OCR 후처리 문장,
+        /// <paramref name="targetLanguageCode"/>는 앱 내부 목표 언어 코드,
+        /// <paramref name="apiKey"/>는 Gemini API 키,
+        /// <paramref name="modelName"/>은 호출할 Gemini 모델명입니다.
+        /// </summary>
+        public async Task<GeminiTranslateApiResult> TranslateWithGeminiAsync(
+            string text,
+            string targetLanguageCode,
+            string apiKey,
+            string modelName)
+        {
+            string url = $"https://generativelanguage.googleapis.com/v1/models/{modelName}:generateContent?key={apiKey}";
+            string prompt = _promptBuilder.BuildGeminiPrompt(text, targetLanguageCode);
+
+            var requestBody = new { contents = new[] { new { parts = new[] { new { text = prompt } } } } };
+            string jsonPayload = JsonSerializer.Serialize(requestBody);
+
+            using var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+            using HttpResponseMessage response = await _httpClient.PostAsync(url, content);
+            string responseJson = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return GeminiTranslateApiResult.Failed((int)response.StatusCode, responseJson);
+            }
+
+            string parsedText = _resultParser.ParseGeminiTranslateResponse(responseJson);
+            return GeminiTranslateApiResult.Succeeded(parsedText);
+        }
+
+        private static string ReadGeminiModelName(JsonElement modelElement)
+        {
+            if (!modelElement.TryGetProperty("name", out JsonElement nameElement)) return "";
+            if (nameElement.ValueKind != JsonValueKind.String) return "";
+            return (nameElement.GetString() ?? "").Replace("models/", "");
+        }
+    }
+
+    /// <summary>
+    /// Gemini 모델 목록 조회 결과입니다.
+    /// IsSuccess가 false이면 StatusCode 또는 ErrorMessage를 UI 로그에 표시할 수 있습니다.
+    /// </summary>
+    public sealed class GeminiModelListApiResult
+    {
+        private GeminiModelListApiResult(bool isSuccess, IReadOnlyList<string> models, int? statusCode, string errorMessage)
+        {
+            IsSuccess = isSuccess;
+            Models = models;
+            StatusCode = statusCode;
+            ErrorMessage = errorMessage ?? "";
+        }
+
+        public bool IsSuccess { get; }
+        public IReadOnlyList<string> Models { get; }
+        public int? StatusCode { get; }
+        public string ErrorMessage { get; }
+
+        public static GeminiModelListApiResult Succeeded(IReadOnlyList<string> models)
+        {
+            return new GeminiModelListApiResult(true, models ?? Array.Empty<string>(), null, "");
+        }
+
+        public static GeminiModelListApiResult Failed(int? statusCode, string errorMessage)
+        {
+            return new GeminiModelListApiResult(false, Array.Empty<string>(), statusCode, errorMessage);
+        }
+    }
+
+    /// <summary>
+    /// Gemini 번역 API 호출 결과입니다.
+    /// IsSuccess가 true여도 Text가 비어 있으면 호출자가 기존 fallback 정책에 따라 Google로 전환할 수 있습니다.
+    /// </summary>
+    public sealed class GeminiTranslateApiResult
+    {
+        private GeminiTranslateApiResult(bool isSuccess, string text, int? statusCode, string errorMessage)
+        {
+            IsSuccess = isSuccess;
+            Text = text ?? "";
+            StatusCode = statusCode;
+            ErrorMessage = errorMessage ?? "";
+        }
+
+        public bool IsSuccess { get; }
+        public string Text { get; }
+        public int? StatusCode { get; }
+        public string ErrorMessage { get; }
+
+        public static GeminiTranslateApiResult Succeeded(string text)
+        {
+            return new GeminiTranslateApiResult(true, text, null, "");
+        }
+
+        public static GeminiTranslateApiResult Failed(int? statusCode, string errorMessage)
+        {
+            return new GeminiTranslateApiResult(false, "", statusCode, errorMessage);
+        }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -738,8 +738,7 @@ namespace GameTranslator
         {
             if (string.IsNullOrWhiteSpace(text)) return "";
 
-            string cleaned = translationPromptBuilder.CleanGoogleTranslateInput(text);
-            if (!translationPromptBuilder.HasTranslatableContent(cleaned)) return "";
+            if (!translationApiClient.CanTranslateWithGoogle(text)) return "";
 
             int retryCount = 3;
             string result = "";
@@ -751,9 +750,7 @@ namespace GameTranslator
             {
                 try
                 {
-                    string url = translationPromptBuilder.BuildGoogleTranslateUrl(cleaned, tLang);
-                    var res = await httpClient.GetStringAsync(url);
-                    result = translationResultParser.ParseGoogleTranslateResponse(res);
+                    result = await translationApiClient.TranslateWithGoogleAsync(text, tLang);
                     if (string.IsNullOrEmpty(result)) throw new Exception("Google 번역 응답 파싱 실패");
                     break;
                 }
@@ -773,24 +770,22 @@ namespace GameTranslator
         /// </summary>
         private async Task ListAvailableGeminiModels(string apiKey)
         {
-            string url = $"https://generativelanguage.googleapis.com/v1beta/models?key={apiKey}";
             try
             {
-                var response = await httpClient.GetAsync(url);
-                if (response.IsSuccessStatusCode)
+                GeminiModelListApiResult result = await translationApiClient.ListGeminiModelsAsync(apiKey);
+                if (result.IsSuccess)
                 {
-                    string resJson = await response.Content.ReadAsStringAsync();
-                    using var doc = System.Text.Json.JsonDocument.Parse(resJson);
-
-                    var models = doc.RootElement.GetProperty("models")
-                                    .EnumerateArray()
-                                    .Select(m => m.GetProperty("name").GetString().Replace("models/", ""))
-                                    .ToList();
-
-                    string modelList = string.Join(", ", models);
+                    string modelList = string.Join(", ", result.Models);
                     AppendLog($"사용 가능한 제미나이 모델 목록: {modelList}");
                 }
-                else AppendLog($"제미나이 모델 목록 가져오기 실패 (HTTP {(int)response.StatusCode})");
+                else if (result.StatusCode.HasValue)
+                {
+                    AppendLog($"제미나이 모델 목록 가져오기 실패 (HTTP {result.StatusCode.Value})");
+                }
+                else
+                {
+                    AppendLog($"모델 목록 확인 중 오류 발생: {result.ErrorMessage}");
+                }
             }
             catch (Exception ex) { AppendLog($"모델 목록 확인 중 오류 발생: {ex.Message}"); }
         }
@@ -805,28 +800,20 @@ namespace GameTranslator
         private async Task<string> CallGeminiAPI(string text, string tLang, string apiKey)
         {
             string modelName = ReadGeminiModel();
-            string url = $"https://generativelanguage.googleapis.com/v1/models/{modelName}:generateContent?key={apiKey}";
-            string prompt = translationPromptBuilder.BuildGeminiPrompt(text, tLang);
-
-            var requestBody = new { contents = new[] { new { parts = new[] { new { text = prompt } } } } };
-            string jsonPayload = System.Text.Json.JsonSerializer.Serialize(requestBody);
 
             int retryCount = 2;
             while (retryCount > 0)
             {
                 try
                 {
-                    using var content = new StringContent(jsonPayload, System.Text.Encoding.UTF8, "application/json");
-                    using var response = await httpClient.PostAsync(url, content);
-                    if (!response.IsSuccessStatusCode)
+                    GeminiTranslateApiResult result = await translationApiClient.TranslateWithGeminiAsync(text, tLang, apiKey, modelName);
+                    if (!result.IsSuccess)
                     {
-                        string errorDetail = await response.Content.ReadAsStringAsync();
-                        AppendLog($"[Gemini API 오류] 모델({modelName}) 호출 실패: {errorDetail}");
+                        AppendLog($"[Gemini API 오류] 모델({modelName}) 호출 실패: {result.ErrorMessage}");
                         throw new Exception("Gemini 호출 실패");
                     }
 
-                    string resJson = await response.Content.ReadAsStringAsync();
-                    string parsedText = translationResultParser.ParseGeminiTranslateResponse(resJson);
+                    string parsedText = result.Text;
                     if (string.IsNullOrWhiteSpace(parsedText)) throw new Exception("Gemini 응답 파싱 실패");
                     return parsedText;
                 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -66,6 +66,7 @@ namespace GameTranslator
         private readonly TranslationPromptBuilder translationPromptBuilder = new TranslationPromptBuilder();
         private readonly TranslationResultParser translationResultParser = new TranslationResultParser();
         private readonly TranslationService translationService = new TranslationService();
+        private readonly TranslationApiClient translationApiClient;
         private Dictionary<string, OcrEngine> ocrEngines = new Dictionary<string, OcrEngine>();
         private IntPtr _windowHandle;
         private LogViewerWindow logViewerWindow;
@@ -94,6 +95,7 @@ namespace GameTranslator
             LoadCharacters();
 
             httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+            translationApiClient = new TranslationApiClient(httpClient, translationPromptBuilder, translationResultParser);
 
             string iniPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.ini");
             ini = new IniFile(iniPath);


### PR DESCRIPTION
## 작업 내용
- Google 번역 HTTP 호출을 TranslationApiClient로 분리
- Gemini 모델 목록 조회와 Gemini 번역 API 호출을 TranslationApiClient로 분리
- MainWindow는 기존 재시도, fallback, UI 로그 흐름만 유지
- 가짜 HttpMessageHandler 기반 TranslationApiClient 단위 테스트 추가

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true