### PR TITLE
수정: 언어팩 설치를 OCR capability 기준으로 변경

### DIFF
--- a/GameChatTranslator/Distribution/LangInstall.bat
+++ b/GameChatTranslator/Distribution/LangInstall.bat
@@ -116,14 +116,24 @@ echo [Install] %~1 (%~2)
 set "INSTALL_RESULT=[OK]"
 powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "$lang = '%~2';" ^
+  "$capabilityName = 'Language.OCR~~~' + $lang + '~0.0.1.0';" ^
   "$installed = $false;" ^
   "try {" ^
-  "  Install-Language -Language $lang -ErrorAction Stop | Out-Null;" ^
+  "  $capability = Get-WindowsCapability -Online | Where-Object { $_.Name -eq $capabilityName } | Select-Object -First 1;" ^
+  "  if ($null -eq $capability) {" ^
+  "    Write-Host ('OCR capability not found: ' + $capabilityName);" ^
+  "    exit 1;" ^
+  "  }" ^
+  "  if ($capability.State -ne 'Installed') {" ^
+  "    Add-WindowsCapability -Online -Name $capability.Name -ErrorAction Stop | Out-Null;" ^
+  "  }" ^
   "} catch {" ^
   "  Write-Host $_.Exception.Message;" ^
   "}" ^
   "try {" ^
-  "  $installed = @(Get-InstalledLanguage | Where-Object { $_.Language -eq $lang }).Count -gt 0;" ^
+  "  $installed = @(" ^
+  "    Get-WindowsCapability -Online | Where-Object { $_.Name -eq $capabilityName -and $_.State -eq 'Installed' }" ^
+  "  ).Count -gt 0;" ^
   "} catch {" ^
   "  Write-Host $_.Exception.Message;" ^
   "  exit 1;" ^


### PR DESCRIPTION
## 요약
- LangInstall.bat를 `Install-Language` 기반에서 OCR capability 직접 설치 방식으로 변경
- 설치 성공 여부도 `Get-WindowsCapability` 기준으로 확인

## 원인
- 기존 배치파일은 언어 설치 상태(`Install-Language`, `Get-InstalledLanguage`)를 기준으로 보고 있었음
- 앱은 `OcrEngine.TryCreateFromLanguage()`로 OCR 엔진 생성 가능 여부를 기준으로 상태를 표시함
- 그래서 배치에서는 정상처럼 보이는데 앱에서는 `en-US 미설치`로 보일 수 있었음

## 반영
- `Language.OCR~~~<lang>~0.0.1.0` capability를 직접 조회
- 미설치 상태면 `Add-WindowsCapability -Online -Name ...`으로 설치
- 설치 결과 확인도 `Get-WindowsCapability -Online`의 `State=Installed` 기준으로 통일

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet restore GameChatTranslator/GameChatTranslator.csproj -r win-x64 -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-capability`
