### PR TITLE
개선: ETC 번역 전처리와 언어 자동 감지 강화

### DIFF
--- a/GameChatTranslator.Tests/Core/Translation/TranslationPromptBuilderTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationPromptBuilderTests.cs
@@ -115,5 +115,40 @@ namespace GameChatTranslator.Tests
 
             Assert.Equal("/no_think Input: 猫可愛 0", prompt);
         }
+
+        [Fact]
+        public void CleanEtcOcrLine_RemovesAsciiNoiseFromMixedEastAsianToken()
+        {
+            string cleaned = _builder.CleanEtcOcrLine("CØ猫` 可愛< 황&`?");
+
+            Assert.Equal("猫可愛 황", cleaned);
+        }
+
+        [Fact]
+        public void CleanEtcOcrLine_PreservesPureEnglishText()
+        {
+            string cleaned = _builder.CleanEtcOcrLine("hello brave world");
+
+            Assert.Equal("hello brave world", cleaned);
+        }
+
+        [Fact]
+        public void CleanEtcOcrLine_DropsMeaninglessBrokenNoise()
+        {
+            string cleaned = _builder.CleanEtcOcrLine("乞5U(私(z構ote.ntOØ?");
+
+            Assert.Equal("", cleaned);
+        }
+
+        [Theory]
+        [InlineData("猫可愛 황", true)]
+        [InlineData("고양이", true)]
+        [InlineData("a", false)]
+        [InlineData("猫", false)]
+        [InlineData("", false)]
+        public void HasMeaningfulEtcContent_AppliesEtcRules(string text, bool expected)
+        {
+            Assert.Equal(expected, _builder.HasMeaningfulEtcContent(text));
+        }
     }
 }

--- a/GameChatTranslator/Core/TranslationPromptBuilder.cs
+++ b/GameChatTranslator/Core/TranslationPromptBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace GameTranslator
@@ -10,6 +11,7 @@ namespace GameTranslator
     public sealed class TranslationPromptBuilder
     {
         private const string TranslatableLetterPattern = @"[a-zA-Z가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ]";
+        private const string NonAsciiReadablePattern = @"[가-힣ぁ-んァ-ヶ一-龥а-яА-ЯёЁ]";
         private const string SingleCharacterAllowPattern = @"^[가-힣ぁ-んァ-ヶ\u4e00-\u9fa5]$";
         private const string EastAsianNoSpacePattern = @"(?<=[ぁ-んァ-ヶ一-龥])\s+(?=[ぁ-んァ-ヶ一-龥])";
 
@@ -28,6 +30,61 @@ namespace GameTranslator
             cleaned = Regex.Replace(cleaned, @"\s+", " ").Trim();
             cleaned = Regex.Replace(cleaned, EastAsianNoSpacePattern, "");
             return cleaned;
+        }
+
+        /// <summary>
+        /// ETC 모드에서 OCR 한 줄을 번역기에 넘기기 전 정리합니다.
+        /// 동아시아 문자와 ASCII/숫자가 섞인 토큰은 ASCII/숫자 노이즈를 제거하고,
+        /// 순수 영어 문장은 가능한 한 유지합니다.
+        /// 의미 있는 문자 구성이 남지 않으면 빈 문자열을 반환합니다.
+        /// </summary>
+        public string CleanEtcOcrLine(string text)
+        {
+            string source = text ?? "";
+            string cleaned = source;
+            cleaned = Regex.Replace(cleaned, @"\d{1,2}:\d{2}", " ");
+            cleaned = Regex.Replace(cleaned, @"[\[\]\(\)\{\}\<\>]", " ");
+            cleaned = Regex.Replace(cleaned, @"[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\.,!\?\-]", " ");
+            cleaned = Regex.Replace(cleaned, @"([\-\=\.\/_])\1+", "$1");
+
+            bool containsNonAsciiReadable = Regex.IsMatch(cleaned, NonAsciiReadablePattern);
+
+            string[] normalizedTokens = Regex
+                .Split(cleaned, @"\s+")
+                .Select(token => NormalizeEtcToken(token, containsNonAsciiReadable))
+                .Where(token => !string.IsNullOrWhiteSpace(token))
+                .ToArray();
+
+            cleaned = string.Join(" ", normalizedTokens);
+            cleaned = Regex.Replace(cleaned, @"\s+", " ").Trim();
+            cleaned = Regex.Replace(cleaned, EastAsianNoSpacePattern, "");
+
+            if (ShouldDiscardEtcLineAsTooNoisy(source))
+            {
+                return "";
+            }
+
+            return HasMeaningfulEtcContent(cleaned) ? cleaned : "";
+        }
+
+        /// <summary>
+        /// ETC 정리 후 남은 문자열이 실제 번역 대상으로 볼 만한지 확인합니다.
+        /// 동아시아/키릴 문자가 섞인 줄은 한 글자만 남으면 노이즈로 보고 제외합니다.
+        /// </summary>
+        public bool HasMeaningfulEtcContent(string cleanedText)
+        {
+            string text = (cleanedText ?? "").Trim();
+            if (!HasTranslatableContent(text))
+            {
+                return false;
+            }
+
+            if (Regex.IsMatch(text, NonAsciiReadablePattern))
+            {
+                return Regex.Matches(text, TranslatableLetterPattern).Count >= 2;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -136,6 +193,57 @@ namespace GameTranslator
         {
             string cleaned = CleanGoogleTranslateInput(text);
             return "/no_think Input: " + cleaned;
+        }
+
+        private string NormalizeEtcToken(string token, bool containsNonAsciiReadable)
+        {
+            string normalized = (token ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                return "";
+            }
+
+            if (containsNonAsciiReadable &&
+                Regex.IsMatch(normalized, NonAsciiReadablePattern) &&
+                Regex.IsMatch(normalized, @"[a-zA-Z0-9]"))
+            {
+                normalized = Regex.Replace(normalized, @"[a-zA-Z0-9]", "");
+            }
+
+            normalized = Regex.Replace(normalized, @"^[\.\,\!\?\-]+|[\.\,\!\?\-]+$", "");
+
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                return "";
+            }
+
+            if (containsNonAsciiReadable)
+            {
+                if (Regex.IsMatch(normalized, @"^[a-zA-Z]$")) return "";
+                if (Regex.IsMatch(normalized, @"^\d$")) return "";
+            }
+
+            if (!Regex.IsMatch(normalized, TranslatableLetterPattern) &&
+                !Regex.IsMatch(normalized, @"^\d{2,}$"))
+            {
+                return "";
+            }
+
+            return normalized;
+        }
+
+        private bool ShouldDiscardEtcLineAsTooNoisy(string source)
+        {
+            string text = source ?? "";
+            int nonAsciiReadableCount = Regex.Matches(text, NonAsciiReadablePattern).Count;
+            if (nonAsciiReadableCount == 0)
+            {
+                return false;
+            }
+
+            int asciiLetterCount = Regex.Matches(text, @"[a-zA-Z]").Count;
+            int noiseCount = Regex.Matches(text, @"[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\.,!\?\-]").Count;
+            return asciiLetterCount > nonAsciiReadableCount && noiseCount >= 3;
         }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -460,7 +460,7 @@ namespace GameTranslator
                             continue;
                         }
 
-                        TranslationDecisionResult translationResult = await TranslateFinalContentAsync(finalContent, performanceStats);
+                        TranslationDecisionResult translationResult = await TranslateFinalContentAsync(finalContent, performanceStats, contentMode);
 
                         AppendLog(characterNameGold + finalContent, translationResult.TranslatedText, translationResult.EngineName);
 
@@ -499,7 +499,7 @@ namespace GameTranslator
                 return;
             }
 
-            TranslationDecisionResult translationResult = await TranslateFinalContentAsync(finalContent, performanceStats);
+            TranslationDecisionResult translationResult = await TranslateFinalContentAsync(finalContent, performanceStats, TranslationContentMode.Etc);
 
             AppendLog("[ETC]: " + finalContent, translationResult.TranslatedText, translationResult.EngineName);
             AddTranslationResultToDisplay("[ETC]: ", translationResult.TranslatedText);
@@ -515,7 +515,8 @@ namespace GameTranslator
             var lines = (mergedLines ?? Enumerable.Empty<OcrLine>())
                 .Select(line => line?.Text?.Trim() ?? "")
                 .Where(text => !string.IsNullOrWhiteSpace(text))
-                .Where(ChatTextAnalyzer.ContainsReadableLetter);
+                .Select(text => translationPromptBuilder.CleanEtcOcrLine(text))
+                .Where(translationPromptBuilder.HasMeaningfulEtcContent);
 
             return string.Join(Environment.NewLine, lines);
         }
@@ -561,12 +562,13 @@ namespace GameTranslator
         /// 현재 선택된 번역 엔진 정책에 따라 Google/Gemini/Local LLM 호출을 수행하고 최종 결과를 반환합니다.
         /// API 호출 시간은 OCR 성능 로그의 Translate 구간에 누적합니다.
         /// </summary>
-        private async Task<TranslationDecisionResult> TranslateFinalContentAsync(string finalContent, OcrPerformanceStats performanceStats)
+        private async Task<TranslationDecisionResult> TranslateFinalContentAsync(string finalContent, OcrPerformanceStats performanceStats, TranslationContentMode contentMode)
         {
             string geminiKey = ReadGeminiKey();
             bool willUseGemini = currentTranslationEngineMode == TranslationEngineMode.Gemini &&
                 !string.IsNullOrWhiteSpace(geminiKey);
             bool willUseLocalLlm = currentTranslationEngineMode == TranslationEngineMode.LocalLlm;
+            string googleSourceLanguage = contentMode == TranslationContentMode.Etc ? "auto" : gameLang;
 
             TranslationPlan translationPlan = translationService.CreatePlan(
                 finalContent,
@@ -595,7 +597,7 @@ namespace GameTranslator
                 }
 
                 translateStopwatch.Restart();
-                string googleFallback = await CallGoogleAPI(finalContent, gameLang, targetLang);
+                string googleFallback = await CallGoogleAPI(finalContent, googleSourceLanguage, targetLang);
                 translateStopwatch.Stop();
                 performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
                 return translationService.ResolveGoogleAttempt(googleFallback, true).FinalResult;
@@ -616,14 +618,14 @@ namespace GameTranslator
                 }
 
                 translateStopwatch.Restart();
-                string googleFallback = await CallGoogleAPI(finalContent, gameLang, targetLang);
+                string googleFallback = await CallGoogleAPI(finalContent, googleSourceLanguage, targetLang);
                 translateStopwatch.Stop();
                 performanceStats.TranslateMs += translateStopwatch.ElapsedMilliseconds;
                 return translationService.ResolveGoogleAttempt(googleFallback, true, "Local LLM").FinalResult;
             }
 
             Stopwatch googleStopwatch = Stopwatch.StartNew();
-            string googleTranslated = await CallGoogleAPI(finalContent, gameLang, targetLang);
+            string googleTranslated = await CallGoogleAPI(finalContent, googleSourceLanguage, targetLang);
             googleStopwatch.Stop();
             performanceStats.TranslateMs += googleStopwatch.ElapsedMilliseconds;
             return translationService.ResolveGoogleAttempt(googleTranslated, false).FinalResult;

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -182,7 +182,7 @@
 
                     <GroupBox Header="언어 설정 (Language)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
                         <StackPanel Margin="10">
-                            <TextBlock Text="게임 언어 (채팅 인식 기준):" Margin="0,0,0,5" Foreground="#CCC"/>
+                            <TextBlock x:Name="TxtGameLangLabel" Text="게임 언어 (채팅 인식 기준):" Margin="0,0,0,5" Foreground="#CCC"/>
                             <ComboBox x:Name="ComboGameLang" Margin="0,0,0,10" Background="#333" Foreground="Black">
                                 <ComboBoxItem Content="한국어" Tag="ko"/>
                                 <ComboBoxItem Content="영어" Tag="en-US"/>
@@ -190,6 +190,12 @@
                                 <ComboBoxItem Content="일본어" Tag="ja"/>
                                 <ComboBoxItem Content="러시아어" Tag="ru"/>
                             </ComboBox>
+                            <TextBlock x:Name="TxtGameLangModeHint"
+                                       Text=""
+                                       Margin="0,0,0,10"
+                                       Foreground="#AFAFAF"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"/>
 
                             <TextBlock Text="번역 언어 (결과 언어):" Margin="0,0,0,5" Foreground="#CCC"/>
                             <ComboBox x:Name="ComboTargetLang" Background="#333" Foreground="Black">
@@ -209,7 +215,8 @@
                                          Tag="Strinova"
                                          Foreground="#CCC"
                                          IsChecked="True"
-                                         Margin="0,0,0,4"/>
+                                         Margin="0,0,0,4"
+                                         Checked="TranslationContentMode_Checked"/>
                             <TextBlock Text="[캐릭터이름]: 채팅 형식과 characters.txt 캐릭터명 검증을 통과한 채팅만 번역합니다."
                                        TextWrapping="Wrap"
                                        FontSize="11"
@@ -219,7 +226,8 @@
                                          Content="ETC"
                                          Tag="ETC"
                                          Foreground="#CCC"
-                                         Margin="0,0,0,4"/>
+                                         Margin="0,0,0,4"
+                                         Checked="TranslationContentMode_Checked"/>
                             <TextBlock Text="채팅 포맷과 무관하게 OCR로 읽은 전체 내용을 하나의 문장 묶음으로 번역합니다."
                                        TextWrapping="Wrap"
                                        FontSize="11"

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -177,6 +177,7 @@ namespace GameTranslator
 
             RadioTranslationContentEtc.IsChecked = contentMode == TranslationContentMode.Etc;
             RadioTranslationContentStrinova.IsChecked = contentMode != TranslationContentMode.Etc;
+            UpdateGameLanguageControlState(contentMode);
         }
 
         /// <summary>
@@ -185,6 +186,46 @@ namespace GameTranslator
         private string GetSelectedTranslationContentModeTag()
         {
             return _settingsService.GetTranslationContentModeTag(
+                RadioTranslationContentEtc?.IsChecked == true
+                    ? TranslationContentMode.Etc
+                    : TranslationContentMode.Strinova);
+        }
+
+        /// <summary>
+        /// ETC 모드에서는 번역 source 언어를 자동 감지하므로 게임 언어 선택을 비활성화해
+        /// 현재 설정이 실제로 사용되지 않는다는 점을 UI에서 명확히 보여줍니다.
+        /// </summary>
+        private void UpdateGameLanguageControlState(TranslationContentMode contentMode)
+        {
+            bool isEtcMode = contentMode == TranslationContentMode.Etc;
+
+            if (ComboGameLang != null)
+            {
+                ComboGameLang.IsEnabled = !isEtcMode;
+                ComboGameLang.Opacity = isEtcMode ? 0.6 : 1.0;
+                ComboGameLang.ToolTip = isEtcMode
+                    ? "ETC 모드에서는 원문 언어를 자동 감지하므로 이 설정을 사용하지 않습니다."
+                    : "게임 채팅 인식 기준 언어입니다.";
+            }
+
+            if (TxtGameLangLabel != null)
+            {
+                TxtGameLangLabel.Foreground = isEtcMode
+                    ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(150, 150, 150))
+                    : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(204, 204, 204));
+            }
+
+            if (TxtGameLangModeHint != null)
+            {
+                TxtGameLangModeHint.Text = isEtcMode
+                    ? "ETC 모드에서는 게임 언어를 source로 강제하지 않고 자동 감지합니다. 번역 결과 언어만 사용됩니다."
+                    : "Strinova 모드에서는 게임 언어를 source 언어로 사용합니다.";
+            }
+        }
+
+        private void TranslationContentMode_Checked(object sender, RoutedEventArgs e)
+        {
+            UpdateGameLanguageControlState(
                 RadioTranslationContentEtc?.IsChecked == true
                     ? TranslationContentMode.Etc
                     : TranslationContentMode.Strinova);


### PR DESCRIPTION
## 요약
- ETC 모드 전용 OCR 텍스트 전처리 강화
- ETC 모드의 Google source language를 `gameLang` 고정 대신 `auto` 감지로 변경
- ETC 모드에서는 환경설정창에서 게임 언어 선택을 비활성화하고 자동 감지 안내 표시

## 처리 기준
- 번역 전 ETC 한 줄을 별도로 정리
- 동아시아/키릴 문자와 ASCII/숫자가 섞인 토큰은 ASCII/숫자 노이즈 제거
- 정리 후 번역 가능한 문자가 없으면 제외
- 동아시아/키릴이 포함된 줄은 정리 후 읽을 수 있는 문자가 2개 미만이면 제외
- 원본 기준으로 `비동아시아 ASCII 문자가 더 많고`, `노이즈 문자가 3개 이상`인 혼합 깨짐 줄은 통째로 제외
- 순수 영어 줄은 최대한 보존

## 엔진별 동작
- Strinova 모드: 기존과 동일, 게임 언어를 source로 사용
- ETC + Google: source language를 `auto` 사용
- ETC + Gemini / Local LLM: 원래 source language 파라미터를 쓰지 않으므로 동작 구조 변화 없음

## 검증
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-etc-hardening`

## 연결 이슈
- Closes #102
