### PR TITLE
수정: 언어팩 설치 배치파일 Confirm 인자 제거

### DIFF
--- a/GameChatTranslator/Distribution/LangInstall.bat
+++ b/GameChatTranslator/Distribution/LangInstall.bat
@@ -111,7 +111,21 @@ exit /b 0
 :InstallLanguage
 echo.
 echo [Install] %~1 (%~2)
-powershell -NoProfile -ExecutionPolicy Bypass -Command "try { Install-Language -Language '%~2' -Confirm:$false -ErrorAction Stop; exit 0 } catch { Write-Host $_.Exception.Message; exit 1 }"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$lang = '%~2';" ^
+  "$installed = $false;" ^
+  "try {" ^
+  "  Install-Language -Language $lang -ErrorAction Stop | Out-Null;" ^
+  "} catch {" ^
+  "  Write-Host $_.Exception.Message;" ^
+  "}" ^
+  "try {" ^
+  "  $installed = @(Get-InstalledLanguage | Where-Object { $_.Language -eq $lang }).Count -gt 0;" ^
+  "} catch {" ^
+  "  Write-Host $_.Exception.Message;" ^
+  "  exit 1;" ^
+  "}" ^
+  "if ($installed) { exit 0 } else { exit 1 }"
 if errorlevel 1 (
     echo [FAIL] %~1 (%~2)
     set "FAILED=Y"


### PR DESCRIPTION
## 요약
- LangInstall.bat의 Install-Language 호출에서 호환되지 않는 -Confirm 인자 제거
- 설치 시도 후 Get-InstalledLanguage로 실제 설치 여부를 다시 확인하도록 변경
- 실패 메시지는 유지하되, 최종 성공/실패 판단을 설치 상태 기준으로 통일

## 검증
- git diff --check
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet restore GameChatTranslator/GameChatTranslator.csproj -r win-x64 -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-langinstall
