### PR TITLE
수정: 언어팩 배치 출력과 입력기 정리 보강

### DIFF
--- a/GameChatTranslator/Distribution/LangInstall.bat
+++ b/GameChatTranslator/Distribution/LangInstall.bat
@@ -83,7 +83,12 @@ set /p "CLEAN_INPUTS=Keep only Korean and English keyboard inputs? (Y/N): "
 if /i "!CLEAN_INPUTS!"=="Y" (
     echo.
     echo Cleaning keyboard input language list...
-    powershell -NoProfile -ExecutionPolicy Bypass -Command "$list = Get-WinUserLanguageList; $list = $list | Where-Object { $_.LanguageTag -match 'ko-KR|en-US' }; Set-WinUserLanguageList -LanguageList $list -Force"
+    powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+      "$list = New-WinUserLanguageList 'ko-KR';" ^
+      "if (@($list | Where-Object { $_.LanguageTag -eq 'en-US' }).Count -eq 0) {" ^
+      "  $list.Add((New-WinUserLanguageList 'en-US')[0]);" ^
+      "}" ^
+      "Set-WinUserLanguageList -LanguageList $list -Force"
     if errorlevel 1 (
         echo [WARN] Failed to clean keyboard input language list.
     ) else (
@@ -111,6 +116,7 @@ exit /b 0
 :InstallLanguage
 echo.
 echo [Install] %~1 (%~2)
+set "INSTALL_RESULT=[OK]"
 powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "$lang = '%~2';" ^
   "$installed = $false;" ^
@@ -127,9 +133,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "}" ^
   "if ($installed) { exit 0 } else { exit 1 }"
 if errorlevel 1 (
-    echo [FAIL] %~1 (%~2)
     set "FAILED=Y"
-) else (
-    echo [OK] %~1 (%~2)
+    set "INSTALL_RESULT=[FAIL]"
 )
+echo !INSTALL_RESULT! %~1 (%~2)
 exit /b 0


### PR DESCRIPTION
## 요약
- LangInstall.bat 설치 결과 출력 중복 문제 정리
- 한국어/영어 입력기 정리 단계 null 오류 제거

## 원인
- 설치 결과를 `if (...)` 블록 안에서 `echo ... (en-US)` 형태로 출력하면서 CMD 괄호 파싱이 꼬여 `[FAIL]` 뒤에 `[OK]`가 이어질 수 있었음
- 입력기 정리 단계는 현재 사용자 언어 목록을 필터링해 비어 있는 배열을 `Set-WinUserLanguageList`에 넘겨 null 오류가 발생할 수 있었음

## 반영
- 설치 결과를 변수로 결정한 뒤 블록 밖에서 한 번만 출력
- 입력기 정리 시 `ko-KR` + `en-US` 목표 목록을 직접 생성해 적용

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet restore GameChatTranslator/GameChatTranslator.csproj -r win-x64 -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-langinstall-fix2`
