### PR TITLE
수정: Gemini 서버 오류 안내 문구 개선

### DIFF
--- a/GameChatTranslator.Tests/Core/Translation/TranslationApiErrorDescriberTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationApiErrorDescriberTests.cs
@@ -51,6 +51,21 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void DescribeGeminiTranslateFailure_ExplainsGeminiServerDemandWithoutGoogleApiStatus()
+        {
+            GeminiTranslateApiResult result = GeminiTranslateApiResult.Failed(
+                503,
+                "{\"error\":{\"code\":503,\"message\":\"This model is currently experiencing high demand\",\"status\":\"UNAVAILABLE\"}}");
+
+            string message = _describer.DescribeGeminiTranslateFailure(result, "gemini-2.5-flash");
+
+            Assert.Contains("Gemini 서버가 혼잡", message);
+            Assert.Contains("Google 번역을 사용", message);
+            Assert.Contains("503 / UNAVAILABLE / This model is currently experiencing high demand", message);
+            Assert.DoesNotContain("Google API 상태", message);
+        }
+
+        [Fact]
         public void DescribeGeminiEmptyResponse_IncludesModelAndFallbackHint()
         {
             string message = _describer.DescribeGeminiEmptyResponse("gemini-test");

--- a/GameChatTranslator/Core/TranslationApiErrorDescriber.cs
+++ b/GameChatTranslator/Core/TranslationApiErrorDescriber.cs
@@ -182,7 +182,7 @@ namespace GameTranslator
                 403 => $"{actionName} 권한이 없습니다. API 키 권한, 프로젝트 사용 설정, 결제/지역 제한을 확인해 주세요.",
                 404 => $"{actionName} 대상 모델을 찾지 못했습니다. GeminiModel 설정값을 확인해 주세요.",
                 429 => $"{actionName} 할당량 또는 호출 제한에 걸렸습니다. 잠시 후 다시 시도하거나 API 사용량을 확인해 주세요.",
-                500 or 502 or 503 or 504 => $"{actionName} 서버 오류가 발생했습니다. Google API 상태를 확인하고 잠시 후 다시 시도해 주세요.",
+                500 or 502 or 503 or 504 => $"{actionName} 서버 오류가 발생했습니다. Gemini 서버가 혼잡하거나 일시적으로 응답하지 않습니다. 잠시 후 다시 시도하거나 Google 번역을 사용해 주세요.",
                 null => $"{actionName} 실패 원인을 특정하지 못했습니다. API 키, 모델명, 네트워크 상태를 확인해 주세요.",
                 _ => $"{actionName} 실패가 발생했습니다. HTTP {statusCode.Value} 응답 내용을 확인해 주세요."
             };


### PR DESCRIPTION
## 작업 내용
- Gemini 500/502/503/504 상세 오류 안내에서 잘못된 `Google API 상태` 문구를 제거했습니다.
- Gemini 서버 혼잡/일시 응답 불가 상황임을 명확히 안내하도록 수정했습니다.
- 503 `UNAVAILABLE` 응답에서 `Google API 상태` 문구가 포함되지 않는지 테스트를 추가했습니다.

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:EnableWindowsTargeting=true