### PR TITLE
개선: ETC OCR 언어 선택 품질 튜닝

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
@@ -187,6 +187,57 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void SelectBestLanguageSelection_ReturnsNullWhenAllCandidatesScoreZero()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine> { new OcrLine { Text = "" } }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine> { new OcrLine { Text = "!!!" } }
+                }
+            };
+
+            OcrLanguageSelection selected = _service.SelectBestLanguageSelection(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Etc);
+
+            Assert.Null(selected);
+        }
+
+        [Fact]
+        public void SelectBestLanguageSelection_TieUsesDeterministicLanguageOrder()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine> { new OcrLine { Text = "hello world" } }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine> { new OcrLine { Text = "hello world" } }
+                }
+            };
+
+            OcrLanguageSelection selected = _service.SelectBestLanguageSelection(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Etc);
+
+            Assert.NotNull(selected);
+            Assert.Equal("ja", selected.LanguageCode);
+        }
+
+        [Fact]
         public void OcrService_DoesNotReferenceWinRtOrBitmapTypes()
         {
             string assemblyQualifiedNames = string.Join(

--- a/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
@@ -141,6 +141,52 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void SelectBestLanguageSelection_EtcMode_PicksMostReadableLanguage()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "猫は可愛い" }
+                    }
+                }
+            };
+
+            OcrLanguageSelection selected = _service.SelectBestLanguageSelection(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Etc);
+
+            Assert.NotNull(selected);
+            Assert.Equal("ja", selected.LanguageCode);
+            Assert.Single(selected.Lines);
+            Assert.Equal("猫は可愛い", selected.Lines[0].Text);
+            Assert.True(selected.Score > 0);
+        }
+
+        [Fact]
+        public void SelectBestLanguageSelection_ReturnsNullWhenNoCandidates()
+        {
+            OcrLanguageSelection selected = _service.SelectBestLanguageSelection(
+                null,
+                KnownCharacters,
+                TranslationContentMode.Etc);
+
+            Assert.Null(selected);
+        }
+
+        [Fact]
         public void OcrService_DoesNotReferenceWinRtOrBitmapTypes()
         {
             string assemblyQualifiedNames = string.Join(

--- a/GameChatTranslator.Tests/Core/Translation/TranslationPromptBuilderTests.cs
+++ b/GameChatTranslator.Tests/Core/Translation/TranslationPromptBuilderTests.cs
@@ -140,6 +140,14 @@ namespace GameChatTranslator.Tests
             Assert.Equal("", cleaned);
         }
 
+        [Fact]
+        public void CleanEtcOcrLine_DropsShortFragmentsFromNoisyMixedLine()
+        {
+            string cleaned = _builder.CleanEtcOcrLine("乞5 5t1황&`Ø?");
+
+            Assert.Equal("", cleaned);
+        }
+
         [Theory]
         [InlineData("猫可愛 황", true)]
         [InlineData("고양이", true)]

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -77,6 +77,31 @@ namespace GameTranslator
                 ? ChatTextAnalyzer.ScoreReadableTextCandidate(lineTexts)
                 : ChatTextAnalyzer.ScoreOcrCandidate(lineTexts, characterNames);
         }
+
+        /// <summary>
+        /// 언어별 OCR 병합 라인 후보 중 현재 모드에서 가장 읽기 좋은 결과를 선택합니다.
+        /// ETC 모드에서는 gameLang 고정 대신 언어별 결과를 비교해 더 읽을 만한 OCR 결과를 고르기 위해 사용합니다.
+        /// </summary>
+        public OcrLanguageSelection SelectBestLanguageSelection(
+            IEnumerable<OcrLanguageCandidate> candidates,
+            ISet<string> characterNames,
+            TranslationContentMode contentMode = TranslationContentMode.Strinova)
+        {
+            OcrLanguageSelection bestSelection = null;
+
+            foreach (OcrLanguageCandidate candidate in candidates ?? Enumerable.Empty<OcrLanguageCandidate>())
+            {
+                List<OcrLine> lines = candidate?.Lines ?? new List<OcrLine>();
+                int score = ScoreLines(lines, characterNames, contentMode);
+
+                if (bestSelection == null || score > bestSelection.Score)
+                {
+                    bestSelection = new OcrLanguageSelection(candidate?.LanguageCode ?? "", lines, score);
+                }
+            }
+
+            return bestSelection;
+        }
     }
 
     /// <summary>
@@ -139,12 +164,40 @@ namespace GameTranslator
     }
 
     /// <summary>
+    /// 하나의 OCR 언어 결과를 병합 라인 기준으로 비교하기 위한 순수 모델입니다.
+    /// ETC 모드에서 언어별 OCR 결과를 읽기 점수로 비교할 때 사용합니다.
+    /// </summary>
+    public sealed class OcrLanguageCandidate
+    {
+        public string LanguageCode { get; set; }
+        public List<OcrLine> Lines { get; set; }
+    }
+
+    /// <summary>
+    /// 언어별 OCR 결과 비교 후 선택된 최종 언어와 점수를 담는 모델입니다.
+    /// </summary>
+    public sealed class OcrLanguageSelection
+    {
+        public OcrLanguageSelection(string languageCode, List<OcrLine> lines, int score)
+        {
+            LanguageCode = languageCode ?? "";
+            Lines = lines ?? new List<OcrLine>();
+            Score = score;
+        }
+
+        public string LanguageCode { get; }
+        public List<OcrLine> Lines { get; }
+        public int Score { get; }
+    }
+
+    /// <summary>
     /// 하나의 전처리 후보에 대한 OCR 결과, 병합 라인, 품질 점수를 묶는 모델입니다.
     /// TResults는 실제 앱에서는 언어별 Windows OCR 결과 딕셔너리이고, 테스트에서는 가짜 결과를 넣을 수 있습니다.
     /// </summary>
     public sealed class OcrCandidate<TResults>
     {
         public string PreprocessName { get; set; }
+        public string SelectedLanguageCode { get; set; }
         public TResults Results { get; set; }
         public List<OcrLine> Lines { get; set; }
         public int Score { get; set; }

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -91,16 +91,20 @@ namespace GameTranslator
 
             foreach (OcrLanguageCandidate candidate in candidates ?? Enumerable.Empty<OcrLanguageCandidate>())
             {
+                string languageCode = candidate?.LanguageCode ?? "";
                 List<OcrLine> lines = candidate?.Lines ?? new List<OcrLine>();
                 int score = ScoreLines(lines, characterNames, contentMode);
 
-                if (bestSelection == null || score > bestSelection.Score)
+                if (bestSelection == null ||
+                    score > bestSelection.Score ||
+                    (score == bestSelection.Score &&
+                     string.Compare(languageCode, bestSelection.LanguageCode, System.StringComparison.OrdinalIgnoreCase) < 0))
                 {
-                    bestSelection = new OcrLanguageSelection(candidate?.LanguageCode ?? "", lines, score);
+                    bestSelection = new OcrLanguageSelection(languageCode, lines, score);
                 }
             }
 
-            return bestSelection;
+            return bestSelection != null && bestSelection.Score > 0 ? bestSelection : null;
         }
     }
 

--- a/GameChatTranslator/Core/TranslationPromptBuilder.cs
+++ b/GameChatTranslator/Core/TranslationPromptBuilder.cs
@@ -64,6 +64,11 @@ namespace GameTranslator
                 return "";
             }
 
+            if (ShouldDiscardEtcLineAsShortFragments(source, cleaned))
+            {
+                return "";
+            }
+
             return HasMeaningfulEtcContent(cleaned) ? cleaned : "";
         }
 
@@ -244,6 +249,31 @@ namespace GameTranslator
             int asciiLetterCount = Regex.Matches(text, @"[a-zA-Z]").Count;
             int noiseCount = Regex.Matches(text, @"[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\.,!\?\-]").Count;
             return asciiLetterCount > nonAsciiReadableCount && noiseCount >= 3;
+        }
+
+        private bool ShouldDiscardEtcLineAsShortFragments(string source, string cleaned)
+        {
+            string rawText = source ?? "";
+            string normalized = (cleaned ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(normalized) || !Regex.IsMatch(normalized, NonAsciiReadablePattern))
+            {
+                return false;
+            }
+
+            int digitCount = Regex.Matches(rawText, @"\d").Count;
+            int noiseCount = Regex.Matches(rawText, @"[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣぁ-んァ-ヶ一-龥а-яА-ЯёЁ\s\.,!\?\-]").Count;
+            if (digitCount + noiseCount < 2)
+            {
+                return false;
+            }
+
+            string[] readableTokens = Regex
+                .Split(normalized, @"\s+")
+                .Where(token => Regex.IsMatch(token, TranslatableLetterPattern))
+                .ToArray();
+
+            return readableTokens.Length > 0 &&
+                readableTokens.All(token => Regex.Matches(token, TranslatableLetterPattern).Count <= 1);
         }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -358,10 +358,10 @@ namespace GameTranslator
                 var ocrResults = bestCandidate.Results;
                 var mergedLines = bestCandidate.Lines;
                 performanceStats.SelectedPreprocessName = bestCandidate.PreprocessName;
-                performanceStats.SelectedOcrLanguages = string.Join("+", ocrResults.Keys);
+                performanceStats.SelectedOcrLanguages = bestCandidate.SelectedLanguageCode;
                 performanceStats.SelectedScore = bestCandidate.Score;
                 performanceStats.MergedLineCount = mergedLines.Count;
-                AppendLog("DEBUG", $"OCR 모드: {GetOcrProcessingModeLabel(processingMode)}, 전처리 선택: {bestCandidate.PreprocessName} (점수 {bestCandidate.Score})", "System");
+                AppendLog("DEBUG", $"OCR 모드: {GetOcrProcessingModeLabel(processingMode)}, 전처리 선택: {bestCandidate.PreprocessName}, 언어 선택: {bestCandidate.SelectedLanguageCode} (점수 {bestCandidate.Score})", "System");
 
                 string currentRawTextCombined = string.Join("\n", mergedLines.Select(l => l.Text.Trim()));
                 if (currentRawTextCombined == lastRawTextCombined)
@@ -720,22 +720,31 @@ namespace GameTranslator
                     // OCR 엔진 호출이 가장 큰 병목입니다. 빠름 모드에서는 게임 언어만 호출해 처리량을 줄입니다.
                     Dictionary<string, OcrResult> candidateResults = await RecognizeLanguagesAsync(croppedBitmap, recognizeAllLanguages, performanceStats);
                     Stopwatch scoringStopwatch = Stopwatch.StartNew();
-                    OcrResult candidateMasterResult = SelectMasterOcrResult(candidateResults);
-                    if (candidateMasterResult == null)
+                    Dictionary<string, List<OcrLine>> mergedLinesByLanguage = candidateResults
+                        .Where(kvp => kvp.Value != null)
+                        .ToDictionary(kvp => kvp.Key, kvp => MergeOcrLines(kvp.Value));
+
+                    OcrLanguageSelection selectedLanguage = SelectOcrLanguageSelection(
+                        candidateResults,
+                        mergedLinesByLanguage,
+                        contentMode);
+
+                    if (selectedLanguage == null || selectedLanguage.Lines.Count == 0)
                     {
                         scoringStopwatch.Stop();
                         performanceStats.ScoringMs += scoringStopwatch.ElapsedMilliseconds;
                         continue;
                     }
 
-                    List<OcrLine> candidateLines = MergeOcrLines(candidateMasterResult);
-                    int candidateScore = ScoreOcrCandidate(candidateLines, contentMode);
+                    List<OcrLine> candidateLines = selectedLanguage.Lines;
+                    int candidateScore = selectedLanguage.Score;
                     scoringStopwatch.Stop();
                     performanceStats.ScoringMs += scoringStopwatch.ElapsedMilliseconds;
 
                     bestCandidate = ocrService.SelectHigherScore(bestCandidate, new OcrResultCandidate
                     {
                         PreprocessName = preprocessedImage.Name,
+                        SelectedLanguageCode = selectedLanguage.LanguageCode,
                         Results = candidateResults,
                         Lines = candidateLines,
                         Score = candidateScore
@@ -751,6 +760,73 @@ namespace GameTranslator
             }
 
             return bestCandidate;
+        }
+
+        /// <summary>
+        /// 이번 OCR 후보에서 실제 번역 대상으로 삼을 기준 언어 결과를 선택합니다.
+        /// Strinova는 기존처럼 게임 언어/한국어 우선 전략을 유지하고, ETC는 언어별 OCR 결과를 읽기 점수로 비교합니다.
+        /// </summary>
+        private OcrLanguageSelection SelectOcrLanguageSelection(
+            Dictionary<string, OcrResult> candidateResults,
+            Dictionary<string, List<OcrLine>> mergedLinesByLanguage,
+            TranslationContentMode contentMode)
+        {
+            if (contentMode == TranslationContentMode.Etc)
+            {
+                OcrLanguageSelection cleanedSelection = ocrService.SelectBestLanguageSelection(
+                    (mergedLinesByLanguage ?? new Dictionary<string, List<OcrLine>>())
+                        .Select(kvp => new OcrLanguageCandidate
+                        {
+                            LanguageCode = kvp.Key,
+                            Lines = BuildCleanedEtcLanguageLines(kvp.Value)
+                        }),
+                    characterNames,
+                    TranslationContentMode.Etc);
+
+                if (cleanedSelection == null ||
+                    cleanedSelection.Score <= 0 ||
+                    string.IsNullOrWhiteSpace(cleanedSelection.LanguageCode) ||
+                    mergedLinesByLanguage == null ||
+                    !mergedLinesByLanguage.TryGetValue(cleanedSelection.LanguageCode, out List<OcrLine> rawLines))
+                {
+                    return null;
+                }
+
+                return new OcrLanguageSelection(
+                    cleanedSelection.LanguageCode,
+                    rawLines,
+                    cleanedSelection.Score);
+            }
+
+            string selectedLanguageCode = GetPreferredMasterLanguageCode(candidateResults);
+            if (string.IsNullOrWhiteSpace(selectedLanguageCode) ||
+                mergedLinesByLanguage == null ||
+                !mergedLinesByLanguage.TryGetValue(selectedLanguageCode, out List<OcrLine> lines))
+            {
+                return null;
+            }
+
+            return new OcrLanguageSelection(
+                selectedLanguageCode,
+                lines,
+                ScoreOcrCandidate(lines, contentMode));
+        }
+
+        /// <summary>
+        /// ETC 모드 언어 선택 점수 비교 전에 각 언어별 OCR 라인을 전처리 결과 기준으로 정리합니다.
+        /// 실제 번역 입력과 같은 필터를 써서, 노이즈가 심한 언어 결과가 선택 점수에서 과대평가되지 않게 합니다.
+        /// </summary>
+        private List<OcrLine> BuildCleanedEtcLanguageLines(IEnumerable<OcrLine> lines)
+        {
+            return (lines ?? Enumerable.Empty<OcrLine>())
+                .Select(line => new OcrLine
+                {
+                    Top = line?.Top ?? 0,
+                    Bottom = line?.Bottom ?? 0,
+                    Text = translationPromptBuilder.CleanEtcOcrLine(line?.Text?.Trim() ?? "")
+                })
+                .Where(line => translationPromptBuilder.HasMeaningfulEtcContent(line.Text))
+                .ToList();
         }
 
         /// <summary>
@@ -846,6 +922,18 @@ namespace GameTranslator
         private OcrResult SelectMasterOcrResult(Dictionary<string, OcrResult> ocrResults)
         {
             return ocrResults.ContainsKey(gameLang) ? ocrResults[gameLang] : (ocrResults.ContainsKey("ko") ? ocrResults["ko"] : null);
+        }
+
+        /// <summary>
+        /// Strinova 모드에서 우선 사용할 기준 OCR 언어 코드를 반환합니다.
+        /// 게임 언어를 우선하고, 없으면 한국어를 fallback으로 사용합니다.
+        /// </summary>
+        private string GetPreferredMasterLanguageCode(Dictionary<string, OcrResult> ocrResults)
+        {
+            if (ocrResults == null) return "";
+            if (ocrResults.ContainsKey(gameLang)) return gameLang;
+            if (ocrResults.ContainsKey("ko")) return "ko";
+            return "";
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -773,6 +773,8 @@ namespace GameTranslator
         {
             if (contentMode == TranslationContentMode.Etc)
             {
+                // ETC는 "선택 점수"와 "실제 번역 입력"이 어긋나지 않게,
+                // 언어 선택에 사용한 cleaned lines 자체를 이후 번역 입력으로 그대로 넘깁니다.
                 OcrLanguageSelection cleanedSelection = ocrService.SelectBestLanguageSelection(
                     (mergedLinesByLanguage ?? new Dictionary<string, List<OcrLine>>())
                         .Select(kvp => new OcrLanguageCandidate
@@ -784,18 +786,12 @@ namespace GameTranslator
                     TranslationContentMode.Etc);
 
                 if (cleanedSelection == null ||
-                    cleanedSelection.Score <= 0 ||
-                    string.IsNullOrWhiteSpace(cleanedSelection.LanguageCode) ||
-                    mergedLinesByLanguage == null ||
-                    !mergedLinesByLanguage.TryGetValue(cleanedSelection.LanguageCode, out List<OcrLine> rawLines))
+                    string.IsNullOrWhiteSpace(cleanedSelection.LanguageCode))
                 {
                     return null;
                 }
 
-                return new OcrLanguageSelection(
-                    cleanedSelection.LanguageCode,
-                    rawLines,
-                    cleanedSelection.Score);
+                return cleanedSelection;
             }
 
             string selectedLanguageCode = GetPreferredMasterLanguageCode(candidateResults);


### PR DESCRIPTION
요약
- ETC 모드에서 gameLang/ko 고정 대신 언어별 OCR 결과를 전처리 후 점수로 비교해 가장 읽기 좋은 언어 결과를 선택
- ETC 노이즈 라인 필터 강화로 짧은 파편(`乞 황` 같은 형태)과 심하게 깨진 혼합 줄을 번역 입력에서 더 적극적으로 제외
- DEBUG 로그에 선택된 OCR 언어를 함께 출력

검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-etc-tuning
