### PR TITLE
수정: Velopack 자산 재귀 탐색 보완

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,15 +174,18 @@ jobs:
             --skipVeloAppCheck `
             --noPortable
 
-          $setupItem = Get-ChildItem -Path $env:VELOPACK_DIR -Filter "*-Setup.exe" | Sort-Object Name | Select-Object -First 1
-          $fullItem = Get-ChildItem -Path $env:VELOPACK_DIR -Filter "*-$($env:APP_VERSION)-full.nupkg" | Sort-Object Name | Select-Object -First 1
-          $deltaItem = Get-ChildItem -Path $env:VELOPACK_DIR -Filter "*-$($env:APP_VERSION)-delta.nupkg" | Sort-Object Name | Select-Object -First 1
+          $setupItem = Get-ChildItem -Path $env:VELOPACK_DIR -Recurse -File -Filter "*-Setup.exe" | Sort-Object FullName | Select-Object -First 1
+          $fullItem = Get-ChildItem -Path $env:VELOPACK_DIR -Recurse -File -Filter "*-$($env:APP_VERSION)-full.nupkg" | Sort-Object FullName | Select-Object -First 1
+          $deltaItem = Get-ChildItem -Path $env:VELOPACK_DIR -Recurse -File -Filter "*-$($env:APP_VERSION)-delta.nupkg" | Sort-Object FullName | Select-Object -First 1
           $setup = $setupItem?.FullName
           $full = $fullItem?.FullName
           $delta = $deltaItem?.FullName
-          $releasesJson = Join-Path $env:VELOPACK_DIR "releases.win.json"
-          $legacyReleases = Join-Path $env:VELOPACK_DIR "RELEASES"
-          $assetsJson = Join-Path $env:VELOPACK_DIR "assets.win.json"
+          $releasesJsonItem = Get-ChildItem -Path $env:VELOPACK_DIR -Recurse -File -Filter "releases.win.json" | Sort-Object FullName | Select-Object -First 1
+          $legacyReleasesItem = Get-ChildItem -Path $env:VELOPACK_DIR -Recurse -File -Filter "RELEASES" | Sort-Object FullName | Select-Object -First 1
+          $assetsJsonItem = Get-ChildItem -Path $env:VELOPACK_DIR -Recurse -File -Filter "assets.win.json" | Sort-Object FullName | Select-Object -First 1
+          $releasesJson = $releasesJsonItem?.FullName
+          $legacyReleases = $legacyReleasesItem?.FullName
+          $assetsJson = $assetsJsonItem?.FullName
 
           if ([string]::IsNullOrWhiteSpace($setup) -or -not (Test-Path $setup)) {
             throw "Velopack Setup.exe was not generated."
@@ -193,7 +196,7 @@ jobs:
           }
 
           foreach ($requiredFile in @($releasesJson, $legacyReleases, $assetsJson)) {
-            if (-not (Test-Path $requiredFile)) {
+            if ([string]::IsNullOrWhiteSpace($requiredFile) -or -not (Test-Path $requiredFile)) {
               throw "Required Velopack artifact missing: $requiredFile"
             }
           }
@@ -306,5 +309,5 @@ jobs:
           path: |
             artifacts/dist/*.zip
             artifacts/dist/sha256.txt
-            artifacts/velopack/*
+            artifacts/velopack/**/*
           if-no-files-found: error


### PR DESCRIPTION
## 배경
- `v.1.0.24-alpha` Release Build workflow_dispatch run `24697614333` 가 다시 `Build Velopack installer assets` 단계에서 실패했습니다.
- 공식 Velopack 문서 기준으로 산출물은 `outputDir` 하위 `Releases/` 구조에 위치할 수 있습니다.
- 이전 수정은 파일명 wildcard만 반영했고, 하위 폴더 탐색은 하지 않아 Setup.exe를 찾지 못했습니다.

## 수정 내용
- Velopack 자산 탐색을 `Get-ChildItem -Recurse -File` 기반으로 변경
- 대상: `*-Setup.exe`, `*-full.nupkg`, `*-delta.nupkg`, `releases.win.json`, `RELEASES`, `assets.win.json`
- upload-artifact 경로도 `artifacts/velopack/**/*` 로 변경
- required file 검사에 null/빈값 방어 유지

## 검증
- `git diff --check`
- `python3`로 `.github/workflows/release.yml` YAML 파싱 확인
- 실패 로그 재확인
  - run `24697233190`: setup package build 성공 후 산출물 검출 실패
  - run `24697614333`: setup package build 성공 후 산출물 검출 실패

## 후속 조치
- 이 PR 머지 후 `Release Build`를 다시 workflow_dispatch로 실행
- `tag = v.1.0.24-alpha`
- Setup.exe / nupkg / releases.win.json / ZIP / sha256 업로드 여부 재확인
