### PR TITLE
기능: OCR 진단 결과 ZIP 저장 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrDiagnosticExporterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrDiagnosticExporterTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class OcrDiagnosticExporterTests
+    {
+        private readonly OcrDiagnosticExporter _exporter = new OcrDiagnosticExporter();
+
+        [Fact]
+        public void BuildSummaryText_IncludesSelectedCandidateAndTimings()
+        {
+            OcrDiagnosticResult result = CreateSampleResult();
+
+            string summary = _exporter.BuildSummaryText(result);
+
+            Assert.Contains("선택 후보: Color", summary);
+            Assert.Contains("Threshold: 120", summary);
+            Assert.Contains("Total: 70ms", summary);
+            Assert.Contains("- Color: 123", summary);
+        }
+
+        [Fact]
+        public void BuildCandidateText_IncludesMergedLinesAndLanguageResults()
+        {
+            OcrDiagnosticCandidate candidate = CreateSampleResult().Candidates[0];
+
+            string text = _exporter.BuildCandidateText(candidate, true);
+
+            Assert.Contains("선택 여부: YES", text);
+            Assert.Contains("01. [미셸]: hello", text);
+            Assert.Contains("-- en-US --", text);
+            Assert.Contains("01. [Michelle]: hello", text);
+        }
+
+        [Fact]
+        public void CreateDefaultFileName_UsesCaptureTimestamp()
+        {
+            string fileName = _exporter.CreateDefaultFileName(new DateTime(2026, 4, 20, 15, 30, 40));
+
+            Assert.Equal("GameChatTranslator_OCR_Diagnostic_20260420_153040.zip", fileName);
+        }
+
+        [Fact]
+        public void ExportToZip_WritesSummaryImagesAndCandidateDetails()
+        {
+            OcrDiagnosticResult result = CreateSampleResult();
+
+            using var stream = new MemoryStream();
+            _exporter.ExportToZip(result, stream);
+
+            stream.Position = 0;
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            AssertEntryExists(archive, "summary.txt");
+            AssertEntryExists(archive, "images/raw_capture.png");
+            AssertEntryExists(archive, "images/resized_ocr.png");
+            AssertEntryExists(archive, "candidates/01_Color/details.txt");
+            AssertEntryExists(archive, "candidates/01_Color/preprocessed.png");
+            AssertEntryExists(archive, "candidates/01_Color/cropped.png");
+
+            string summary = ReadEntryText(archive, "summary.txt");
+            string candidateDetails = ReadEntryText(archive, "candidates/01_Color/details.txt");
+            Assert.Contains("선택 후보: Color", summary);
+            Assert.Contains("[언어별 OCR 결과]", candidateDetails);
+        }
+
+        private static OcrDiagnosticResult CreateSampleResult()
+        {
+            var result = new OcrDiagnosticResult
+            {
+                CapturedAt = new DateTime(2026, 4, 20, 15, 30, 40),
+                CaptureArea = new System.Drawing.Rectangle(10, 20, 300, 120),
+                Threshold = 120,
+                ScaleFactor = 3,
+                RawPng = new byte[] { 1, 2, 3 },
+                ResizedPng = new byte[] { 4, 5, 6 },
+                SelectedCandidateName = "Color",
+                SelectedScore = 123,
+                CaptureMs = 10,
+                ResizeMs = 11,
+                PreprocessMs = 12,
+                CropMs = 13,
+                OcrMs = 14,
+                ScoringMs = 15,
+                TotalMs = 70,
+                OcrCallCount = 2
+            };
+
+            var candidate = new OcrDiagnosticCandidate
+            {
+                Name = "Color",
+                Score = 123,
+                PreprocessedPng = new byte[] { 7, 8, 9 },
+                CroppedPng = new byte[] { 10, 11, 12 }
+            };
+            candidate.MergedLines.Add("[미셸]: hello");
+
+            var language = new OcrDiagnosticLanguageResult
+            {
+                LanguageTag = "en-US"
+            };
+            language.Lines.Add("[Michelle]: hello");
+            candidate.Languages.Add(language);
+            result.Candidates.Add(candidate);
+
+            return result;
+        }
+
+        private static void AssertEntryExists(ZipArchive archive, string entryName)
+        {
+            Assert.Contains(archive.Entries, entry => entry.FullName == entryName);
+        }
+
+        private static string ReadEntryText(ZipArchive archive, string entryName)
+        {
+            ZipArchiveEntry entry = archive.Entries.Single(item => item.FullName == entryName);
+            using Stream stream = entry.Open();
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -20,6 +20,8 @@
     <Compile Include="../GameChatTranslator/Core/ChatTextAnalyzer.cs" Link="Core/ChatTextAnalyzer.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrMaskProcessor.cs" Link="Core/OcrMaskProcessor.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
+    <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
+    <Compile Include="../GameChatTranslator/Models/OcrDiagnosticModels.cs" Link="Models/OcrDiagnosticModels.cs" />
     <Compile Include="../GameChatTranslator/Core/SettingsService.cs" Link="Core/SettingsService.cs" />
     <Compile Include="../GameChatTranslator/Core/SettingsValueNormalizer.cs" Link="Core/SettingsValueNormalizer.cs" />
     <Compile Include="../GameChatTranslator/Core/TranslationPromptBuilder.cs" Link="Core/TranslationPromptBuilder.cs" />

--- a/GameChatTranslator/Core/OcrDiagnosticExporter.cs
+++ b/GameChatTranslator/Core/OcrDiagnosticExporter.cs
@@ -1,0 +1,157 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// OCR 진단 결과를 텍스트와 PNG 이미지 묶음 ZIP으로 저장합니다.
+    /// WPF UI에 의존하지 않으므로 테스트에서 MemoryStream으로 검증할 수 있습니다.
+    /// </summary>
+    public sealed class OcrDiagnosticExporter
+    {
+        /// <summary>
+        /// OCR 진단 결과를 ZIP 스트림에 기록합니다.
+        /// <paramref name="result"/>는 OcrDiagnosticWindow에 표시된 진단 결과이고,
+        /// <paramref name="outputStream"/>은 저장 대상 ZIP 파일 스트림입니다.
+        /// </summary>
+        public void ExportToZip(OcrDiagnosticResult result, Stream outputStream)
+        {
+            if (result == null) throw new ArgumentNullException(nameof(result));
+            if (outputStream == null) throw new ArgumentNullException(nameof(outputStream));
+
+            using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpen: true, Encoding.UTF8);
+            WriteTextEntry(archive, "summary.txt", BuildSummaryText(result));
+            WriteBinaryEntry(archive, "images/raw_capture.png", result.RawPng);
+            WriteBinaryEntry(archive, "images/resized_ocr.png", result.ResizedPng);
+
+            for (int i = 0; i < result.Candidates.Count; i++)
+            {
+                OcrDiagnosticCandidate candidate = result.Candidates[i];
+                bool selected = candidate.Name == result.SelectedCandidateName;
+                string folder = $"candidates/{i + 1:00}_{SanitizeEntryName(candidate.Name)}";
+
+                WriteTextEntry(archive, $"{folder}/details.txt", BuildCandidateText(candidate, selected));
+                WriteBinaryEntry(archive, $"{folder}/preprocessed.png", candidate.PreprocessedPng);
+                WriteBinaryEntry(archive, $"{folder}/cropped.png", candidate.CroppedPng);
+            }
+        }
+
+        /// <summary>
+        /// 저장 대화상자에서 사용할 기본 ZIP 파일명을 생성합니다.
+        /// <paramref name="capturedAt"/>은 진단 캡처 시각입니다.
+        /// </summary>
+        public string CreateDefaultFileName(DateTime capturedAt)
+        {
+            return $"GameChatTranslator_OCR_Diagnostic_{capturedAt:yyyyMMdd_HHmmss}.zip";
+        }
+
+        /// <summary>
+        /// OCR 진단 요약 텍스트를 생성합니다.
+        /// </summary>
+        public string BuildSummaryText(OcrDiagnosticResult result)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("[OCR 진단 요약]");
+            builder.AppendLine($"진단 시각: {result.CapturedAt:yyyy-MM-dd HH:mm:ss}");
+            builder.AppendLine($"캡처 영역: X={result.CaptureArea.X}, Y={result.CaptureArea.Y}, W={result.CaptureArea.Width}, H={result.CaptureArea.Height}");
+            builder.AppendLine($"Threshold: {result.Threshold}");
+            builder.AppendLine($"ScaleFactor: {result.ScaleFactor}");
+            builder.AppendLine();
+            builder.AppendLine("[선택 결과]");
+            builder.AppendLine($"선택 후보: {result.SelectedCandidateName}");
+            builder.AppendLine($"선택 점수: {result.SelectedScore}");
+            builder.AppendLine($"후보 수: {result.Candidates.Count}");
+            builder.AppendLine($"OCR 호출 수: {result.OcrCallCount}");
+            builder.AppendLine();
+            builder.AppendLine("[처리 시간]");
+            builder.AppendLine($"Capture: {result.CaptureMs}ms");
+            builder.AppendLine($"Resize: {result.ResizeMs}ms");
+            builder.AppendLine($"Preprocess: {result.PreprocessMs}ms");
+            builder.AppendLine($"Crop: {result.CropMs}ms");
+            builder.AppendLine($"OCR: {result.OcrMs}ms");
+            builder.AppendLine($"Scoring: {result.ScoringMs}ms");
+            builder.AppendLine($"Total: {result.TotalMs}ms");
+            builder.AppendLine();
+            builder.AppendLine("[후보 점수]");
+            foreach (OcrDiagnosticCandidate candidate in result.Candidates.OrderByDescending(c => c.Score))
+            {
+                builder.AppendLine($"- {candidate.Name}: {candidate.Score}");
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// 후보별 병합 라인과 언어별 OCR 원문을 텍스트로 정리합니다.
+        /// </summary>
+        public string BuildCandidateText(OcrDiagnosticCandidate candidate, bool selected)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine($"[{candidate.Name}]");
+            builder.AppendLine($"선택 여부: {(selected ? "YES" : "NO")}");
+            builder.AppendLine($"점수: {candidate.Score}");
+            builder.AppendLine();
+            builder.AppendLine("[병합 라인]");
+            AppendNumberedLines(builder, candidate.MergedLines);
+            builder.AppendLine();
+            builder.AppendLine("[언어별 OCR 결과]");
+
+            foreach (OcrDiagnosticLanguageResult language in candidate.Languages)
+            {
+                builder.AppendLine();
+                builder.AppendLine($"-- {language.LanguageTag} --");
+                AppendNumberedLines(builder, language.Lines);
+            }
+
+            if (candidate.Languages.Count == 0)
+            {
+                builder.AppendLine("OCR 결과 없음");
+            }
+
+            return builder.ToString();
+        }
+
+        private static void AppendNumberedLines(StringBuilder builder, System.Collections.Generic.IList<string> lines)
+        {
+            if (lines == null || lines.Count == 0)
+            {
+                builder.AppendLine("없음");
+                return;
+            }
+
+            for (int i = 0; i < lines.Count; i++)
+            {
+                builder.AppendLine($"{i + 1:00}. {lines[i]}");
+            }
+        }
+
+        private static void WriteTextEntry(ZipArchive archive, string entryName, string text)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(text ?? "");
+            WriteBinaryEntry(archive, entryName, bytes);
+        }
+
+        private static void WriteBinaryEntry(ZipArchive archive, string entryName, byte[] bytes)
+        {
+            if (bytes == null || bytes.Length == 0) return;
+
+            ZipArchiveEntry entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using Stream stream = entry.Open();
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static string SanitizeEntryName(string name)
+        {
+            string value = string.IsNullOrWhiteSpace(name) ? "candidate" : name.Trim();
+            foreach (char invalidChar in Path.GetInvalidFileNameChars())
+            {
+                value = value.Replace(invalidChar, '_');
+            }
+
+            return value.Replace(' ', '_');
+        }
+    }
+}

--- a/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml
+++ b/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml
@@ -22,6 +22,16 @@
                     BorderThickness="0"
                     Cursor="Hand"
                     Click="BtnRunDiagnostic_Click"/>
+            <Button x:Name="BtnSaveDiagnostic"
+                    Content="진단 결과 저장"
+                    Padding="10,4"
+                    Margin="0,0,10,0"
+                    Background="#444"
+                    Foreground="White"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    IsEnabled="False"
+                    Click="BtnSaveDiagnostic_Click"/>
             <TextBlock x:Name="TxtStatus"
                        VerticalAlignment="Center"
                        Foreground="#8FE388"
@@ -30,7 +40,7 @@
         </StackPanel>
 
         <TextBlock DockPanel.Dock="Top"
-                   Text="현재 저장된 채팅 캡처 영역을 실제 번역과 같은 기준으로 분석합니다. 원본, 전처리, 크롭 이미지와 OCR 결과/점수를 비교해 인식 실패 원인을 확인하세요."
+                   Text="현재 저장된 채팅 캡처 영역을 실제 번역과 같은 기준으로 분석합니다. 원본, 전처리, 크롭 이미지와 OCR 결과/점수를 비교하고, 결과 저장 버튼으로 ZIP 묶음을 만들 수 있습니다."
                    TextWrapping="Wrap"
                    Foreground="#CCC"
                    Margin="0,0,0,8"/>

--- a/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
+++ b/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
@@ -1,13 +1,13 @@
 using System;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Microsoft.Win32;
 using MediaBrushes = System.Windows.Media.Brushes;
 using MediaColor = System.Windows.Media.Color;
+using WpfMessageBox = System.Windows.MessageBox;
 using WpfFontFamily = System.Windows.Media.FontFamily;
 using WpfImage = System.Windows.Controls.Image;
 using WpfTextBox = System.Windows.Controls.TextBox;
@@ -21,6 +21,8 @@ namespace GameTranslator
     public partial class OcrDiagnosticWindow : Window
     {
         private readonly MainWindow mainWindow;
+        private readonly OcrDiagnosticExporter diagnosticExporter = new OcrDiagnosticExporter();
+        private OcrDiagnosticResult lastDiagnosticResult;
 
         /// <summary>
         /// OCR 진단 창을 생성합니다.
@@ -49,16 +51,20 @@ namespace GameTranslator
         private async System.Threading.Tasks.Task RunDiagnosticAsync()
         {
             BtnRunDiagnostic.IsEnabled = false;
+            BtnSaveDiagnostic.IsEnabled = false;
             TxtStatus.Text = "OCR 진단 실행 중...";
 
             try
             {
                 OcrDiagnosticResult result = await mainWindow.RunOcrDiagnosticAsync();
                 RenderResult(result);
+                lastDiagnosticResult = result;
+                BtnSaveDiagnostic.IsEnabled = true;
                 TxtStatus.Text = $"완료: {result.SelectedCandidateName} 선택 / {result.TotalMs}ms";
             }
             catch (Exception ex)
             {
+                lastDiagnosticResult = null;
                 TabDiagnostics.Items.Clear();
                 TabDiagnostics.Items.Add(CreateTextTab("오류", ex.Message));
                 TxtStatus.Text = $"실패: {ex.Message}";
@@ -66,6 +72,44 @@ namespace GameTranslator
             finally
             {
                 BtnRunDiagnostic.IsEnabled = true;
+            }
+        }
+
+        /// <summary>
+        /// 현재 화면에 표시된 OCR 진단 결과를 ZIP 파일로 저장합니다.
+        /// ZIP에는 요약 텍스트, 원본/확대 이미지, 후보별 전처리/크롭 이미지와 OCR 텍스트가 포함됩니다.
+        /// </summary>
+        private void BtnSaveDiagnostic_Click(object sender, RoutedEventArgs e)
+        {
+            if (lastDiagnosticResult == null)
+            {
+                WpfMessageBox.Show(this, "저장할 OCR 진단 결과가 없습니다. 먼저 진단을 실행해 주세요.", "OCR 진단 결과 저장", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var dialog = new Microsoft.Win32.SaveFileDialog
+            {
+                Title = "OCR 진단 결과 저장",
+                Filter = "ZIP 파일 (*.zip)|*.zip",
+                FileName = diagnosticExporter.CreateDefaultFileName(lastDiagnosticResult.CapturedAt),
+                AddExtension = true,
+                DefaultExt = ".zip",
+                OverwritePrompt = true
+            };
+
+            bool? result = dialog.ShowDialog(this);
+            if (result != true) return;
+
+            try
+            {
+                using FileStream stream = File.Create(dialog.FileName);
+                diagnosticExporter.ExportToZip(lastDiagnosticResult, stream);
+                TxtStatus.Text = $"저장 완료: {Path.GetFileName(dialog.FileName)}";
+            }
+            catch (Exception ex)
+            {
+                WpfMessageBox.Show(this, $"OCR 진단 결과 저장에 실패했습니다.\n{ex.Message}", "OCR 진단 결과 저장 실패", MessageBoxButton.OK, MessageBoxImage.Warning);
+                TxtStatus.Text = $"저장 실패: {ex.Message}";
             }
         }
 
@@ -223,35 +267,7 @@ namespace GameTranslator
         /// </summary>
         private string BuildSummaryText(OcrDiagnosticResult result)
         {
-            var builder = new StringBuilder();
-            builder.AppendLine("[OCR 진단 요약]");
-            builder.AppendLine($"진단 시각: {result.CapturedAt:yyyy-MM-dd HH:mm:ss}");
-            builder.AppendLine($"캡처 영역: X={result.CaptureArea.X}, Y={result.CaptureArea.Y}, W={result.CaptureArea.Width}, H={result.CaptureArea.Height}");
-            builder.AppendLine($"Threshold: {result.Threshold}");
-            builder.AppendLine($"ScaleFactor: {result.ScaleFactor}");
-            builder.AppendLine();
-            builder.AppendLine("[선택 결과]");
-            builder.AppendLine($"선택 후보: {result.SelectedCandidateName}");
-            builder.AppendLine($"선택 점수: {result.SelectedScore}");
-            builder.AppendLine($"후보 수: {result.Candidates.Count}");
-            builder.AppendLine($"OCR 호출 수: {result.OcrCallCount}");
-            builder.AppendLine();
-            builder.AppendLine("[처리 시간]");
-            builder.AppendLine($"Capture: {result.CaptureMs}ms");
-            builder.AppendLine($"Resize: {result.ResizeMs}ms");
-            builder.AppendLine($"Preprocess: {result.PreprocessMs}ms");
-            builder.AppendLine($"Crop: {result.CropMs}ms");
-            builder.AppendLine($"OCR: {result.OcrMs}ms");
-            builder.AppendLine($"Scoring: {result.ScoringMs}ms");
-            builder.AppendLine($"Total: {result.TotalMs}ms");
-            builder.AppendLine();
-            builder.AppendLine("[후보 점수]");
-            foreach (OcrDiagnosticCandidate candidate in result.Candidates.OrderByDescending(c => c.Score))
-            {
-                builder.AppendLine($"- {candidate.Name}: {candidate.Score}");
-            }
-
-            return builder.ToString();
+            return diagnosticExporter.BuildSummaryText(result);
         }
 
         /// <summary>
@@ -259,46 +275,7 @@ namespace GameTranslator
         /// </summary>
         private string BuildCandidateText(OcrDiagnosticCandidate candidate, bool selected)
         {
-            var builder = new StringBuilder();
-            builder.AppendLine($"[{candidate.Name}]");
-            builder.AppendLine($"선택 여부: {(selected ? "YES" : "NO")}");
-            builder.AppendLine($"점수: {candidate.Score}");
-            builder.AppendLine();
-            builder.AppendLine("[병합 라인]");
-            AppendNumberedLines(builder, candidate.MergedLines);
-            builder.AppendLine();
-            builder.AppendLine("[언어별 OCR 결과]");
-
-            foreach (OcrDiagnosticLanguageResult language in candidate.Languages)
-            {
-                builder.AppendLine();
-                builder.AppendLine($"-- {language.LanguageTag} --");
-                AppendNumberedLines(builder, language.Lines);
-            }
-
-            if (candidate.Languages.Count == 0)
-            {
-                builder.AppendLine("OCR 결과 없음");
-            }
-
-            return builder.ToString();
-        }
-
-        /// <summary>
-        /// 문자열 목록을 01, 02 형식으로 정리해 StringBuilder에 추가합니다.
-        /// </summary>
-        private void AppendNumberedLines(StringBuilder builder, System.Collections.Generic.IList<string> lines)
-        {
-            if (lines == null || lines.Count == 0)
-            {
-                builder.AppendLine("없음");
-                return;
-            }
-
-            for (int i = 0; i < lines.Count; i++)
-            {
-                builder.AppendLine($"{i + 1:00}. {lines[i]}");
-            }
+            return diagnosticExporter.BuildCandidateText(candidate, selected);
         }
 
         /// <summary>


### PR DESCRIPTION
## 작업 내용
- OCR 진단창에 [진단 결과 저장] 버튼 추가
- 진단 요약, 후보별 상세 텍스트, 원본/전처리/크롭 이미지를 ZIP으로 저장
- 저장 로직을 OcrDiagnosticExporter로 분리
- ZIP 구조와 요약 텍스트 단위 테스트 추가

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true → 168 passed, 0 failed
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true → 0 Warning, 0 Error
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true → 0 Warning, 0 Error
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true → 성공

## publish 산출물 확인
- GameChatTranslator.exe
- GameChatTranslator.pdb
- LangInstall.bat
- characters.txt
- readme.txt

## Windows 확인 필요
- OCR 진단창에서 진단 실행 후 [진단 결과 저장] 버튼 활성화 확인
- 저장된 ZIP 안에 summary.txt, raw/resized 이미지, 후보별 details/preprocessed/cropped 파일이 들어있는지 확인