### PR TITLE
수정: 숨김 단축키 안내 문구 간격 조정

### DIFF
--- a/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
@@ -154,14 +154,14 @@ namespace GameTranslator
 
             if (!isHotkeyGuideExpanded)
             {
-                TxtHotkeyGuide.Inlines.Add(new Run($"[{guide}] 단축키 안내 ON  "));
+                TxtHotkeyGuide.Inlines.Add(new Run($"[{guide}] 단축키 안내\t\t"));
                 TxtHotkeyGuide.Inlines.Add(new Run("자동: "));
                 TxtHotkeyGuide.Inlines.Add(new Run(GetAutoTranslateModeLabel())
                 {
                     Foreground = isAutoTranslating ? Brushes.Lime : Brushes.Gray,
                     FontWeight = FontWeights.Bold
                 });
-                TxtHotkeyGuide.Inlines.Add(new Run($"  |  번역기: {engineStr}"));
+                TxtHotkeyGuide.Inlines.Add(new Run($"\t\t번역기: {engineStr}"));
                 return;
             }
 


### PR DESCRIPTION
## 작업 내용
- 단축키 안내 숨김 상태에서 `ON` 문구를 제거했습니다.
- 숨김 상태 표시를 `[Ctrl+F10] 단축키 안내    자동: ...    번역기: ...` 형태로 간격을 넓혔습니다.
- 단축키 안내 / 자동 상태 / 번역기가 붙어 보이지 않도록 분리했습니다.

## 검증
- git diff --check HEAD~1 HEAD
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:EnableWindowsTargeting=true