### PR TITLE
수정: 게시 산출물 배포 파일 복사 보강

### DIFF
--- a/GameChatTranslator/GameChatTranslator.csproj
+++ b/GameChatTranslator/GameChatTranslator.csproj
@@ -44,4 +44,13 @@
 	  </None>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <!-- Visual Studio 게시 프로필에서도 배포 보조 파일이 누락되지 않도록 Publish 후 루트 출력 폴더에 한 번 더 복사합니다. -->
+	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/readme.txt" />
+	</ItemGroup>
+
+	<Target Name="CopyDistributionFilesToPublishDirectory" AfterTargets="Publish" Condition="'$(PublishDir)' != ''">
+	  <Copy SourceFiles="@(DistributionPublishFile)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" />
+	</Target>
+
 </Project>


### PR DESCRIPTION
## 작업 내용
- Visual Studio 게시 프로필에서도 Distribution 보조 파일이 누락되지 않도록 Publish 후 복사 타깃을 추가했습니다.
- characters.txt / LangInstall.bat / readme.txt를 게시 폴더 루트에 다시 복사합니다.
- 앱 런타임은 characters.txt를 실행 폴더 루트에서 읽으므로 기존 루트 배치 구조는 유지했습니다.

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:EnableWindowsTargeting=true

## publish 산출물 확인
- GameChatTranslator.exe
- GameChatTranslator.pdb
- LangInstall.bat
- characters.txt
- readme.txt