### PR TITLE
개선: 번역 API 흐름 판단 분리

### DIFF
--- a/GameChatTranslator.Tests/Core/Translation/TranslationServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationServiceTests.cs
@@ -49,6 +49,47 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void ResolveGeminiAttempt_ReturnsFinalResultWhenGeminiTextExists()
+        {
+            TranslationAttemptResolution resolution = _service.ResolveGeminiAttempt("제미나이 결과", "gemini-test");
+
+            Assert.True(resolution.HasFinalResult);
+            Assert.False(resolution.RequiresGoogleFallback);
+            Assert.Equal(TranslationRequestKind.None, resolution.NextRequestKind);
+            Assert.Equal("제미나이 결과", resolution.FinalResult.TranslatedText);
+            Assert.Equal("Gemini gemini-test", resolution.FinalResult.EngineName);
+            Assert.False(resolution.FinalResult.FallbackUsed);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ResolveGeminiAttempt_RequestsGoogleFallbackWhenGeminiResultIsEmpty(string geminiResult)
+        {
+            TranslationAttemptResolution resolution = _service.ResolveGeminiAttempt(geminiResult, "gemini-test");
+
+            Assert.False(resolution.HasFinalResult);
+            Assert.True(resolution.RequiresGoogleFallback);
+            Assert.Equal(TranslationRequestKind.Google, resolution.NextRequestKind);
+            Assert.Null(resolution.FinalResult);
+        }
+
+        [Theory]
+        [InlineData(false, "Google", "구글 결과")]
+        [InlineData(true, "Google (Fallback)", "[Gemini 에러 - 구글 전환됨] 구글 결과")]
+        public void ResolveGoogleAttempt_ReturnsFinalGoogleResult(bool fallback, string expectedEngine, string expectedText)
+        {
+            TranslationAttemptResolution resolution = _service.ResolveGoogleAttempt("구글 결과", fallback);
+
+            Assert.True(resolution.HasFinalResult);
+            Assert.False(resolution.RequiresGoogleFallback);
+            Assert.Equal(TranslationRequestKind.None, resolution.NextRequestKind);
+            Assert.Equal(expectedEngine, resolution.FinalResult.EngineName);
+            Assert.Equal(expectedText, resolution.FinalResult.TranslatedText);
+            Assert.Equal(fallback, resolution.FinalResult.FallbackUsed);
+        }
+
+        [Fact]
         public void CreatePlan_UsesGoogleWhenGeminiIsDisabled()
         {
             TranslationPlan plan = _service.CreatePlan("hello squad", "ko", false);
@@ -106,6 +147,7 @@ namespace GameChatTranslator.Tests
                         type == typeof(TranslationService) ||
                         type == typeof(TranslationPlan) ||
                         type == typeof(TranslationDecisionResult) ||
+                        type == typeof(TranslationAttemptResolution) ||
                         type == typeof(TranslationRequestKind))
                     .Select(type => type.AssemblyQualifiedName));
 

--- a/GameChatTranslator/Core/TranslationService.cs
+++ b/GameChatTranslator/Core/TranslationService.cs
@@ -42,6 +42,30 @@ namespace GameTranslator
         }
 
         /// <summary>
+        /// Gemini API 호출 결과를 최종 번역 결과 또는 Google fallback 요청으로 해석합니다.
+        /// <paramref name="geminiResult"/>가 비어 있으면 호출자가 Google을 한 번 더 호출해야 하며,
+        /// 값이 있으면 Gemini 최종 결과로 확정합니다.
+        /// </summary>
+        public TranslationAttemptResolution ResolveGeminiAttempt(string geminiResult, string modelName)
+        {
+            if (ShouldFallbackToGoogle(geminiResult))
+            {
+                return TranslationAttemptResolution.RequestGoogleFallback();
+            }
+
+            return TranslationAttemptResolution.Final(CreateGeminiResult(geminiResult, modelName));
+        }
+
+        /// <summary>
+        /// Google API 호출 결과를 최종 번역 결과로 해석합니다.
+        /// <paramref name="isFallback"/>이 true이면 Gemini 실패 후 Google로 전환된 결과임을 출력문과 엔진명에 반영합니다.
+        /// </summary>
+        public TranslationAttemptResolution ResolveGoogleAttempt(string googleResult, bool isFallback)
+        {
+            return TranslationAttemptResolution.Final(CreateGoogleResult(googleResult, isFallback));
+        }
+
+        /// <summary>
         /// 성공한 Gemini 번역 결과를 UI/로그에 사용할 공통 결과 모델로 변환합니다.
         /// <paramref name="geminiResult"/>는 Gemini 응답에서 추출한 번역문,
         /// <paramref name="modelName"/>은 사용한 Gemini 모델명입니다.
@@ -148,5 +172,33 @@ namespace GameTranslator
         public string EngineName { get; }
         public bool Skipped { get; }
         public bool FallbackUsed { get; }
+    }
+
+    /// <summary>
+    /// 한 번의 API 호출 결과를 해석한 상태입니다.
+    /// FinalResult가 있으면 화면에 출력할 수 있고, NextRequestKind가 Google이면 Google fallback 호출이 필요합니다.
+    /// </summary>
+    public sealed class TranslationAttemptResolution
+    {
+        private TranslationAttemptResolution(TranslationDecisionResult finalResult, TranslationRequestKind nextRequestKind)
+        {
+            FinalResult = finalResult;
+            NextRequestKind = nextRequestKind;
+        }
+
+        public TranslationDecisionResult FinalResult { get; }
+        public TranslationRequestKind NextRequestKind { get; }
+        public bool HasFinalResult => FinalResult != null;
+        public bool RequiresGoogleFallback => !HasFinalResult && NextRequestKind == TranslationRequestKind.Google;
+
+        public static TranslationAttemptResolution Final(TranslationDecisionResult result)
+        {
+            return new TranslationAttemptResolution(result, TranslationRequestKind.None);
+        }
+
+        public static TranslationAttemptResolution RequestGoogleFallback()
+        {
+            return new TranslationAttemptResolution(null, TranslationRequestKind.Google);
+        }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -442,17 +442,18 @@ namespace GameTranslator
                             translateStopwatch.Stop();
                             performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
 
-                            if (translationService.ShouldFallbackToGoogle(geminiTranslated))
+                            TranslationAttemptResolution geminiResolution = translationService.ResolveGeminiAttempt(geminiTranslated, modelName);
+                            if (geminiResolution.RequiresGoogleFallback)
                             {
                                 translateStopwatch.Restart();
                                 string googleFallback = await CallGoogleAPI(finalContent, targetLang);
                                 translateStopwatch.Stop();
                                 performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
-                                translationResult = translationService.CreateGoogleResult(googleFallback, true);
+                                translationResult = translationService.ResolveGoogleAttempt(googleFallback, true).FinalResult;
                             }
                             else
                             {
-                                translationResult = translationService.CreateGeminiResult(geminiTranslated, modelName);
+                                translationResult = geminiResolution.FinalResult;
                             }
                         }
                         else
@@ -461,7 +462,7 @@ namespace GameTranslator
                             string googleTranslated = await CallGoogleAPI(finalContent, targetLang);
                             translateStopwatch.Stop();
                             performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
-                            translationResult = translationService.CreateGoogleResult(googleTranslated, false);
+                            translationResult = translationService.ResolveGoogleAttempt(googleTranslated, false).FinalResult;
                         }
                     }
 


### PR DESCRIPTION
## 작업 내용
- Gemini API 호출 결과를 최종 결과 또는 Google fallback 요청으로 해석하는 `TranslationAttemptResolution` 모델을 추가했습니다.
- `TranslationService.ResolveGeminiAttempt` / `ResolveGoogleAttempt`를 추가해 API 결과 해석 흐름을 순수 로직으로 분리했습니다.
- `MainWindow.Translation.cs`는 실제 HTTP 호출과 성능 시간 측정만 유지하고, Gemini 성공/실패 및 fallback 결과 확정은 `TranslationService`를 사용하도록 변경했습니다.
- Gemini 성공, Gemini 빈 결과 fallback, Google 일반/ fallback 결과에 대한 테스트를 추가했습니다.

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true` → 198 passed
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true` → 0 Warning / 0 Error
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true` → 0 Warning / 0 Error
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore` → 198 passed
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:EnableWindowsTargeting=true` → 성공
- publish 산출물: GameChatTranslator.exe, GameChatTranslator.pdb, LangInstall.bat, characters.txt, readme.txt

## 확인 필요
- Windows / VS2026에서 Gemini 번역 성공 경로와 Gemini 실패 후 Google fallback 경로가 기존과 동일하게 동작하는지 확인해 주세요.