### PR TITLE
수정: 번역창 단축키 안내 표시 개선

### DIFF
--- a/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
@@ -140,42 +140,50 @@ namespace GameTranslator
 
             // 🌟 안내 문구에 엔진 전환 추가
             string engineStr = useGeminiEngine ? "Gemini" : "Google";
-            string newGuide = $"[{m}] 이동  [{a}] 영역  [{t}] 번역  [{copy}] 복사  [{diag}] 진단\n[{au}] 자동  [{tg}] {engineStr}  [{log}] 로그";
-
-            foreach (var tb in FindVisualChildren<TextBlock>(this))
+            if (TxtHotkeyGuide == null)
             {
-                if (tb.Text.Contains("이동") && tb.Text.Contains("영역설정") || tb.Text.Contains("자동"))
-                {
-                    // TextBlock 내부 Run을 직접 교체해 자동 모드 상태만 색상 강조합니다.
-                    tb.Inlines.Clear();
-                    tb.Inlines.Add(new Run(newGuide));
-                    tb.Inlines.Add(new Run($"\n  ● 자동: {GetAutoTranslateModeLabel()}")
-                    {
-                        Foreground = isAutoTranslating ? Brushes.Lime : Brushes.Gray,
-                        FontWeight = FontWeights.Bold
-                    });
-                    break;
-                }
+                return;
             }
+
+            // 상단 안내가 길어져 고정 높이에서 잘리지 않도록 2줄짜리 축약 문구로 유지합니다.
+            TxtHotkeyGuide.Inlines.Clear();
+            TxtHotkeyGuide.Inlines.Add(new Run($"[{m}] 이동  [{a}] 영역  [{t}] 번역  [{au}] 자동: "));
+            TxtHotkeyGuide.Inlines.Add(new Run(GetAutoTranslateModeLabel())
+            {
+                Foreground = isAutoTranslating ? Brushes.Lime : Brushes.Gray,
+                FontWeight = FontWeights.Bold
+            });
+            TxtHotkeyGuide.Inlines.Add(new Run($"\n[{copy}] 복사  [{diag}] 진단  [{tg}] {engineStr}  [{log}] 로그"));
         }
 
         /// <summary>
-        /// WPF 시각 트리에서 특정 타입의 자식 컨트롤을 재귀적으로 찾습니다.
-        /// <typeparam name="T"/>는 찾을 DependencyObject 타입입니다. 예: TextBlock.
-        /// <paramref name="depObj"/>는 검색을 시작할 루트 컨트롤입니다.
-        /// 반환값은 루트 아래에서 발견된 모든 T 타입 컨트롤입니다.
+        /// 자동 번역 모드가 바뀔 때 별도 상태 문구를 잠깐 표시합니다.
+        /// 단축키 안내 영역과 분리해 안내 문구가 길어져도 모드 전환 피드백이 잘리지 않게 합니다.
         /// </summary>
-        public static IEnumerable<T> FindVisualChildren<T>(DependencyObject depObj) where T : DependencyObject
+        private void ShowAutoModeStatus()
         {
-            if (depObj != null)
-            {
-                for (int i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
-                {
-                    DependencyObject child = VisualTreeHelper.GetChild(depObj, i);
-                    if (child != null && child is T) yield return (T)child;
-                    foreach (T childOfChild in FindVisualChildren<T>(child)) yield return childOfChild;
-                }
-            }
+            if (TxtAutoModeStatus == null) return;
+
+            string modeLabel = GetAutoTranslateModeLabel();
+            TxtAutoModeStatus.Text = modeLabel == "OFF"
+                ? "자동 번역 OFF"
+                : $"자동 번역: {modeLabel}";
+            TxtAutoModeStatus.Foreground = isAutoTranslating ? Brushes.Lime : Brushes.Gray;
+            TxtAutoModeStatus.Visibility = Visibility.Visible;
+            autoModeStatusTimer?.Stop();
+            autoModeStatusTimer?.Start();
+        }
+
+        /// <summary>
+        /// 자동 번역 모드 전환 상태 문구를 숨깁니다.
+        /// </summary>
+        private void HideAutoModeStatus()
+        {
+            autoModeStatusTimer?.Stop();
+
+            if (TxtAutoModeStatus == null) return;
+            TxtAutoModeStatus.Text = "";
+            TxtAutoModeStatus.Visibility = Visibility.Collapsed;
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -53,6 +53,7 @@ namespace GameTranslator
             isAutoTranslating = autoTranslateMode != AutoTranslateMode.Off;
             ResetTranslationCache($"자동 번역 모드 변경: {GetAutoTranslateModeLabel()}");
             UpdateYellowHotkeyGuideText();
+            ShowAutoModeStatus();
             AppendLog($"자동 번역 모드: {GetAutoTranslateModeLabel()}");
 
             if (isAutoTranslating)

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml
@@ -13,8 +13,27 @@
     <Border x:Name="MainBorder" Background="#CC1E1E1E" CornerRadius="10" BorderThickness="2" BorderBrush="#55FFFFFF">
         <StackPanel Margin="15">
             <!-- 단축키와 현재 자동 번역 모드를 표시하는 상단 안내 영역입니다. MainWindow.Hotkeys.cs에서 동적으로 갱신합니다. -->
-            <TextBlock Text="[Ctrl+7] 이동/잠금  [Ctrl+8] 영역설정  [Ctrl+9] 번역  [Ctrl+6] 복사"
-                       TextWrapping="Wrap" Foreground="#FFCC00" FontSize="12" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,10" Height="50"/>
+            <TextBlock x:Name="TxtHotkeyGuide"
+                       Text="[Ctrl+7] 이동  [Ctrl+8] 영역  [Ctrl+9] 번역  [Ctrl+0] 자동"
+                       TextWrapping="Wrap"
+                       Foreground="#FFCC00"
+                       FontSize="11"
+                       FontWeight="Bold"
+                       LineHeight="16"
+                       TextAlignment="Center"
+                       HorizontalAlignment="Center"
+                       Margin="0,0,0,6"/>
+
+            <!-- 자동 번역 모드 전환 시 현재 상태를 잠깐 강조 표시합니다. 단축키 안내가 길어져도 전환 상태를 놓치지 않게 분리했습니다. -->
+            <TextBlock x:Name="TxtAutoModeStatus"
+                       TextWrapping="Wrap"
+                       Foreground="#7CFF7C"
+                       FontSize="12"
+                       FontWeight="Bold"
+                       TextAlignment="Center"
+                       HorizontalAlignment="Center"
+                       Margin="0,0,0,8"
+                       Visibility="Collapsed"/>
 
             <!-- API 오류가 발생했을 때 게임 화면을 크게 가리지 않는 짧은 안내만 잠시 표시합니다. 상세 원인은 로그창에 남깁니다. -->
             <TextBlock x:Name="TxtApiStatus"

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -54,6 +54,7 @@ namespace GameTranslator
         // 🌟 [추가] 최상단 강제 유지 타이머
         private DispatcherTimer topmostTimer;
         private DispatcherTimer apiStatusTimer;
+        private DispatcherTimer autoModeStatusTimer;
 
         private AutoTranslateMode autoTranslateMode = AutoTranslateMode.Off;
         private bool isAutoTranslating = false;
@@ -130,6 +131,10 @@ namespace GameTranslator
             apiStatusTimer = new DispatcherTimer();
             apiStatusTimer.Interval = TimeSpan.FromSeconds(7);
             apiStatusTimer.Tick += (s, e) => HideTranslationApiStatus();
+
+            autoModeStatusTimer = new DispatcherTimer();
+            autoModeStatusTimer.Interval = TimeSpan.FromSeconds(2.5);
+            autoModeStatusTimer.Tick += (s, e) => HideAutoModeStatus();
         }
     }
 }


### PR DESCRIPTION
## 작업 내용
- 번역창 상단 단축키 안내 TextBlock의 고정 Height를 제거해 안내 문구가 잘리지 않도록 수정했습니다.
- 단축키 안내를 이름 지정 컨트롤(`TxtHotkeyGuide`)로 직접 갱신하도록 정리했습니다.
- 안내 문구를 2줄 축약 표시로 바꾸고 자동 번역 현재 모드를 같은 줄에 표시했습니다.
- 자동 번역 모드 전환 시 `TxtAutoModeStatus`에 별도 상태 문구를 2.5초 표시하도록 추가했습니다.
- 기존 시각 트리 TextBlock 탐색 기반 갱신 코드를 제거했습니다.

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:EnableWindowsTargeting=true