### PR TITLE
개선: Google 번역 입력 한중일 공백 정리

### DIFF
--- a/GameChatTranslator.Tests/Core/Translation/TranslationPromptBuilderTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationPromptBuilderTests.cs
@@ -15,6 +15,22 @@ namespace GameChatTranslator.Tests
             Assert.Equal("미셸 hello - world", cleaned);
         }
 
+        [Fact]
+        public void CleanGoogleTranslateInput_JoinsEastAsianCharactersSplitByOcrSpaces()
+        {
+            string cleaned = _builder.CleanGoogleTranslateInput("猫 可 愛");
+
+            Assert.Equal("猫可愛", cleaned);
+        }
+
+        [Fact]
+        public void CleanGoogleTranslateInput_KeepsKoreanWordSpaces()
+        {
+            string cleaned = _builder.CleanGoogleTranslateInput("나는 고양이 좋아");
+
+            Assert.Equal("나는 고양이 좋아", cleaned);
+        }
+
         [Theory]
         [InlineData("hello", true)]
         [InlineData("안", true)]

--- a/GameChatTranslator/Core/TranslationPromptBuilder.cs
+++ b/GameChatTranslator/Core/TranslationPromptBuilder.cs
@@ -11,6 +11,7 @@ namespace GameTranslator
     {
         private const string TranslatableLetterPattern = @"[a-zA-Z가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ]";
         private const string SingleCharacterAllowPattern = @"^[가-힣ぁ-んァ-ヶ\u4e00-\u9fa5]$";
+        private const string EastAsianNoSpacePattern = @"(?<=[ぁ-んァ-ヶ一-龥])\s+(?=[ぁ-んァ-ヶ一-龥])";
 
         /// <summary>
         /// Google Translate API에 보내기 전 OCR 노이즈와 불필요한 기호를 제거합니다.
@@ -25,6 +26,7 @@ namespace GameTranslator
             cleaned = Regex.Replace(cleaned, @"[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\.,!\?\-]", "");
             cleaned = Regex.Replace(cleaned, @"([\-\=\.\/_])\1+", "$1");
             cleaned = Regex.Replace(cleaned, @"\s+", " ").Trim();
+            cleaned = Regex.Replace(cleaned, EastAsianNoSpacePattern, "");
             return cleaned;
         }
 


### PR DESCRIPTION
## 작업 내용
- OCR이 한중일 문자를 문자 단위로 띄어쓴 경우 Google 번역 전 붙여서 보냅니다.
- 예: `猫 可 愛` → `猫可愛`
- 한국어 단어 사이 공백은 유지합니다.
- 관련 단위 테스트를 추가했습니다.

## 배경
- Google 번역 입력이 `猫 可 愛`처럼 분리되면 번역하지 않고 원문을 그대로 반환하는 경우가 있었습니다.
- 이 PR은 Google 무료 번역 호출 전에 한자/일본어 문자 사이 공백만 제거해 언어 감지와 번역 가능성을 높입니다.

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:EnableWindowsTargeting=true