### PR TITLE
개선: OCR 진단 화면 가독성 강화

### DIFF
--- a/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml
+++ b/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml
@@ -11,39 +11,80 @@
         Foreground="White"
         ResizeMode="CanResize"
         Topmost="True">
-    <DockPanel Margin="10">
-        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,8">
-            <Button x:Name="BtnRunDiagnostic"
-                    Content="현재 캡처 영역 진단"
-                    Padding="10,4"
-                    Margin="0,0,10,0"
-                    Background="#444"
-                    Foreground="White"
-                    BorderThickness="0"
-                    Cursor="Hand"
-                    Click="BtnRunDiagnostic_Click"/>
+    <DockPanel Margin="12">
+        <Grid DockPanel.Dock="Top" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" Orientation="Horizontal">
+                <Button x:Name="BtnRunDiagnostic"
+                        Content="현재 캡처 영역 진단"
+                        Padding="12,5"
+                        Margin="0,0,10,0"
+                        Background="#444"
+                        Foreground="White"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        Click="BtnRunDiagnostic_Click"/>
+                <TextBlock x:Name="TxtStatus"
+                           VerticalAlignment="Center"
+                           Foreground="#8FE388"
+                           FontWeight="Bold"
+                           Text="진단 준비 완료"/>
+            </StackPanel>
+
             <Button x:Name="BtnSaveDiagnostic"
-                    Content="진단 결과 저장"
-                    Padding="10,4"
-                    Margin="0,0,10,0"
-                    Background="#444"
+                    Grid.Column="1"
+                    Content="진단 결과 ZIP 저장"
+                    Padding="12,5"
+                    Background="#3F5F7F"
                     Foreground="White"
                     BorderThickness="0"
                     Cursor="Hand"
                     IsEnabled="False"
                     Click="BtnSaveDiagnostic_Click"/>
-            <TextBlock x:Name="TxtStatus"
-                       VerticalAlignment="Center"
-                       Foreground="#8FE388"
-                       FontWeight="Bold"
-                       Text="진단 준비 완료"/>
-        </StackPanel>
+        </Grid>
 
         <TextBlock DockPanel.Dock="Top"
                    Text="현재 저장된 채팅 캡처 영역을 실제 번역과 같은 기준으로 분석합니다. 원본, 전처리, 크롭 이미지와 OCR 결과/점수를 비교하고, 결과 저장 버튼으로 ZIP 묶음을 만들 수 있습니다."
                    TextWrapping="Wrap"
                    Foreground="#CCC"
                    Margin="0,0,0,8"/>
+
+        <Border DockPanel.Dock="Top"
+                BorderBrush="#555"
+                BorderThickness="1"
+                Background="#252525"
+                Padding="10"
+                Margin="0,0,0,10">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1.2*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="선택 후보" Foreground="#AAAAAA" FontSize="11"/>
+                    <TextBlock x:Name="TxtSelectedCandidate" Text="-" Foreground="White" FontWeight="Bold" FontSize="16"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Margin="12,0,0,0">
+                    <TextBlock Text="점수" Foreground="#AAAAAA" FontSize="11"/>
+                    <TextBlock x:Name="TxtSelectedScore" Text="-" Foreground="#FFD966" FontWeight="Bold" FontSize="16"/>
+                </StackPanel>
+                <StackPanel Grid.Column="2" Margin="12,0,0,0">
+                    <TextBlock Text="처리 시간" Foreground="#AAAAAA" FontSize="11"/>
+                    <TextBlock x:Name="TxtTotalTime" Text="-" Foreground="#8FE388" FontWeight="Bold" FontSize="16"/>
+                </StackPanel>
+                <StackPanel Grid.Column="3" Margin="12,0,0,0">
+                    <TextBlock Text="OCR 호출" Foreground="#AAAAAA" FontSize="11"/>
+                    <TextBlock x:Name="TxtOcrCalls" Text="-" Foreground="#9CDCFE" FontWeight="Bold" FontSize="16"/>
+                </StackPanel>
+            </Grid>
+        </Border>
 
         <TabControl x:Name="TabDiagnostics"
                     Background="#222"

--- a/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
+++ b/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
@@ -32,6 +32,7 @@ namespace GameTranslator
         {
             InitializeComponent();
             this.mainWindow = mainWindow;
+            UpdateSummaryHeader(null);
 
             Loaded += async (s, e) => await RunDiagnosticAsync();
         }
@@ -53,6 +54,7 @@ namespace GameTranslator
             BtnRunDiagnostic.IsEnabled = false;
             BtnSaveDiagnostic.IsEnabled = false;
             TxtStatus.Text = "OCR 진단 실행 중...";
+            UpdateSummaryHeader(null);
 
             try
             {
@@ -67,6 +69,7 @@ namespace GameTranslator
                 lastDiagnosticResult = null;
                 TabDiagnostics.Items.Clear();
                 TabDiagnostics.Items.Add(CreateTextTab("오류", ex.Message));
+                UpdateSummaryHeader(null);
                 TxtStatus.Text = $"실패: {ex.Message}";
             }
             finally
@@ -120,6 +123,7 @@ namespace GameTranslator
         private void RenderResult(OcrDiagnosticResult result)
         {
             TabDiagnostics.Items.Clear();
+            UpdateSummaryHeader(result);
             TabDiagnostics.Items.Add(CreateSummaryTab(result));
 
             foreach (OcrDiagnosticCandidate candidate in result.Candidates)
@@ -165,25 +169,124 @@ namespace GameTranslator
         /// </summary>
         private TabItem CreateCandidateTab(OcrDiagnosticCandidate candidate, bool selected)
         {
-            var root = new Grid();
-            root.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1.1, GridUnitType.Star) });
-            root.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            var root = new DockPanel();
+            FrameworkElement overview = CreateCandidateOverview(candidate, selected);
+            DockPanel.SetDock(overview, Dock.Top);
+            root.Children.Add(overview);
+
+            var contentGrid = new Grid();
+            contentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1.1, GridUnitType.Star) });
+            contentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
 
             var imagePanel = new StackPanel();
             imagePanel.Children.Add(CreateImageBlock("전처리 이미지", candidate.PreprocessedPng));
             imagePanel.Children.Add(CreateImageBlock("OCR 입력 크롭 이미지", candidate.CroppedPng));
             Grid.SetColumn(imagePanel, 0);
-            root.Children.Add(imagePanel);
+            contentGrid.Children.Add(imagePanel);
+
+            var detailGrid = new Grid();
+            detailGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            detailGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+
+            detailGrid.Children.Add(new TextBlock
+            {
+                Text = "OCR 결과 / 점수 상세",
+                Foreground = MediaBrushes.White,
+                FontWeight = FontWeights.Bold,
+                Margin = new Thickness(0, 0, 0, 6)
+            });
 
             WpfTextBox details = CreateReadOnlyTextBox(BuildCandidateText(candidate, selected));
-            Grid.SetColumn(details, 1);
-            root.Children.Add(details);
+            Grid.SetRow(details, 1);
+            detailGrid.Children.Add(details);
+            Grid.SetColumn(detailGrid, 1);
+            contentGrid.Children.Add(detailGrid);
+
+            root.Children.Add(contentGrid);
 
             return new TabItem
             {
-                Header = selected ? $"{candidate.Name} 선택" : candidate.Name,
+                Header = selected ? $"★ {candidate.Name} ({candidate.Score})" : $"{candidate.Name} ({candidate.Score})",
                 Content = root
             };
+        }
+
+        /// <summary>
+        /// 선택 후보, 점수, 처리 시간, OCR 호출 수를 창 상단 요약 영역에 표시합니다.
+        /// </summary>
+        private void UpdateSummaryHeader(OcrDiagnosticResult result)
+        {
+            if (result == null)
+            {
+                TxtSelectedCandidate.Text = "-";
+                TxtSelectedScore.Text = "-";
+                TxtTotalTime.Text = "-";
+                TxtOcrCalls.Text = "-";
+                return;
+            }
+
+            TxtSelectedCandidate.Text = string.IsNullOrWhiteSpace(result.SelectedCandidateName) ? "-" : result.SelectedCandidateName;
+            TxtSelectedScore.Text = result.SelectedScore.ToString();
+            TxtTotalTime.Text = $"{result.TotalMs}ms";
+            TxtOcrCalls.Text = $"{result.OcrCallCount}회";
+        }
+
+        /// <summary>
+        /// 후보 탭 최상단에 후보명, 선택 여부, 점수, OCR 결과량을 요약해 보여주는 영역을 만듭니다.
+        /// </summary>
+        private FrameworkElement CreateCandidateOverview(OcrDiagnosticCandidate candidate, bool selected)
+        {
+            var border = new Border
+            {
+                BorderBrush = selected
+                    ? new SolidColorBrush(MediaColor.FromRgb(143, 227, 136))
+                    : new SolidColorBrush(MediaColor.FromRgb(85, 85, 85)),
+                BorderThickness = new Thickness(1),
+                Background = selected
+                    ? new SolidColorBrush(MediaColor.FromRgb(36, 54, 38))
+                    : new SolidColorBrush(MediaColor.FromRgb(37, 37, 37)),
+                Padding = new Thickness(10),
+                Margin = new Thickness(0, 0, 0, 10)
+            };
+
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1.3, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            grid.Children.Add(CreateMetricBlock("후보", candidate.Name, selected ? "#8FE388" : "#FFFFFF", 0));
+            grid.Children.Add(CreateMetricBlock("선택 여부", selected ? "선택됨" : "미선택", selected ? "#8FE388" : "#CCCCCC", 1));
+            grid.Children.Add(CreateMetricBlock("점수", candidate.Score.ToString(), "#FFD966", 2));
+            grid.Children.Add(CreateMetricBlock("결과량", $"병합 {candidate.MergedLines.Count}줄 / 언어 {candidate.Languages.Count}개", "#9CDCFE", 3));
+
+            border.Child = grid;
+            return border;
+        }
+
+        /// <summary>
+        /// 요약 영역에서 사용할 작은 제목/값 묶음을 만듭니다.
+        /// </summary>
+        private FrameworkElement CreateMetricBlock(string label, string value, string valueColor, int column)
+        {
+            var panel = new StackPanel { Margin = column == 0 ? new Thickness(0) : new Thickness(12, 0, 0, 0) };
+            panel.Children.Add(new TextBlock
+            {
+                Text = label,
+                Foreground = new SolidColorBrush(MediaColor.FromRgb(170, 170, 170)),
+                FontSize = 11
+            });
+            panel.Children.Add(new TextBlock
+            {
+                Text = string.IsNullOrWhiteSpace(value) ? "-" : value,
+                Foreground = (SolidColorBrush)new BrushConverter().ConvertFrom(valueColor),
+                FontWeight = FontWeights.Bold,
+                FontSize = 15,
+                TextWrapping = TextWrapping.Wrap
+            });
+
+            Grid.SetColumn(panel, column);
+            return panel;
         }
 
         /// <summary>


### PR DESCRIPTION
## 작업 내용
- OCR 진단 창 상단에 선택 후보, 점수, 처리 시간, OCR 호출 수 요약 영역을 추가했습니다.
- 진단 결과 ZIP 저장 버튼을 우측에 분리하고 버튼 문구를 명확히 정리했습니다.
- 후보 탭 헤더에 점수를 표시하고, 선택 후보는 별도 표시가 보이도록 개선했습니다.
- 후보별 상세 화면 상단에 후보/선택 여부/점수/결과량 요약 영역을 추가했습니다.
- 기능 로직 변경 없이 OCR 진단 화면 표시 구조만 개선했습니다.

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true` → 175 passed
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:EnableWindowsTargeting=true`
- publish 산출물: GameChatTranslator.exe, GameChatTranslator.pdb, LangInstall.bat, characters.txt, readme.txt

## 확인 필요
- Windows / VS2026에서 OCR 진단 창을 열고 상단 요약, 후보 탭 점수, ZIP 저장 버튼 위치가 의도대로 보이는지 확인이 필요합니다.