### PR TITLE
수정: 언어팩 배치 입력기를 한글만 유지

### DIFF
--- a/GameChatTranslator/Distribution/LangInstall.bat
+++ b/GameChatTranslator/Distribution/LangInstall.bat
@@ -75,24 +75,21 @@ if /i "!FAILED!"=="Y" (
 echo ===================================================
 echo.
 echo Installing OCR language packs can also add keyboard input methods.
-echo You can optionally keep only Korean and English input methods.
+echo You can optionally keep only the Korean keyboard input method.
 echo OCR recognition languages remain installed even if extra keyboard inputs are removed.
 echo.
 set "CLEAN_INPUTS="
-set /p "CLEAN_INPUTS=Keep only Korean and English keyboard inputs? (Y/N): "
+set /p "CLEAN_INPUTS=Keep only the Korean keyboard input method? (Y/N): "
 if /i "!CLEAN_INPUTS!"=="Y" (
     echo.
     echo Cleaning keyboard input language list...
     powershell -NoProfile -ExecutionPolicy Bypass -Command ^
       "$list = New-WinUserLanguageList 'ko-KR';" ^
-      "if (@($list | Where-Object { $_.LanguageTag -eq 'en-US' }).Count -eq 0) {" ^
-      "  $list.Add((New-WinUserLanguageList 'en-US')[0]);" ^
-      "}" ^
       "Set-WinUserLanguageList -LanguageList $list -Force"
     if errorlevel 1 (
         echo [WARN] Failed to clean keyboard input language list.
     ) else (
-        echo [OK] Keyboard input language list was limited to Korean and English.
+        echo [OK] Keyboard input language list was limited to Korean only.
     )
 ) else (
     echo Keyboard input language list was not changed.


### PR DESCRIPTION
## 요약
- 언어팩 설치 후 키보드 입력기를 한글만 남기도록 변경
- 안내 문구도 실제 동작과 맞게 정리

## 원인
- 기존 배치파일은 입력기 정리 단계에서 `ko-KR` 목록을 만든 뒤 `en-US`를 다시 추가하고 있었음
- 그래서 Win+Space 입력기 전환 목록에 영어가 계속 남았음

## 반영
- `Set-WinUserLanguageList` 대상 목록을 `ko-KR` 단일 목록으로 변경
- 안내 문구를 `Korean only` 기준으로 수정

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet restore GameChatTranslator/GameChatTranslator.csproj -r win-x64 -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-langinstall-korean-only`
