### PR TITLE
수정: Velopack 릴리즈 자산 경로 보정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,18 +174,21 @@ jobs:
             --skipVeloAppCheck `
             --noPortable
 
-          $setup = Join-Path $env:VELOPACK_DIR "$($env:VELOPACK_PACK_ID)-Setup.exe"
-          $full = Join-Path $env:VELOPACK_DIR "$($env:VELOPACK_PACK_ID)-$($env:APP_VERSION)-full.nupkg"
-          $delta = Join-Path $env:VELOPACK_DIR "$($env:VELOPACK_PACK_ID)-$($env:APP_VERSION)-delta.nupkg"
+          $setupItem = Get-ChildItem -Path $env:VELOPACK_DIR -Filter "*-Setup.exe" | Sort-Object Name | Select-Object -First 1
+          $fullItem = Get-ChildItem -Path $env:VELOPACK_DIR -Filter "*-$($env:APP_VERSION)-full.nupkg" | Sort-Object Name | Select-Object -First 1
+          $deltaItem = Get-ChildItem -Path $env:VELOPACK_DIR -Filter "*-$($env:APP_VERSION)-delta.nupkg" | Sort-Object Name | Select-Object -First 1
+          $setup = $setupItem?.FullName
+          $full = $fullItem?.FullName
+          $delta = $deltaItem?.FullName
           $releasesJson = Join-Path $env:VELOPACK_DIR "releases.win.json"
           $legacyReleases = Join-Path $env:VELOPACK_DIR "RELEASES"
           $assetsJson = Join-Path $env:VELOPACK_DIR "assets.win.json"
 
-          if (-not (Test-Path $setup)) {
+          if ([string]::IsNullOrWhiteSpace($setup) -or -not (Test-Path $setup)) {
             throw "Velopack Setup.exe was not generated."
           }
 
-          if (-not (Test-Path $full)) {
+          if ([string]::IsNullOrWhiteSpace($full) -or -not (Test-Path $full)) {
             throw "Velopack full package was not generated."
           }
 


### PR DESCRIPTION
## 배경
- `v.1.0.24-alpha` Release Build run `24697233190` 이 `Build Velopack installer assets` 단계에서 실패했습니다.
- 로그 확인 결과 `vpk pack` 자체와 setup package build 는 성공했지만, workflow가 Setup.exe 파일명을 정확히 가정하면서 `Velopack Setup.exe was not generated.` 예외를 던졌습니다.

## 수정 내용
- `Build Velopack installer assets` 단계의 자산 검출 로직 수정
- Setup.exe: `*-Setup.exe` wildcard로 실제 생성 파일 탐색
- full / delta nupkg: 현재 `APP_VERSION` 기준 wildcard 탐색
- null/빈 경로 방어 추가

## 검증
- `git diff --check`
- `python3`로 `.github/workflows/release.yml` YAML 파싱 확인
- 실패 로그 재확인: `run 24697233190` 에서 `vpk pack` / `Building setup package` 까지 성공한 뒤 파일 검출에서만 실패함을 확인

## 후속 조치
- 이 PR 머지 후 `Release Build` workflow를 **workflow_dispatch**로 재실행하고
  `tag = v.1.0.24-alpha` 를 넣어 Setup.exe / nupkg / releases.win.json 업로드를 다시 확인하면 됩니다.
