### PR TITLE
개선: 환경설정창 2열 레이아웃 적용

### DIFF
--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="GameTranslator.OptionSelector"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="GameChatTranslator 환경 설정" Width="500" Height="1000"
+        Title="GameChatTranslator 환경 설정" Width="980" Height="860"
         WindowStartupLocation="CenterScreen" Topmost="True" Background="#1E1E1E" Foreground="White" ResizeMode="NoResize">
 
     <Window.Resources>
@@ -19,280 +19,292 @@
         </Style>
     </Window.Resources>
 
-    <!-- 설정 항목이 많기 때문에 기본 높이 1000을 유지하되, 화면보다 내용이 길면 세로 스크롤로 접근합니다. -->
+    <!-- 설정 항목을 2열로 배치해 한 화면에 더 많은 항목을 표시하고, 화면보다 내용이 길면 세로 스크롤로 접근합니다. -->
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="20">
-        <TextBlock Text="⚙️ 초기 환경 설정" FontSize="20" FontWeight="Bold" Foreground="LimeGreen" HorizontalAlignment="Center" Margin="0,0,0,6"/>
-        <TextBlock Text="자주 쓰는 설정부터 번역 엔진 설정까지 순서대로 정리했습니다. 변경한 값은 아래 저장 버튼을 눌러야 적용됩니다."
-                   TextWrapping="Wrap"
-                   TextAlignment="Center"
-                   Foreground="#CCC"
-                   Margin="0,0,0,14"/>
+            <TextBlock Text="⚙️ 초기 환경 설정" FontSize="20" FontWeight="Bold" Foreground="LimeGreen" HorizontalAlignment="Center" Margin="0,0,0,6"/>
+            <TextBlock Text="자주 쓰는 설정부터 번역 엔진 설정까지 순서대로 정리했습니다. 변경한 값은 아래 저장 버튼을 눌러야 적용됩니다."
+                       TextWrapping="Wrap"
+                       TextAlignment="Center"
+                       Foreground="#CCC"
+                       Margin="0,0,0,14"/>
 
-        <TextBlock Text="1. 설정 관리" Style="{StaticResource SectionTitleStyle}"/>
-        <TextBlock Text="프리셋, 설정 백업, 업데이트, 로그창처럼 프로그램 운영에 필요한 항목입니다." Style="{StaticResource SectionHintStyle}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="20"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
 
-        <!-- 프리셋 영역: 현재 UI 설정을 이름별로 저장/불러오기/삭제합니다. API 키는 저장하지 않습니다. -->
-        <GroupBox Header="설정 프리셋 (Preset)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <TextBlock Text="현재 설정을 이름별로 저장하고 다시 불러올 수 있습니다. API 키는 프리셋에 저장하지 않습니다." TextWrapping="Wrap" Margin="0,0,0,8" Foreground="#CCC"/>
-                <ComboBox x:Name="ComboPreset" Height="24" Margin="0,0,0,8" Background="#333" Foreground="Black" SelectionChanged="ComboPreset_SelectionChanged"/>
-                <TextBox x:Name="TxtPresetName" Height="26" Margin="0,0,0,8" Background="#333" Foreground="White" BorderBrush="#555" ToolTip="저장할 프리셋 이름"/>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button x:Name="BtnSavePreset" Content="프리셋 저장" Padding="8,2" Margin="0,0,8,0" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnSavePreset_Click"/>
-                    <Button x:Name="BtnLoadPreset" Content="불러오기" Padding="8,2" Margin="0,0,8,0" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnLoadPreset_Click"/>
-                    <Button x:Name="BtnDeletePreset" Content="삭제" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnDeletePreset_Click"/>
-                </StackPanel>
-            </StackPanel>
-        </GroupBox>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="1. 설정 관리" Style="{StaticResource SectionTitleStyle}"/>
+                    <TextBlock Text="프리셋, 설정 백업, 업데이트, 로그창처럼 프로그램 운영에 필요한 항목입니다." Style="{StaticResource SectionHintStyle}"/>
 
-        <!-- 설정 백업: config.ini 전체를 파일로 내보내거나 다른 PC/백업 파일에서 다시 가져옵니다. -->
-        <GroupBox Header="설정 백업 / 복원" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <TextBlock Text="현재 저장된 config.ini를 내보내거나, 백업한 config.ini를 가져옵니다. 프리셋도 함께 포함됩니다."
-                           TextWrapping="Wrap"
-                           Margin="0,0,0,8"
-                           Foreground="#CCC"/>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button x:Name="BtnExportSettings"
-                            Content="설정 내보내기"
-                            Padding="8,2"
-                            Margin="0,0,8,0"
-                            Background="#444"
-                            Foreground="White"
-                            BorderThickness="0"
-                            Cursor="Hand"
-                            Click="BtnExportSettings_Click"/>
-                    <Button x:Name="BtnImportSettings"
-                            Content="설정 가져오기"
-                            Padding="8,2"
-                            Background="#444"
-                            Foreground="White"
-                            BorderThickness="0"
-                            Cursor="Hand"
-                            Click="BtnImportSettings_Click"/>
-                </StackPanel>
-            </StackPanel>
-        </GroupBox>
+                    <!-- 프리셋 영역: 현재 UI 설정을 이름별로 저장/불러오기/삭제합니다. API 키는 저장하지 않습니다. -->
+                    <GroupBox Header="설정 프리셋 (Preset)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="현재 설정을 이름별로 저장하고 다시 불러올 수 있습니다. API 키는 프리셋에 저장하지 않습니다." TextWrapping="Wrap" Margin="0,0,0,8" Foreground="#CCC"/>
+                            <ComboBox x:Name="ComboPreset" Height="24" Margin="0,0,0,8" Background="#333" Foreground="Black" SelectionChanged="ComboPreset_SelectionChanged"/>
+                            <TextBox x:Name="TxtPresetName" Height="26" Margin="0,0,0,8" Background="#333" Foreground="White" BorderBrush="#555" ToolTip="저장할 프리셋 이름"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button x:Name="BtnSavePreset" Content="프리셋 저장" Padding="8,2" Margin="0,0,8,0" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnSavePreset_Click"/>
+                                <Button x:Name="BtnLoadPreset" Content="불러오기" Padding="8,2" Margin="0,0,8,0" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnLoadPreset_Click"/>
+                                <Button x:Name="BtnDeletePreset" Content="삭제" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnDeletePreset_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
 
-        <!-- 업데이트 영역: 시작 시 자동 확인 여부와 수동 릴리즈 확인 버튼을 제공합니다. -->
-        <GroupBox Header="업데이트 확인 (Update)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <CheckBox x:Name="CheckUpdatesOnStartup" Content="실행 시 업데이트 자동 확인" Foreground="#CCC" Margin="0,0,0,8"/>
-                <TextBlock Text="새 버전이 있으면 릴리즈 페이지 이동 여부를 묻고, 이동 시 프로그램을 종료합니다." TextWrapping="Wrap" Margin="0,0,0,8" Foreground="#CCC"/>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <TextBlock x:Name="TxtUpdateStatus" Foreground="#CCC" FontSize="11" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                    <Button x:Name="BtnCheckUpdate" Content="업데이트 확인" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnCheckUpdate_Click"/>
-                </StackPanel>
-            </StackPanel>
-        </GroupBox>
+                    <!-- 설정 백업: config.ini 전체를 파일로 내보내거나 다른 PC/백업 파일에서 다시 가져옵니다. -->
+                    <GroupBox Header="설정 백업 / 복원" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="현재 저장된 config.ini를 내보내거나, 백업한 config.ini를 가져옵니다. 프리셋도 함께 포함됩니다."
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"
+                                       Foreground="#CCC"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button x:Name="BtnExportSettings"
+                                        Content="설정 내보내기"
+                                        Padding="8,2"
+                                        Margin="0,0,8,0"
+                                        Background="#444"
+                                        Foreground="White"
+                                        BorderThickness="0"
+                                        Cursor="Hand"
+                                        Click="BtnExportSettings_Click"/>
+                                <Button x:Name="BtnImportSettings"
+                                        Content="설정 가져오기"
+                                        Padding="8,2"
+                                        Background="#444"
+                                        Foreground="White"
+                                        BorderThickness="0"
+                                        Cursor="Hand"
+                                        Click="BtnImportSettings_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
 
-        <!-- 로그창 영역: 현재 세션 로그를 별도 창에서 실시간으로 확인합니다. -->
-        <GroupBox Header="로그 확인 (Log Viewer)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <TextBlock Text="현재 세션 로그를 별도 창으로 열어 보조 모니터에서 실시간으로 확인할 수 있습니다." TextWrapping="Wrap" Margin="0,0,0,8" Foreground="#CCC"/>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button x:Name="BtnOpenLogViewer" Content="로그창 열기" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnOpenLogViewer_Click"/>
-                </StackPanel>
-            </StackPanel>
-        </GroupBox>
+                    <!-- 업데이트 영역: 시작 시 자동 확인 여부와 수동 릴리즈 확인 버튼을 제공합니다. -->
+                    <GroupBox Header="업데이트 확인 (Update)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <CheckBox x:Name="CheckUpdatesOnStartup" Content="실행 시 업데이트 자동 확인" Foreground="#CCC" Margin="0,0,0,8"/>
+                            <TextBlock Text="새 버전이 있으면 릴리즈 페이지 이동 여부를 묻고, 이동 시 프로그램을 종료합니다." TextWrapping="Wrap" Margin="0,0,0,8" Foreground="#CCC"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <TextBlock x:Name="TxtUpdateStatus" Foreground="#CCC" FontSize="11" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                <Button x:Name="BtnCheckUpdate" Content="업데이트 확인" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnCheckUpdate_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
 
-        <TextBlock Text="2. 언어 / OCR" Style="{StaticResource SectionTitleStyle}"/>
-        <TextBlock Text="게임 채팅을 어떤 언어로 읽고, OCR 언어팩과 진단 화면을 어떻게 확인할지 설정합니다." Style="{StaticResource SectionHintStyle}"/>
+                    <!-- 로그창 영역: 현재 세션 로그를 별도 창에서 실시간으로 확인합니다. -->
+                    <GroupBox Header="로그 확인 (Log Viewer)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="현재 세션 로그를 별도 창으로 열어 보조 모니터에서 실시간으로 확인할 수 있습니다." TextWrapping="Wrap" Margin="0,0,0,8" Foreground="#CCC"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button x:Name="BtnOpenLogViewer" Content="로그창 열기" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnOpenLogViewer_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
 
-        <!-- 언어 영역: OCR 기준 게임 언어와 최종 번역 출력 언어를 선택합니다. -->
-        <GroupBox Header="언어 설정 (Language)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <TextBlock Text="게임 언어 (채팅 인식 기준):" Margin="0,0,0,5" Foreground="#CCC"/>
-                <ComboBox x:Name="ComboGameLang" Margin="0,0,0,10" Background="#333" Foreground="Black">
-                    <ComboBoxItem Content="한국어" Tag="ko"/>
-                    <ComboBoxItem Content="영어" Tag="en-US"/>
-                    <ComboBoxItem Content="중국어(간체)" Tag="zh-Hans-CN"/>
-                    <ComboBoxItem Content="일본어" Tag="ja"/>
-                    <ComboBoxItem Content="러시아어" Tag="ru"/>
-                </ComboBox>
+                    <TextBlock Text="2. 언어 / OCR" Style="{StaticResource SectionTitleStyle}"/>
+                    <TextBlock Text="게임 채팅을 어떤 언어로 읽고, OCR 언어팩과 진단 화면을 어떻게 확인할지 설정합니다." Style="{StaticResource SectionHintStyle}"/>
 
-                <TextBlock Text="번역 언어 (결과 언어):" Margin="0,0,0,5" Foreground="#CCC"/>
-                <ComboBox x:Name="ComboTargetLang" Background="#333" Foreground="Black">
-                    <ComboBoxItem Content="한국어" Tag="ko"/>
-                    <ComboBoxItem Content="영어" Tag="en-US"/>
-                    <ComboBoxItem Content="중국어(간체)" Tag="zh-Hans-CN"/>
-                    <ComboBoxItem Content="일본어" Tag="ja"/>
-                    <ComboBoxItem Content="러시아어" Tag="ru"/>
-                </ComboBox>
-            </StackPanel>
-        </GroupBox>
+                    <!-- 언어 영역: OCR 기준 게임 언어와 최종 번역 출력 언어를 선택합니다. -->
+                    <GroupBox Header="언어 설정 (Language)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="게임 언어 (채팅 인식 기준):" Margin="0,0,0,5" Foreground="#CCC"/>
+                            <ComboBox x:Name="ComboGameLang" Margin="0,0,0,10" Background="#333" Foreground="Black">
+                                <ComboBoxItem Content="한국어" Tag="ko"/>
+                                <ComboBoxItem Content="영어" Tag="en-US"/>
+                                <ComboBoxItem Content="중국어(간체)" Tag="zh-Hans-CN"/>
+                                <ComboBoxItem Content="일본어" Tag="ja"/>
+                                <ComboBoxItem Content="러시아어" Tag="ru"/>
+                            </ComboBox>
 
-        <!-- OCR 언어팩 상태: Windows OCR 엔진 생성 가능 여부를 보여줍니다. -->
-        <GroupBox Header="OCR 언어팩 설치 상태" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <TextBlock Text="Windows OCR 엔진이 감지한 언어팩 상태입니다. 미설치 언어는 LangInstall.bat를 관리자 권한으로 실행한 뒤 재부팅하세요."
-                           TextWrapping="Wrap"
-                           Margin="0,0,0,8"
-                           Foreground="#CCC"/>
-                <TextBlock x:Name="TxtOcrLanguageStatus"
-                           Text="OCR 언어팩 상태 확인 중..."
-                           TextWrapping="Wrap"
-                           FontFamily="Consolas"
-                           Foreground="#E6E6E6"
-                           Margin="0,0,0,8"/>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button x:Name="BtnRefreshOcrLanguages"
-                            Content="상태 새로고침"
-                            Padding="8,2"
-                            Background="#444"
-                            Foreground="White"
-                            BorderThickness="0"
-                            Cursor="Hand"
-                            Click="BtnRefreshOcrLanguages_Click"/>
-                </StackPanel>
-            </StackPanel>
-        </GroupBox>
+                            <TextBlock Text="번역 언어 (결과 언어):" Margin="0,0,0,5" Foreground="#CCC"/>
+                            <ComboBox x:Name="ComboTargetLang" Background="#333" Foreground="Black">
+                                <ComboBoxItem Content="한국어" Tag="ko"/>
+                                <ComboBoxItem Content="영어" Tag="en-US"/>
+                                <ComboBoxItem Content="중국어(간체)" Tag="zh-Hans-CN"/>
+                                <ComboBoxItem Content="일본어" Tag="ja"/>
+                                <ComboBoxItem Content="러시아어" Tag="ru"/>
+                            </ComboBox>
+                        </StackPanel>
+                    </GroupBox>
 
-        <!-- OCR 테스트/진단: 현재 캡처 영역의 원본/전처리 이미지와 OCR 결과를 별도 창에서 확인합니다. -->
-        <GroupBox Header="OCR 테스트 / 진단" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <TextBlock Text="현재 저장된 캡처 영역을 분석해 원본, 전처리 후보, OCR 결과, 후보 점수를 별도 창에서 비교합니다."
-                           TextWrapping="Wrap"
-                           Margin="0,0,0,8"
-                           Foreground="#CCC"/>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button x:Name="BtnOpenOcrDiagnostic"
-                            Content="OCR 진단 화면 열기"
-                            Padding="8,2"
-                            Background="#444"
-                            Foreground="White"
-                            BorderThickness="0"
-                            Cursor="Hand"
-                            Click="BtnOpenOcrDiagnostic_Click"/>
-                </StackPanel>
-            </StackPanel>
-        </GroupBox>
+                    <!-- OCR 언어팩 상태: Windows OCR 엔진 생성 가능 여부를 보여줍니다. -->
+                    <GroupBox Header="OCR 언어팩 설치 상태" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="Windows OCR 엔진이 감지한 언어팩 상태입니다. 미설치 언어는 LangInstall.bat를 관리자 권한으로 실행한 뒤 재부팅하세요."
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"
+                                       Foreground="#CCC"/>
+                            <TextBlock x:Name="TxtOcrLanguageStatus"
+                                       Text="OCR 언어팩 상태 확인 중..."
+                                       TextWrapping="Wrap"
+                                       FontFamily="Consolas"
+                                       Foreground="#E6E6E6"
+                                       Margin="0,0,0,8"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button x:Name="BtnRefreshOcrLanguages"
+                                        Content="상태 새로고침"
+                                        Padding="8,2"
+                                        Background="#444"
+                                        Foreground="White"
+                                        BorderThickness="0"
+                                        Cursor="Hand"
+                                        Click="BtnRefreshOcrLanguages_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
 
-        <TextBlock Text="3. 실행 옵션" Style="{StaticResource SectionTitleStyle}"/>
-        <TextBlock Text="번역창 표시, 자동 번역 주기, 결과 표시 방식, 단축키, 캡처 영역처럼 실행 중 동작을 조정합니다." Style="{StaticResource SectionHintStyle}"/>
-
-        <!-- 고급 설정: 오버레이 투명도, OCR 확대 배율, 이진화 기준값, 자동 번역 주기, 디버그 이미지 저장 여부를 조정합니다. -->
-        <GroupBox Header="상세 설정 (Advanced Options)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-
-                <TextBlock x:Name="TxtOpacityInfo" Text="번역창 불투명도: 70%" Margin="0,0,0,5" Foreground="#CCC"/>
-                <Slider x:Name="SliderOpacity" Minimum="10" Maximum="100" Value="70" TickFrequency="5" IsSnapToTickEnabled="True" ValueChanged="SliderOpacity_ValueChanged" Margin="0,0,0,15"/>
-
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                    <TextBlock Text="OCR 인식 배율 (1~4):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
-                    <ComboBox x:Name="ComboScale" Width="120" Height="24" Background="#333" Foreground="Black" ToolTip="기본값 3, 허용 범위 1~4">
-                        <ComboBoxItem Content="1배 (빠름)" Tag="1"/>
-                        <ComboBoxItem Content="2배" Tag="2"/>
-                        <ComboBoxItem Content="3배 (권장)" Tag="3"/>
-                        <ComboBoxItem Content="4배 (정밀)" Tag="4"/>
-                    </ComboBox>
+                    <!-- OCR 테스트/진단: 현재 캡처 영역의 원본/전처리 이미지와 OCR 결과를 별도 창에서 확인합니다. -->
+                    <GroupBox Header="OCR 테스트 / 진단" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="현재 저장된 캡처 영역을 분석해 원본, 전처리 후보, OCR 결과, 후보 점수를 별도 창에서 비교합니다."
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"
+                                       Foreground="#CCC"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button x:Name="BtnOpenOcrDiagnostic"
+                                        Content="OCR 진단 화면 열기"
+                                        Padding="8,2"
+                                        Background="#444"
+                                        Foreground="White"
+                                        BorderThickness="0"
+                                        Cursor="Hand"
+                                        Click="BtnOpenOcrDiagnostic_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                    <TextBlock Text="OCR 이진화 기준 (1~255):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtThreshold" Width="120" TextAlignment="Center" Background="#333" Foreground="White" BorderBrush="#555" ToolTip="기본값 120, 권장 110~130" InputMethod.IsInputMethodEnabled="False" PreviewTextInput="NumericSetting_PreviewTextInput" TextChanged="NumericSetting_TextChanged"/>
+                <StackPanel Grid.Column="2">
+                    <TextBlock Text="3. 실행 옵션" Style="{StaticResource SectionTitleStyle}"/>
+                    <TextBlock Text="번역창 표시, 자동 번역 주기, 결과 표시 방식, 단축키, 캡처 영역처럼 실행 중 동작을 조정합니다." Style="{StaticResource SectionHintStyle}"/>
+
+                    <!-- 고급 설정: 오버레이 투명도, OCR 확대 배율, 이진화 기준값, 자동 번역 주기, 디버그 이미지 저장 여부를 조정합니다. -->
+                    <GroupBox Header="상세 설정 (Advanced Options)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+
+                            <TextBlock x:Name="TxtOpacityInfo" Text="번역창 불투명도: 70%" Margin="0,0,0,5" Foreground="#CCC"/>
+                            <Slider x:Name="SliderOpacity" Minimum="10" Maximum="100" Value="70" TickFrequency="5" IsSnapToTickEnabled="True" ValueChanged="SliderOpacity_ValueChanged" Margin="0,0,0,15"/>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                <TextBlock Text="OCR 인식 배율 (1~4):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
+                                <ComboBox x:Name="ComboScale" Width="120" Height="24" Background="#333" Foreground="Black" ToolTip="기본값 3, 허용 범위 1~4">
+                                    <ComboBoxItem Content="1배 (빠름)" Tag="1"/>
+                                    <ComboBoxItem Content="2배" Tag="2"/>
+                                    <ComboBoxItem Content="3배 (권장)" Tag="3"/>
+                                    <ComboBoxItem Content="4배 (정밀)" Tag="4"/>
+                                </ComboBox>
+                            </StackPanel>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                <TextBlock Text="OCR 이진화 기준 (1~255):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtThreshold" Width="120" TextAlignment="Center" Background="#333" Foreground="White" BorderBrush="#555" ToolTip="기본값 120, 권장 110~130" InputMethod.IsInputMethodEnabled="False" PreviewTextInput="NumericSetting_PreviewTextInput" TextChanged="NumericSetting_TextChanged"/>
+                            </StackPanel>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                <TextBlock Text="자동 번역 주기 (1~60초):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtInterval" Width="120" TextAlignment="Center" Background="#333" Foreground="White" BorderBrush="#555" ToolTip="기본값 5초, 허용 범위 1~60초" InputMethod.IsInputMethodEnabled="False" PreviewTextInput="NumericSetting_PreviewTextInput" TextChanged="NumericSetting_TextChanged"/>
+                            </StackPanel>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                <TextBlock Text="번역 결과 표시 방식:" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
+                                <ComboBox x:Name="ComboResultDisplayMode" Width="170" Height="24" Background="#333" Foreground="Black">
+                                    <ComboBoxItem Content="최신 결과만 표시" Tag="Latest"/>
+                                    <ComboBoxItem Content="최근 내역 누적 표시" Tag="History"/>
+                                </ComboBox>
+                            </StackPanel>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                <TextBlock Text="누적 표시 최대 줄 수 (1~10):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtResultHistoryLimit" Width="120" TextAlignment="Center" Background="#333" Foreground="White" BorderBrush="#555" ToolTip="기본값 5, 허용 범위 1~10" InputMethod.IsInputMethodEnabled="False" PreviewTextInput="NumericSetting_PreviewTextInput" TextChanged="NumericSetting_TextChanged"/>
+                            </StackPanel>
+
+                            <TextBlock x:Name="TxtAdvancedValidationStatus" TextWrapping="Wrap" FontSize="11" Foreground="#8BE28B" Margin="0,0,0,10"/>
+
+                            <CheckBox x:Name="CheckSaveDebugImages" Content="디버그 캡처 이미지 저장" Foreground="#CCC"/>
+
+                        </StackPanel>
+                    </GroupBox>
+
+                    <!-- 단축키 설정: 각 TextBox 클릭 후 키 조합을 누르면 OptionSelector.xaml.cs에서 문자열로 저장합니다. -->
+                    <GroupBox Header="단축키 설정 (클릭 후 키보드 입력)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Text="이동/잠금 :" Grid.Row="0" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyMove" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+
+                                <TextBlock Text="영역 설정 :" Grid.Row="1" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyArea" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+
+                                <TextBlock Text="수동 번역 :" Grid.Row="2" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyTrans" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+
+                                <TextBlock Text="자동 번역 모드 :" Grid.Row="3" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyAuto" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+
+                                <TextBlock Text="엔진 전환 단축키 :" Grid.Row="4" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyToggle" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+
+                                <TextBlock Text="번역 복사 :" Grid.Row="5" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyCopy" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+
+                                <TextBlock Text="로그창 ON/OFF :" Grid.Row="6" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyLog" Grid.Row="6" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+                            </Grid>
+
+                            <!-- 입력칸만 기본값으로 되돌립니다. config.ini 저장은 아래 저장 버튼을 눌렀을 때만 수행됩니다. -->
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,0,0">
+                                <Button x:Name="BtnResetHotkeys" Content="단축키 초기화" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetHotkeys_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
+
+                    <!-- 캡처 영역: 현재 저장된 채팅 영역을 보여주고 필요하면 초기화합니다. 실제 영역 지정은 Ctrl+8에서 수행합니다. -->
+                    <GroupBox Header="캡처 영역 (Capture Area)" Foreground="White" BorderBrush="#555" Margin="0,0,0,10">
+                        <StackPanel Margin="10" Orientation="Horizontal">
+                            <TextBlock x:Name="TxtAreaInfo" Text="저장된 영역: 없음 (좌측 하단 기본값)" VerticalAlignment="Center" Foreground="#CCC" Width="280"/>
+                            <Button x:Name="BtnResetArea" Content="🔄 영역 초기화" Padding="5,0" Height="25" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
+                        </StackPanel>
+                    </GroupBox>
+
+                    <TextBlock Text="4. 번역 엔진" Style="{StaticResource SectionTitleStyle}"/>
+                    <TextBlock Text="Gemini API 키와 모델을 입력합니다. 비워두면 Google 무료 번역만 사용합니다." Style="{StaticResource SectionHintStyle}"/>
+
+                    <!-- Gemini 영역: API 키와 모델명을 입력합니다. 프리셋 저장 대상에서 API 키는 제외됩니다. -->
+                    <GroupBox Header="Gemini AI 번역 설정" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="API 키를 입력하면 Gemini AI 번역을 사용할 수 있습니다. 비워두면 Google 무료 번역으로 실행됩니다." TextWrapping="Wrap" Margin="0,0,0,10" Foreground="#CCC"/>
+
+                            <TextBlock Text="Gemini API Key:" Margin="0,0,0,5" Foreground="#CCC"/>
+                            <PasswordBox x:Name="PasswordGeminiKey" Height="26" Margin="0,0,0,10" Background="#333" Foreground="White" BorderBrush="#555"/>
+
+                            <TextBlock Text="Gemini Model:" Margin="0,0,0,5" Foreground="#CCC"/>
+                            <TextBox x:Name="TxtGeminiModel" Height="26" Margin="0,0,0,5" Background="#333" Foreground="White" BorderBrush="#555"/>
+                            <TextBlock Text="기본값: gemini-2.5-flash" FontSize="11" Foreground="#888"/>
+                        </StackPanel>
+                    </GroupBox>
                 </StackPanel>
+            </Grid>
 
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                    <TextBlock Text="자동 번역 주기 (1~60초):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtInterval" Width="120" TextAlignment="Center" Background="#333" Foreground="White" BorderBrush="#555" ToolTip="기본값 5초, 허용 범위 1~60초" InputMethod.IsInputMethodEnabled="False" PreviewTextInput="NumericSetting_PreviewTextInput" TextChanged="NumericSetting_TextChanged"/>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                    <TextBlock Text="번역 결과 표시 방식:" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
-                    <ComboBox x:Name="ComboResultDisplayMode" Width="170" Height="24" Background="#333" Foreground="Black">
-                        <ComboBoxItem Content="최신 결과만 표시" Tag="Latest"/>
-                        <ComboBoxItem Content="최근 내역 누적 표시" Tag="History"/>
-                    </ComboBox>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                    <TextBlock Text="누적 표시 최대 줄 수 (1~10):" Width="180" VerticalAlignment="Center" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtResultHistoryLimit" Width="120" TextAlignment="Center" Background="#333" Foreground="White" BorderBrush="#555" ToolTip="기본값 5, 허용 범위 1~10" InputMethod.IsInputMethodEnabled="False" PreviewTextInput="NumericSetting_PreviewTextInput" TextChanged="NumericSetting_TextChanged"/>
-                </StackPanel>
-
-                <TextBlock x:Name="TxtAdvancedValidationStatus" TextWrapping="Wrap" FontSize="11" Foreground="#8BE28B" Margin="0,0,0,10"/>
-
-                <CheckBox x:Name="CheckSaveDebugImages" Content="디버그 캡처 이미지 저장" Foreground="#CCC"/>
-
-            </StackPanel>
-        </GroupBox>
-
-        <!-- 단축키 설정: 각 TextBox 클릭 후 키 조합을 누르면 OptionSelector.xaml.cs에서 문자열로 저장합니다. -->
-        <GroupBox Header="단축키 설정 (클릭 후 키보드 입력)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-
-                    <TextBlock Text="이동/잠금 :" Grid.Row="0" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtKeyMove" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                    <TextBlock Text="영역 설정 :" Grid.Row="1" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtKeyArea" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                    <TextBlock Text="수동 번역 :" Grid.Row="2" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtKeyTrans" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                    <TextBlock Text="자동 번역 모드 :" Grid.Row="3" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtKeyAuto" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                    <TextBlock Text="엔진 전환 단축키 :" Grid.Row="4" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtKeyToggle" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                    <TextBlock Text="번역 복사 :" Grid.Row="5" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtKeyCopy" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                    <TextBlock Text="로그창 ON/OFF :" Grid.Row="6" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                    <TextBox x:Name="TxtKeyLog" Grid.Row="6" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-                </Grid>
-
-                <!-- 입력칸만 기본값으로 되돌립니다. config.ini 저장은 아래 저장 버튼을 눌렀을 때만 수행됩니다. -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,0,0">
-                    <Button x:Name="BtnResetHotkeys" Content="단축키 초기화" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetHotkeys_Click"/>
-                </StackPanel>
-            </StackPanel>
-        </GroupBox>
-
-        <!-- 캡처 영역: 현재 저장된 채팅 영역을 보여주고 필요하면 초기화합니다. 실제 영역 지정은 Ctrl+8에서 수행합니다. -->
-        <GroupBox Header="캡처 영역 (Capture Area)" Foreground="White" BorderBrush="#555" Margin="0,0,0,10">
-            <StackPanel Margin="10" Orientation="Horizontal">
-                <TextBlock x:Name="TxtAreaInfo" Text="저장된 영역: 없음 (좌측 하단 기본값)" VerticalAlignment="Center" Foreground="#CCC" Width="280"/>
-                <Button x:Name="BtnResetArea" Content="🔄 영역 초기화" Padding="5,0" Height="25" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
-            </StackPanel>
-        </GroupBox>
-
-        <TextBlock Text="4. 번역 엔진" Style="{StaticResource SectionTitleStyle}"/>
-        <TextBlock Text="Gemini API 키와 모델을 입력합니다. 비워두면 Google 무료 번역만 사용합니다." Style="{StaticResource SectionHintStyle}"/>
-
-        <!-- Gemini 영역: API 키와 모델명을 입력합니다. 프리셋 저장 대상에서 API 키는 제외됩니다. -->
-        <GroupBox Header="Gemini AI 번역 설정" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
-            <StackPanel Margin="10">
-                <TextBlock Text="API 키를 입력하면 Gemini AI 번역을 사용할 수 있습니다. 비워두면 Google 무료 번역으로 실행됩니다." TextWrapping="Wrap" Margin="0,0,0,10" Foreground="#CCC"/>
-
-                <TextBlock Text="Gemini API Key:" Margin="0,0,0,5" Foreground="#CCC"/>
-                <PasswordBox x:Name="PasswordGeminiKey" Height="26" Margin="0,0,0,10" Background="#333" Foreground="White" BorderBrush="#555"/>
-
-                <TextBlock Text="Gemini Model:" Margin="0,0,0,5" Foreground="#CCC"/>
-                <TextBox x:Name="TxtGeminiModel" Height="26" Margin="0,0,0,5" Background="#333" Foreground="White" BorderBrush="#555"/>
-                <TextBlock Text="기본값: gemini-2.5-flash" FontSize="11" Foreground="#888"/>
-            </StackPanel>
-        </GroupBox>
-
-        <!-- 저장 버튼: 모든 설정을 config.ini에 기록하고 설정창을 정상 종료해 MainWindow 로딩을 계속합니다. -->
-        <Button x:Name="BtnSaveAndStart" Content="💾 저장 및 게임 시작" Height="40" Background="LimeGreen" Foreground="Black" FontWeight="Bold" FontSize="16" Click="BtnSaveAndStart_Click" Cursor="Hand" Margin="0,0,0,10"/>
+            <!-- 저장 버튼: 모든 설정을 config.ini에 기록하고 설정창을 정상 종료해 MainWindow 로딩을 계속합니다. -->
+            <Button x:Name="BtnSaveAndStart" Content="💾 저장 및 게임 시작" Height="40" Background="LimeGreen" Foreground="Black" FontWeight="Bold" FontSize="16" Click="BtnSaveAndStart_Click" Cursor="Hand" Margin="0,8,0,10"/>
         </StackPanel>
     </ScrollViewer>
 </Window>


### PR DESCRIPTION
## 작업 내용
- 환경설정창 크기 조정: 500x1000 → 980x860
- 본문을 2열 Grid 구조로 변경
- 왼쪽 열: 설정 관리 / 언어·OCR
- 오른쪽 열: 실행 옵션 / 번역 엔진
- 기존 컨트롤 이름과 이벤트 연결은 유지
- 저장 버튼은 하단 전체 폭 유지

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true

## 확인 필요
- Windows/VS2026에서 설정창 실제 표시 확인
- 1080p 보조 모니터에서 창 크기와 스크롤 동작 확인