### PR TITLE
개선: OCR 언어팩 상태 진단 분리 표시

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrLanguageStatusFormatterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrLanguageStatusFormatterTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class OcrLanguageStatusFormatterTests
+    {
+        private readonly OcrLanguageStatusFormatter _formatter = new OcrLanguageStatusFormatter();
+
+        [Theory]
+        [InlineData("ko", "ko-KR")]
+        [InlineData("en-US", "en-US")]
+        [InlineData("zh-Hans-CN", "zh-CN")]
+        [InlineData("ja", "ja-JP")]
+        [InlineData("ru", "ru-RU")]
+        [InlineData("custom-tag", "custom-tag")]
+        public void GetCapabilityLanguageTag_MapsAppTagsToCapabilityTags(string appLanguageTag, string expected)
+        {
+            Assert.Equal(expected, _formatter.GetCapabilityLanguageTag(appLanguageTag));
+        }
+
+        [Theory]
+        [InlineData("Installed", "설치됨(Installed)")]
+        [InlineData("NotPresent", "미설치(NotPresent)")]
+        [InlineData("Removed", "미설치(Removed)")]
+        [InlineData("InstallPending", "설치 후 재시작 대기(InstallPending)")]
+        [InlineData("Unknown", "확인 실패")]
+        [InlineData("CustomState", "CustomState")]
+        public void FormatCapabilityState_MapsKnownStates(string state, string expected)
+        {
+            Assert.Equal(expected, _formatter.FormatCapabilityState(state));
+        }
+
+        [Fact]
+        public void BuildLine_InstalledButEngineMissing_IncludesRebootHint()
+        {
+            OcrLanguageStatusEntry entry = _formatter.CreateEntry("영어", "en-US", "Installed", false);
+
+            string line = _formatter.BuildLine(entry);
+
+            Assert.Contains("WARN", line);
+            Assert.Contains("capability: 설치됨(Installed)", line);
+            Assert.Contains("OCR 엔진: 미감지", line);
+            Assert.Contains("재부팅 필요 가능", line);
+        }
+
+        [Fact]
+        public void BuildLine_NotInstalled_DoesNotIncludeRebootHint()
+        {
+            OcrLanguageStatusEntry entry = _formatter.CreateEntry("일본어", "ja", "NotPresent", false);
+
+            string line = _formatter.BuildLine(entry);
+
+            Assert.Contains("NO", line);
+            Assert.Contains("capability: 미설치(NotPresent)", line);
+            Assert.DoesNotContain("재부팅 필요 가능", line);
+        }
+
+        [Fact]
+        public void BuildDisplayText_AddsGlobalRebootHintWhenNeeded()
+        {
+            var entries = new List<OcrLanguageStatusEntry>
+            {
+                _formatter.CreateEntry("영어", "en-US", "Installed", false),
+                _formatter.CreateEntry("일본어", "ja", "Installed", true)
+            };
+
+            string text = _formatter.BuildDisplayText(entries);
+
+            Assert.Contains("영어 (en-US)", text);
+            Assert.Contains("일본어 (ja)", text);
+            Assert.Contains("안내: capability는 설치됐지만 OCR 엔진이 아직 생성되지 않은 언어가 있습니다.", text);
+        }
+
+        [Fact]
+        public void BuildDisplayText_ReturnsFallbackWhenEntriesAreEmpty()
+        {
+            Assert.Equal("OCR 언어팩 상태 확인 실패", _formatter.BuildDisplayText(new List<OcrLanguageStatusEntry>()));
+        }
+    }
+}

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="../GameChatTranslator/Core/ChatTextAnalyzer.cs" Link="Core/ChatTextAnalyzer.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrMaskProcessor.cs" Link="Core/OcrMaskProcessor.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrPerformanceReport.cs" Link="Core/OcrPerformanceReport.cs" />
+    <Compile Include="../GameChatTranslator/Core/OcrLanguageStatusFormatter.cs" Link="Core/OcrLanguageStatusFormatter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
     <Compile Include="../GameChatTranslator/Models/OcrDiagnosticModels.cs" Link="Models/OcrDiagnosticModels.cs" />

--- a/GameChatTranslator/Core/OcrLanguageStatusFormatter.cs
+++ b/GameChatTranslator/Core/OcrLanguageStatusFormatter.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GameTranslator
+{
+    public sealed class OcrLanguageStatusEntry
+    {
+        public OcrLanguageStatusEntry(string label, string appLanguageTag, string capabilityLanguageTag, string capabilityState, bool engineAvailable)
+        {
+            Label = label ?? "";
+            AppLanguageTag = appLanguageTag ?? "";
+            CapabilityLanguageTag = capabilityLanguageTag ?? "";
+            CapabilityState = string.IsNullOrWhiteSpace(capabilityState) ? "Unknown" : capabilityState.Trim();
+            EngineAvailable = engineAvailable;
+        }
+
+        public string Label { get; }
+        public string AppLanguageTag { get; }
+        public string CapabilityLanguageTag { get; }
+        public string CapabilityState { get; }
+        public bool EngineAvailable { get; }
+
+        public bool IsCapabilityInstalled =>
+            string.Equals(CapabilityState, "Installed", StringComparison.OrdinalIgnoreCase);
+
+        public bool NeedsRebootHint => IsCapabilityInstalled && !EngineAvailable;
+    }
+
+    public sealed class OcrLanguageStatusFormatter
+    {
+        public string GetCapabilityLanguageTag(string appLanguageTag)
+        {
+            return (appLanguageTag ?? "").Trim() switch
+            {
+                "ko" => "ko-KR",
+                "en-US" => "en-US",
+                "zh-Hans-CN" => "zh-CN",
+                "ja" => "ja-JP",
+                "ru" => "ru-RU",
+                _ => (appLanguageTag ?? "").Trim()
+            };
+        }
+
+        public OcrLanguageStatusEntry CreateEntry(string label, string appLanguageTag, string capabilityState, bool engineAvailable)
+        {
+            return new OcrLanguageStatusEntry(
+                label,
+                appLanguageTag,
+                GetCapabilityLanguageTag(appLanguageTag),
+                capabilityState,
+                engineAvailable);
+        }
+
+        public string BuildDisplayText(IEnumerable<OcrLanguageStatusEntry> entries)
+        {
+            List<OcrLanguageStatusEntry> items = entries?.ToList() ?? new List<OcrLanguageStatusEntry>();
+            if (items.Count == 0)
+            {
+                return "OCR 언어팩 상태 확인 실패";
+            }
+
+            List<string> lines = items.Select(BuildLine).ToList();
+            if (items.Any(item => item.NeedsRebootHint))
+            {
+                lines.Add("");
+                lines.Add("안내: capability는 설치됐지만 OCR 엔진이 아직 생성되지 않은 언어가 있습니다. 재부팅 후 다시 확인하세요.");
+            }
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        public string BuildLine(OcrLanguageStatusEntry entry)
+        {
+            string marker = entry.EngineAvailable
+                ? "OK"
+                : entry.IsCapabilityInstalled ? "WARN" : "NO";
+
+            string line = $"{marker}  {entry.Label} ({entry.AppLanguageTag}) - capability: {FormatCapabilityState(entry.CapabilityState)} / OCR 엔진: {(entry.EngineAvailable ? "사용 가능" : "미감지")}";
+            if (entry.NeedsRebootHint)
+            {
+                line += " / 재부팅 필요 가능";
+            }
+
+            return line;
+        }
+
+        public string FormatCapabilityState(string capabilityState)
+        {
+            string state = string.IsNullOrWhiteSpace(capabilityState) ? "Unknown" : capabilityState.Trim();
+            return state switch
+            {
+                "Installed" => "설치됨(Installed)",
+                "NotPresent" => "미설치(NotPresent)",
+                "Removed" => "미설치(Removed)",
+                "InstallPending" => "설치 후 재시작 대기(InstallPending)",
+                "Staged" => "설치 준비됨(Staged)",
+                "Unknown" => "확인 실패",
+                _ => state
+            };
+        }
+    }
+}

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -230,10 +230,10 @@
                         </StackPanel>
                     </GroupBox>
 
-                    <!-- OCR 언어팩 상태: Windows OCR 엔진 생성 가능 여부를 보여줍니다. -->
+                    <!-- OCR 언어팩 상태: capability 설치 여부와 OCR 엔진 생성 가능 여부를 함께 보여줍니다. -->
                     <GroupBox Header="OCR 언어팩 설치 상태" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
                         <StackPanel Margin="10">
-                            <TextBlock Text="Windows OCR 엔진이 감지한 언어팩 상태입니다. 미설치 언어는 LangInstall.bat를 관리자 권한으로 실행한 뒤 재부팅하세요."
+                            <TextBlock Text="Windows capability 설치 여부와 현재 세션의 OCR 엔진 생성 가능 여부를 함께 표시합니다. capability는 설치됐는데 엔진이 미감지면 재부팅이 필요할 수 있습니다."
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,8"
                                        Foreground="#CCC"/>

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Http;
+using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
@@ -20,6 +24,7 @@ namespace GameTranslator
         // 환경설정 파일(config.ini)을 읽고 쓰기 위한 객체
         private IniFile _ini;
         private readonly SettingsService _settingsService = new SettingsService();
+        private readonly OcrLanguageStatusFormatter _ocrLanguageStatusFormatter = new OcrLanguageStatusFormatter();
 
         private static readonly (string Label, string Tag)[] OcrLanguageStatusTargets =
         {
@@ -186,23 +191,23 @@ namespace GameTranslator
         }
 
         /// <summary>
-        /// Windows OCR 엔진을 언어별로 생성해 설치 상태를 UI에 표시합니다.
-        /// 설치된 언어는 OcrEngine.TryCreateFromLanguage가 null이 아닌 값을 반환합니다.
+        /// Windows OCR capability 설치 여부와 OCR 엔진 생성 가능 여부를 언어별로 나눠 표시합니다.
+        /// capability는 설치됐는데 엔진이 안 만들어지면 재부팅 필요 가능성을 함께 안내합니다.
         /// </summary>
         private void RefreshOcrLanguageStatus()
         {
             if (TxtOcrLanguageStatus == null) return;
 
-            var lines = new System.Collections.Generic.List<string>();
+            Dictionary<string, string> capabilityStates = GetOcrCapabilityStates();
+            var entries = new List<OcrLanguageStatusEntry>();
             foreach ((string label, string tag) in OcrLanguageStatusTargets)
             {
-                bool installed = IsOcrLanguageInstalled(tag);
-                string marker = installed ? "OK" : "NO";
-                string status = installed ? "설치됨" : "미설치";
-                lines.Add($"{marker}  {label,-8} ({tag}) : {status}");
+                capabilityStates.TryGetValue(tag, out string capabilityState);
+                bool engineAvailable = IsOcrLanguageEngineAvailable(tag);
+                entries.Add(_ocrLanguageStatusFormatter.CreateEntry(label, tag, capabilityState, engineAvailable));
             }
 
-            TxtOcrLanguageStatus.Text = string.Join(System.Environment.NewLine, lines);
+            TxtOcrLanguageStatus.Text = _ocrLanguageStatusFormatter.BuildDisplayText(entries);
         }
 
         /// <summary>
@@ -220,10 +225,96 @@ namespace GameTranslator
         }
 
         /// <summary>
-        /// 지정한 Windows OCR 언어팩이 현재 OS에서 사용 가능한지 확인합니다.
-        /// <paramref name="languageTag"/>는 ko, en-US, zh-Hans-CN, ja, ru 같은 Windows 언어 태그입니다.
+        /// PowerShell의 Get-WindowsCapability 결과를 이용해 OCR capability 설치 상태를 읽습니다.
+        /// 반환 키는 앱 언어 태그(ko, en-US, zh-Hans-CN, ja, ru)이며 값은 Installed/NotPresent/Unknown 같은 상태 문자열입니다.
         /// </summary>
-        private bool IsOcrLanguageInstalled(string languageTag)
+        private Dictionary<string, string> GetOcrCapabilityStates()
+        {
+            var states = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                StringBuilder script = new StringBuilder();
+                script.AppendLine("$targets = @{}");
+                foreach ((string _, string tag) in OcrLanguageStatusTargets)
+                {
+                    string escapedTag = EscapePowerShellSingleQuotedString(tag);
+                    string capabilityTag = EscapePowerShellSingleQuotedString(_ocrLanguageStatusFormatter.GetCapabilityLanguageTag(tag));
+                    script.AppendLine($"$targets['{escapedTag}'] = 'Language.OCR~~~{capabilityTag}~0.0.1.0'");
+                }
+
+                script.AppendLine("$result = @{}");
+                script.AppendLine("try {");
+                script.AppendLine("  $capabilities = Get-WindowsCapability -Online");
+                script.AppendLine("  foreach ($key in $targets.Keys) {");
+                script.AppendLine("    $cap = $capabilities | Where-Object { $_.Name -eq $targets[$key] } | Select-Object -First 1");
+                script.AppendLine("    if ($null -eq $cap) { $result[$key] = 'Unknown' } else { $result[$key] = [string]$cap.State }");
+                script.AppendLine("  }");
+                script.AppendLine("  $result | ConvertTo-Json -Compress");
+                script.AppendLine("} catch {");
+                script.AppendLine("  '{}' ");
+                script.AppendLine("}");
+
+                ProcessStartInfo startInfo = new ProcessStartInfo
+                {
+                    FileName = "powershell",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+                startInfo.ArgumentList.Add("-NoProfile");
+                startInfo.ArgumentList.Add("-NonInteractive");
+                startInfo.ArgumentList.Add("-ExecutionPolicy");
+                startInfo.ArgumentList.Add("Bypass");
+                startInfo.ArgumentList.Add("-Command");
+                startInfo.ArgumentList.Add(script.ToString());
+
+                using (Process process = Process.Start(startInfo))
+                {
+                    if (process == null)
+                    {
+                        return states;
+                    }
+
+                    if (!process.WaitForExit(8000))
+                    {
+                        try { process.Kill(); } catch { }
+                        return states;
+                    }
+
+                    string output = process.StandardOutput.ReadToEnd().Trim();
+                    if (string.IsNullOrWhiteSpace(output))
+                    {
+                        return states;
+                    }
+
+                    using (JsonDocument document = JsonDocument.Parse(output))
+                    {
+                        if (document.RootElement.ValueKind != JsonValueKind.Object)
+                        {
+                            return states;
+                        }
+
+                        foreach (JsonProperty property in document.RootElement.EnumerateObject())
+                        {
+                            states[property.Name] = property.Value.GetString();
+                        }
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return states;
+        }
+
+        /// <summary>
+        /// 지정한 Windows OCR 언어로 실제 OcrEngine이 생성 가능한지 확인합니다.
+        /// capability 설치 여부와 별개로 현재 세션에서 엔진 생성이 가능한지를 보여주기 위해 따로 확인합니다.
+        /// </summary>
+        private bool IsOcrLanguageEngineAvailable(string languageTag)
         {
             try
             {
@@ -233,6 +324,11 @@ namespace GameTranslator
             {
                 return false;
             }
+        }
+
+        private static string EscapePowerShellSingleQuotedString(string value)
+        {
+            return (value ?? "").Replace("'", "''");
         }
 
         /// <summary>


### PR DESCRIPTION
## 요약
- OCR 언어팩 상태를 capability 설치 여부와 OCR 엔진 생성 가능 여부로 분리 표시
- capability가 Installed인데 엔진이 미감지인 경우 재부팅 필요 가능 안내 추가
- 앱 언어 태그(ko / ja / zh-Hans-CN 등)와 Windows capability 태그(ko-KR / ja-JP / zh-CN 등) 매핑 helper 추가
- 상태 표시 formatting 로직 테스트 추가

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-status`
