### PR TITLE
개선: 설치 경로 UX 보강

### DIFF
--- a/GameChatTranslator/Distribution/readme.txt
+++ b/GameChatTranslator/Distribution/readme.txt
@@ -7,7 +7,7 @@
 Google 무료 번역, Gemini AI 번역, Local LLM 번역을 사용해 한국어 등 원하는 언어로 표시하는 도구입니다.
 
 릴리즈 페이지에 GameChatTranslator-win-Setup.exe 설치형 파일이 함께 제공되는 버전에서는
-해당 설치형 파일 사용을 권장합니다. 설치 경로를 직접 지정하려면 `GameChatTranslator-win-Setup.exe --installto <경로>` 형식으로 실행하세요.
+해당 설치형 파일 사용을 권장합니다. 설치 경로를 직접 지정하려면 `GameChatTranslator-win-Setup.exe --installto D:\Apps\GameChatTranslator` 형식으로 실행하세요.
 현재 압축을 풀어 보고 있는 이 ZIP은 수동 실행용 배포본입니다.
 설치형으로 설치한 경우 이후 업데이트는 프로그램 안에서 바로 다운로드/설치/재시작할 수 있습니다.
 
@@ -27,7 +27,7 @@ OCR로 읽은 전체 텍스트를 하나의 번역 대상으로 보냅니다. St
 
 - GameChatTranslator-win-Setup.exe
   릴리즈 페이지에 별도로 제공되는 설치형 배포 파일입니다.
-  명령줄에서는 `--installto <경로>` 옵션으로 설치 경로를 지정할 수 있습니다.
+  명령줄에서는 `GameChatTranslator-win-Setup.exe --installto D:\Apps\GameChatTranslator` 형식으로 설치 경로를 지정할 수 있습니다.
   ZIP 내부에는 포함되지 않으며, 릴리즈 페이지에서 직접 실행합니다.
   설치 시 프로그램 파일은 %LocalAppData%\\GameChatTranslator\\current 에 배치됩니다.
 
@@ -67,7 +67,8 @@ OCR로 읽은 전체 텍스트를 하나의 번역 대상으로 보냅니다. St
   첫 실행 시 새 위치로 자동 복사됩니다.
 
 - 현재 실행 경로 확인
-  환경설정창의 업데이트 영역에서 현재 실행 중인 EXE 경로를 확인할 수 있습니다.
+  환경설정창의 업데이트 영역에서 현재 실행 중인 EXE 경로를 확인하고,
+  경로 복사와 현재 폴더 열기를 바로 사용할 수 있습니다.
 
 ------------------------------------------
 2. 필수 사전 설정

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Update.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Update.cs
@@ -380,33 +380,46 @@ namespace GameTranslator
         /// 현재 실행 중인 앱의 설치/실행 경로를 사용자에게 보여줄 문자열로 반환합니다.
         /// 설치형이면 Velopack current 폴더 경로를, ZIP 직접 실행이면 현재 EXE 폴더 경로를 표시합니다.
         /// </summary>
-        internal string GetInstallLocationDisplayText()
+        internal string GetInstallLocationPath()
         {
-            string baseDirectory;
-
             try
             {
-                baseDirectory = Path.GetFullPath(AppContext.BaseDirectory)
+                return Path.GetFullPath(AppContext.BaseDirectory)
                     .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             }
             catch
             {
-                baseDirectory = AppContext.BaseDirectory ?? "";
+                return (AppContext.BaseDirectory ?? "").TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             }
+        }
 
+        /// <summary>
+        /// 현재 실행 중인 앱이 Velopack 설치형 환경인지 판단합니다.
+        /// 설치형이면 인앱 업데이트 가능 여부와 실행 경로 표시 문구가 함께 설치형 기준으로 바뀝니다.
+        /// </summary>
+        internal bool IsInstalledExecution()
+        {
             try
             {
                 UpdateManager updateManager = CreateUpdateManager();
-                if (CanUseVelopackDirectUpdate(updateManager))
-                {
-                    return $"설치형 실행 경로: {baseDirectory}";
-                }
+                return CanUseVelopackDirectUpdate(updateManager);
             }
             catch
             {
+                return false;
             }
+        }
 
-            return $"직접 실행 경로: {baseDirectory}";
+        /// <summary>
+        /// 현재 실행 중인 앱의 설치/실행 경로를 사용자에게 보여줄 문자열로 반환합니다.
+        /// 설치형이면 Velopack current 폴더 경로를, ZIP 직접 실행이면 현재 EXE 폴더 경로를 표시합니다.
+        /// </summary>
+        internal string GetInstallLocationDisplayText()
+        {
+            string baseDirectory = GetInstallLocationPath();
+            return IsInstalledExecution()
+                ? $"설치형 실행 경로: {baseDirectory}"
+                : $"직접 실행 경로: {baseDirectory}";
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -154,7 +154,36 @@
                                        Foreground="#E6E6E6"
                                        FontFamily="Consolas"
                                        Margin="0,0,0,6"/>
-                            <TextBlock Text="Setup.exe는 one-click 설치이며, 설치 경로를 직접 지정하려면 명령줄에서 --installto 옵션을 사용하세요."
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                <Button x:Name="BtnOpenInstallFolder"
+                                        Content="현재 폴더 열기"
+                                        Padding="8,2"
+                                        Margin="0,0,8,0"
+                                        Background="#444"
+                                        Foreground="White"
+                                        BorderThickness="0"
+                                        Cursor="Hand"
+                                        Click="BtnOpenInstallFolder_Click"/>
+                                <Button x:Name="BtnCopyInstallPath"
+                                        Content="경로 복사"
+                                        Padding="8,2"
+                                        Background="#444"
+                                        Foreground="White"
+                                        BorderThickness="0"
+                                        Cursor="Hand"
+                                        Click="BtnCopyInstallPath_Click"/>
+                            </StackPanel>
+                            <TextBlock Text="설치 경로 지정 예시"
+                                       Foreground="#8FE388"
+                                       FontWeight="Bold"
+                                       Margin="0,0,0,4"/>
+                            <TextBlock Text="GameChatTranslator-win-Setup.exe --installto D:\Apps\GameChatTranslator"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,6"
+                                       Foreground="#E6E6E6"
+                                       FontFamily="Consolas"
+                                       FontSize="11"/>
+                            <TextBlock Text="Setup.exe는 one-click 설치입니다. 설치 경로를 직접 지정하려면 명령줄에서 --installto 옵션을 사용하세요."
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,8"
                                        Foreground="#AFAFAF"

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -267,6 +267,18 @@ namespace GameTranslator
         }
 
         /// <summary>
+        /// 업데이트 영역 상태 문구를 지정한 색상과 함께 갱신합니다.
+        /// 경로 복사/폴더 열기/업데이트 확인 버튼이 같은 하단 상태 줄을 공유합니다.
+        /// </summary>
+        private void SetUpdateStatusText(string text, System.Windows.Media.Brush brush)
+        {
+            if (TxtUpdateStatus == null) return;
+
+            TxtUpdateStatus.Foreground = brush;
+            TxtUpdateStatus.Text = text ?? "";
+        }
+
+        /// <summary>
         /// PowerShell의 Get-WindowsCapability 결과를 이용해 OCR capability 설치 상태를 읽습니다.
         /// 반환 키는 앱 언어 태그(ko, en-US, zh-Hans-CN, ja, ru)이며 값은 Installed/NotPresent/Unknown 같은 상태 문자열입니다.
         /// </summary>
@@ -547,15 +559,73 @@ namespace GameTranslator
         private async void BtnCheckUpdate_Click(object sender, RoutedEventArgs e)
         {
             BtnCheckUpdate.IsEnabled = false;
-            TxtUpdateStatus.Text = "확인 중...";
+            SetUpdateStatusText("확인 중...", System.Windows.Media.Brushes.LightGray);
 
             try
             {
-                await _mainWindow.RunManualUpdateCheckAsync(this, status => TxtUpdateStatus.Text = status);
+                await _mainWindow.RunManualUpdateCheckAsync(this, status => SetUpdateStatusText(status, System.Windows.Media.Brushes.LightGray));
             }
             finally
             {
             BtnCheckUpdate.IsEnabled = true;
+            }
+        }
+
+        /// <summary>
+        /// 현재 실행 중인 EXE 폴더를 탐색기로 엽니다.
+        /// 설치형이면 설치 폴더, ZIP 실행이면 압축을 푼 현재 실행 폴더가 열립니다.
+        /// </summary>
+        private void BtnOpenInstallFolder_Click(object sender, RoutedEventArgs e)
+        {
+            string folderPath = _mainWindow?.GetInstallLocationPath();
+            if (string.IsNullOrWhiteSpace(folderPath) || !System.IO.Directory.Exists(folderPath))
+            {
+                SetUpdateStatusText("폴더를 찾지 못했습니다.", System.Windows.Media.Brushes.OrangeRed);
+                System.Windows.MessageBox.Show("현재 실행 폴더를 찾지 못했습니다.", "현재 폴더 열기", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    UseShellExecute = true
+                };
+                startInfo.ArgumentList.Add(folderPath);
+                Process.Start(startInfo);
+                SetUpdateStatusText("현재 실행 폴더를 열었습니다.", System.Windows.Media.Brushes.LightGreen);
+            }
+            catch (Exception ex)
+            {
+                SetUpdateStatusText("폴더 열기 실패", System.Windows.Media.Brushes.OrangeRed);
+                System.Windows.MessageBox.Show($"현재 폴더를 열지 못했습니다.\n{ex.Message}", "현재 폴더 열기", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        /// <summary>
+        /// 현재 실행 중인 EXE 폴더 경로를 클립보드에 복사합니다.
+        /// 사용자는 탐색기 주소창이나 Setup.exe --installto 경로 입력에 그대로 붙여넣을 수 있습니다.
+        /// </summary>
+        private void BtnCopyInstallPath_Click(object sender, RoutedEventArgs e)
+        {
+            string folderPath = _mainWindow?.GetInstallLocationPath();
+            if (string.IsNullOrWhiteSpace(folderPath))
+            {
+                SetUpdateStatusText("경로 확인 실패", System.Windows.Media.Brushes.OrangeRed);
+                System.Windows.MessageBox.Show("현재 실행 경로를 확인하지 못했습니다.", "경로 복사", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            try
+            {
+                System.Windows.Clipboard.SetText(folderPath);
+                SetUpdateStatusText("실행 경로를 복사했습니다.", System.Windows.Media.Brushes.LightGreen);
+            }
+            catch (Exception ex)
+            {
+                SetUpdateStatusText("경로 복사 실패", System.Windows.Media.Brushes.OrangeRed);
+                System.Windows.MessageBox.Show($"실행 경로를 복사하지 못했습니다.\n{ex.Message}", "경로 복사", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ https://github.com/SeoArin9142/GameChatTranslator/releases
 권장 배포 방식:
 
 - 릴리즈 페이지에 `GameChatTranslator-win-Setup.exe`가 있으면 설치형 배포를 우선 사용합니다.
-- 설치 경로를 직접 지정하려면 `GameChatTranslator-win-Setup.exe --installto <경로>` 형식으로 실행합니다.
+- 설치 경로를 직접 지정하려면 `GameChatTranslator-win-Setup.exe --installto D:\Apps\GameChatTranslator` 형식으로 실행합니다.
 - 설치형으로 설치한 경우 이후 업데이트는 앱 안에서 바로 다운로드/설치/재시작할 수 있습니다.
 - ZIP 파일은 수동 실행/백업용으로 사용할 수 있습니다.
 
 ## 빠른 시작
 
 1. 릴리즈 페이지에 `GameChatTranslator-win-Setup.exe`가 있으면 먼저 실행해 설치합니다.
-   - `Setup.exe`를 명령줄로 실행하는 경우 `--installto <경로>` 옵션으로 경로를 지정할 수 있습니다.
+   - `Setup.exe`를 명령줄로 실행하는 경우 `GameChatTranslator-win-Setup.exe --installto D:\Apps\GameChatTranslator` 형식으로 경로를 지정할 수 있습니다.
    - 설치형 배포가 아직 없거나 수동 실행이 필요하면 ZIP 파일을 내려받아 압축을 풉니다.
    - 설치형으로 설치한 경우 이후 업데이트 확인 시 새 버전을 앱에서 바로 적용할 수 있습니다.
 2. `LangInstall.bat`를 **관리자 권한**으로 실행해 필요한 Windows OCR 언어팩을 설치합니다.
@@ -199,7 +199,7 @@ qwen/qwen3.5-9b
 - 이후 설정 변경, 로그 기록, 디버그 캡처 저장은 모두 `%LocalAppData%\GameChatTranslator` 아래를 사용합니다.
 - `characters.txt`를 직접 수정해 쓰는 경우에는 사용자 데이터 폴더 쪽 파일을 수정하면 됩니다.
 - 설치형 Velopack 배포는 `%LocalAppData%\GameChatTranslator\current` 폴더를 교체하므로, 설정/로그는 이 사용자 데이터 폴더에 유지됩니다.
-- 환경설정창의 업데이트 영역에서 현재 실행 경로를 확인할 수 있습니다.
+- 환경설정창의 업데이트 영역에서 현재 실행 경로를 확인하고, 경로 복사와 현재 폴더 열기를 바로 사용할 수 있습니다.
 - 로컬 PC에서 실행되므로 외부 API 비용은 없지만, 모델 로드 용량과 GPU/CPU 자원을 사용합니다.
 
 ## 기본 단축키


### PR DESCRIPTION
## 요약
- 환경설정창 업데이트 영역에 현재 폴더 열기 / 경로 복사 버튼 추가
- 실행 경로 표시용 문자열과 실제 폴더 경로 반환 로직 분리
- 설치 경로 지정 예시를 UI/README/readme.txt에 명시

## 반영 내용
- 업데이트 영역에 `현재 폴더 열기`, `경로 복사` 버튼 추가
- 설치형/직접 실행 여부와 무관하게 실제 EXE 폴더를 열거나 복사 가능
- 수동 업데이트 확인을 다시 누르면 상태 문구 색상을 기본 회색으로 초기화
- 문서 예시를 `GameChatTranslator-win-Setup.exe --installto D:\Apps\GameChatTranslator` 형식으로 통일

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-install-path-ux`
