### PR TITLE
기능: Local LLM API 클라이언트 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Translation/TranslationApiClientTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationApiClientTests.cs
@@ -116,6 +116,83 @@ namespace GameChatTranslator.Tests
             Assert.Contains("bad model", result.ErrorMessage);
         }
 
+        [Fact]
+        public async Task TranslateWithLocalLlmAsync_PostsOpenAiCompatibleUtf8Request()
+        {
+            var handler = new StubHttpMessageHandler(async request =>
+            {
+                Assert.Equal(HttpMethod.Post, request.Method);
+                Assert.Equal("http://localhost:1234/v1/chat/completions", request.RequestUri.ToString());
+                Assert.Equal("application/json", request.Content.Headers.ContentType.MediaType);
+                Assert.Equal("utf-8", request.Content.Headers.ContentType.CharSet);
+
+                string payload = await request.Content.ReadAsStringAsync();
+                using JsonDocument document = JsonDocument.Parse(payload);
+                JsonElement root = document.RootElement;
+                Assert.Equal("qwen/qwen3.5-9b", root.GetProperty("model").GetString());
+                Assert.Equal(0.1, root.GetProperty("temperature").GetDouble());
+                Assert.Equal(120, root.GetProperty("max_tokens").GetInt32());
+
+                JsonElement messages = root.GetProperty("messages");
+                Assert.Contains("/no_think", messages[0].GetProperty("content").GetString());
+                Assert.Contains("Korean", messages[0].GetProperty("content").GetString());
+                Assert.Contains("猫可愛 0", messages[1].GetProperty("content").GetString());
+
+                return JsonResponse("{\"choices\":[{\"message\":{\"content\":\"고양이는 귀여워요.\"},\"finish_reason\":\"stop\"}]}");
+            });
+            TranslationApiClient client = CreateClient(handler);
+
+            LocalLlmTranslateApiResult result = await client.TranslateWithLocalLlmAsync(
+                "猫 可 愛 0",
+                "ko",
+                "http://localhost:1234/v1/chat/completions",
+                "qwen/qwen3.5-9b",
+                0.1,
+                120);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("고양이는 귀여워요.", result.Text);
+            Assert.Equal(1, handler.CallCount);
+        }
+
+        [Fact]
+        public async Task TranslateWithLocalLlmAsync_SkipsNonTranslatableContent()
+        {
+            var handler = new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP 호출이 없어야 합니다."));
+            TranslationApiClient client = CreateClient(handler);
+
+            LocalLlmTranslateApiResult result = await client.TranslateWithLocalLlmAsync(
+                "123 !!!",
+                "ko",
+                "http://localhost:1234/v1/chat/completions",
+                "qwen/qwen3.5-9b",
+                0.1,
+                120);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("", result.Text);
+            Assert.Equal(0, handler.CallCount);
+        }
+
+        [Fact]
+        public async Task TranslateWithLocalLlmAsync_ReturnsHttpFailure()
+        {
+            var handler = new StubHttpMessageHandler(_ => Task.FromResult(JsonResponse("{\"error\":\"server down\"}", HttpStatusCode.ServiceUnavailable)));
+            TranslationApiClient client = CreateClient(handler);
+
+            LocalLlmTranslateApiResult result = await client.TranslateWithLocalLlmAsync(
+                "hello",
+                "ko",
+                "http://localhost:1234/v1/chat/completions",
+                "qwen/qwen3.5-9b",
+                0.1,
+                120);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(503, result.StatusCode);
+            Assert.Contains("server down", result.ErrorMessage);
+        }
+
         private static TranslationApiClient CreateClient(HttpMessageHandler handler)
         {
             return new TranslationApiClient(

--- a/GameChatTranslator.Tests/Core/Translation/TranslationPromptBuilderTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationPromptBuilderTests.cs
@@ -97,5 +97,23 @@ namespace GameChatTranslator.Tests
             Assert.Contains("伽好", prompt);
             Assert.Contains("Output ONLY the translation", prompt);
         }
+
+        [Fact]
+        public void BuildLocalLlmSystemPrompt_DisablesThinkingAndTargetsLanguage()
+        {
+            string prompt = _builder.BuildLocalLlmSystemPrompt("ko");
+
+            Assert.Contains("/no_think", prompt);
+            Assert.Contains("Korean", prompt);
+            Assert.Contains("Return only", prompt);
+        }
+
+        [Fact]
+        public void BuildLocalLlmUserPrompt_CleansOcrSpacing()
+        {
+            string prompt = _builder.BuildLocalLlmUserPrompt("猫 可 愛 0");
+
+            Assert.Equal("/no_think Input: 猫可愛 0", prompt);
+        }
     }
 }

--- a/GameChatTranslator.Tests/Core/Translation/TranslationResultParserTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationResultParserTests.cs
@@ -37,6 +37,26 @@ namespace GameChatTranslator.Tests
             Assert.Equal("번역 결과", result);
         }
 
+        [Fact]
+        public void ParseOpenAiChatCompletionResponse_ExtractsMessageContent()
+        {
+            string json = "{\"choices\":[{\"message\":{\"content\":\"고양이는 귀여워요.\"},\"finish_reason\":\"stop\"}]}";
+
+            string result = _parser.ParseOpenAiChatCompletionResponse(json);
+
+            Assert.Equal("고양이는 귀여워요.", result);
+        }
+
+        [Fact]
+        public void ParseOpenAiChatCompletionResponse_RemovesThinkBlock()
+        {
+            string json = "{\"choices\":[{\"message\":{\"content\":\"<think>reasoning</think>고양이는 귀여워요.\"}}]}";
+
+            string result = _parser.ParseOpenAiChatCompletionResponse(json);
+
+            Assert.Equal("고양이는 귀여워요.", result);
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData(null)]

--- a/GameChatTranslator/Core/TranslationApiClient.cs
+++ b/GameChatTranslator/Core/TranslationApiClient.cs
@@ -138,6 +138,59 @@ namespace GameTranslator
             return GeminiTranslateApiResult.Succeeded(parsedText);
         }
 
+        /// <summary>
+        /// LM Studio/OpenAI 호환 chat completions 엔드포인트를 1회 호출합니다.
+        /// <paramref name="endpoint"/>는 예: http://localhost:1234/v1/chat/completions,
+        /// <paramref name="modelName"/>은 LM Studio에서 로드된 모델 ID입니다.
+        /// </summary>
+        public async Task<LocalLlmTranslateApiResult> TranslateWithLocalLlmAsync(
+            string text,
+            string targetLanguageCode,
+            string endpoint,
+            string modelName,
+            double temperature,
+            int maxTokens)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return LocalLlmTranslateApiResult.Succeeded("");
+            if (string.IsNullOrWhiteSpace(endpoint)) return LocalLlmTranslateApiResult.Failed(null, "Local LLM endpoint가 비어 있습니다.");
+            if (string.IsNullOrWhiteSpace(modelName)) return LocalLlmTranslateApiResult.Failed(null, "Local LLM model이 비어 있습니다.");
+
+            string cleaned = _promptBuilder.CleanGoogleTranslateInput(text);
+            if (!_promptBuilder.HasTranslatableContent(cleaned)) return LocalLlmTranslateApiResult.Succeeded("");
+
+            string userPrompt = _promptBuilder.BuildLocalLlmUserPrompt(text);
+
+            var requestBody = new
+            {
+                model = modelName,
+                messages = new[]
+                {
+                    new { role = "system", content = _promptBuilder.BuildLocalLlmSystemPrompt(targetLanguageCode) },
+                    new { role = "user", content = userPrompt }
+                },
+                temperature,
+                max_tokens = maxTokens
+            };
+
+            string jsonPayload = JsonSerializer.Serialize(requestBody);
+            using var content = new ByteArrayContent(Encoding.UTF8.GetBytes(jsonPayload));
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json")
+            {
+                CharSet = "utf-8"
+            };
+
+            using HttpResponseMessage response = await _httpClient.PostAsync(endpoint, content);
+            string responseJson = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return LocalLlmTranslateApiResult.Failed((int)response.StatusCode, responseJson);
+            }
+
+            string parsedText = _resultParser.ParseOpenAiChatCompletionResponse(responseJson);
+            return LocalLlmTranslateApiResult.Succeeded(parsedText);
+        }
+
         private static string ReadGeminiModelName(JsonElement modelElement)
         {
             if (!modelElement.TryGetProperty("name", out JsonElement nameElement)) return "";
@@ -203,6 +256,36 @@ namespace GameTranslator
         public static GeminiTranslateApiResult Failed(int? statusCode, string errorMessage)
         {
             return new GeminiTranslateApiResult(false, "", statusCode, errorMessage);
+        }
+    }
+
+    /// <summary>
+    /// Local LLM 번역 API 호출 결과입니다.
+    /// IsSuccess가 false이면 StatusCode/ErrorMessage를 로그에 남기고 Google fallback을 시도할 수 있습니다.
+    /// </summary>
+    public sealed class LocalLlmTranslateApiResult
+    {
+        private LocalLlmTranslateApiResult(bool isSuccess, string text, int? statusCode, string errorMessage)
+        {
+            IsSuccess = isSuccess;
+            Text = text ?? "";
+            StatusCode = statusCode;
+            ErrorMessage = errorMessage ?? "";
+        }
+
+        public bool IsSuccess { get; }
+        public string Text { get; }
+        public int? StatusCode { get; }
+        public string ErrorMessage { get; }
+
+        public static LocalLlmTranslateApiResult Succeeded(string text)
+        {
+            return new LocalLlmTranslateApiResult(true, text, null, "");
+        }
+
+        public static LocalLlmTranslateApiResult Failed(int? statusCode, string errorMessage)
+        {
+            return new LocalLlmTranslateApiResult(false, "", statusCode, errorMessage);
         }
     }
 }

--- a/GameChatTranslator/Core/TranslationPromptBuilder.cs
+++ b/GameChatTranslator/Core/TranslationPromptBuilder.cs
@@ -114,5 +114,28 @@ namespace GameTranslator
                    "3. If the text is just a name or nonsense, return an empty string. " +
                    "Output ONLY the translation: \n\n" + (text ?? "");
         }
+
+        /// <summary>
+        /// LM Studio/OpenAI 호환 로컬 LLM에 전달할 system 프롬프트를 생성합니다.
+        /// Qwen 계열 reasoning 모델이 내부 추론 토큰을 소모하지 않도록 /no_think를 포함합니다.
+        /// </summary>
+        public string BuildLocalLlmSystemPrompt(string targetLanguageCode)
+        {
+            string targetLanguage = GetGeminiTargetLanguageName(targetLanguageCode);
+            return "/no_think You are a game chat translator. " +
+                   "The input text may contain OCR mistakes from a game chat overlay. " +
+                   "Restore the intended sentence and translate it naturally into " + targetLanguage + ". " +
+                   "Return only the translated sentence. Do not explain. Do not think step by step.";
+        }
+
+        /// <summary>
+        /// 로컬 LLM에 전달할 user 프롬프트를 생성합니다.
+        /// Google 입력 정리와 같은 OCR 노이즈 정리를 적용해 한중일 문자 사이 불필요한 공백을 줄입니다.
+        /// </summary>
+        public string BuildLocalLlmUserPrompt(string text)
+        {
+            string cleaned = CleanGoogleTranslateInput(text);
+            return "/no_think Input: " + cleaned;
+        }
     }
 }

--- a/GameChatTranslator/Core/TranslationResultParser.cs
+++ b/GameChatTranslator/Core/TranslationResultParser.cs
@@ -72,5 +72,48 @@ namespace GameTranslator
                 return "";
             }
         }
+
+        /// <summary>
+        /// LM Studio/OpenAI 호환 chat completions 응답에서 choices[0].message.content를 추출합니다.
+        /// 응답 구조가 예상과 다르면 빈 문자열을 반환합니다.
+        /// </summary>
+        public string ParseOpenAiChatCompletionResponse(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return "";
+
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(json);
+                JsonElement choices = document.RootElement.GetProperty("choices");
+                if (choices.ValueKind != JsonValueKind.Array || choices.GetArrayLength() == 0) return "";
+
+                JsonElement message = choices[0].GetProperty("message");
+                if (!message.TryGetProperty("content", out JsonElement contentElement)) return "";
+                if (contentElement.ValueKind != JsonValueKind.String) return "";
+
+                return RemoveThinkingBlock(contentElement.GetString() ?? "").Trim();
+            }
+            catch
+            {
+                return "";
+            }
+        }
+
+        private static string RemoveThinkingBlock(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return "";
+
+            const string openTag = "<think>";
+            const string closeTag = "</think>";
+            int openIndex = text.IndexOf(openTag, StringComparison.OrdinalIgnoreCase);
+            int closeIndex = text.IndexOf(closeTag, StringComparison.OrdinalIgnoreCase);
+
+            if (openIndex >= 0 && closeIndex >= openIndex)
+            {
+                return text.Remove(openIndex, closeIndex + closeTag.Length - openIndex);
+            }
+
+            return text;
+        }
     }
 }


### PR DESCRIPTION
## 작업 내용
- LM Studio/OpenAI 호환 chat completions 호출부를 추가했습니다.
- `/no_think` 기반 Local LLM system/user 프롬프트를 추가했습니다.
- UTF-8 byte body로 요청을 전송합니다.
- choices[0].message.content 파서와 `<think>...</think>` 제거 로직을 추가했습니다.
- Local LLM 호출 결과 모델을 추가했습니다.
- API 클라이언트/프롬프트/파서 단위 테스트를 보강했습니다.

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet test GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true --no-build --no-restore
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:EnableWindowsTargeting=true

## 참고
- 이 PR은 A 통합 브랜치 대상 중간 PR입니다. 아직 UI/번역 흐름에는 연결하지 않았습니다.