### PR TITLE
수정: 릴리즈 워크플로우 Node 24 action 적용

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,6 @@ on:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-release:
     name: Build and publish Windows release
@@ -31,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
@@ -70,7 +67,7 @@ jobs:
           "ZIP_NAME=$zipName" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -151,7 +148,7 @@ jobs:
           "path=$notesPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Create or update GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: ${{ env.RELEASE_TITLE }}
@@ -167,7 +164,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-package
           path: |


### PR DESCRIPTION
## 작업 내용
- 릴리즈 워크플로우의 JavaScript action을 Node 24 기반 major 버전으로 갱신
  - actions/checkout@v6
  - actions/setup-dotnet@v5
  - actions/upload-artifact@v7
  - softprops/action-gh-release@v3
- FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 환경변수 제거

## 확인
- 각 action.yml에서 using: node24 확인
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true

## 참고
- 실제 GitHub Actions annotation 제거 여부는 이 PR 머지 후 다음 태그 릴리즈 실행에서 최종 확인 가능합니다.