### PR TITLE
수정: 번역창 위치와 캡처 영역 UI 보정

### DIFF
--- a/GameChatTranslator/Views/MainWindow/MainWindow.Capture.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Capture.cs
@@ -21,11 +21,14 @@ using Application = System.Windows.Application;
 using Brushes = System.Windows.Media.Brushes;
 using ColorConverter = System.Windows.Media.ColorConverter;
 using PixelFormat = System.Drawing.Imaging.PixelFormat;
+using Screen = System.Windows.Forms.Screen;
 
 namespace GameTranslator
 {
     public partial class MainWindow
     {
+        private const int TranslationWindowGap = 8;
+
         /// <summary>
         /// 캡처 영역 선택용 오버레이 창을 엽니다.
         /// 이미 열린 AreaSelector가 있으면 닫고 새로 만들어 중복 선택 창이 쌓이지 않도록 합니다.
@@ -56,8 +59,6 @@ namespace GameTranslator
         {
             gameChatArea = area;
             gameChatCaptureArea = pixelArea;
-            this.Top = area.Y + area.Height + 50;
-            this.Left = area.X - 5;
             this.SizeToContent = SizeToContent.Manual;
             this.Width = area.Width;
             this.MinWidth = area.Width;
@@ -65,6 +66,7 @@ namespace GameTranslator
             this.Visibility = Visibility.Visible;
             this.Topmost = true;
             UpdateYellowHotkeyGuideText();
+            PositionTranslationWindowNearCaptureArea(area, pixelArea);
 
             ini.Write("CaptureX", area.X.ToString());
             ini.Write("CaptureY", area.Y.ToString());
@@ -115,6 +117,78 @@ namespace GameTranslator
             }
 
             return ConvertDisplayAreaToPixels(gameChatArea);
+        }
+
+        /// <summary>
+        /// 번역창을 캡처 영역 위/아래 중 더 자연스러운 위치로 배치합니다.
+        /// 캡처 영역이 해당 모니터의 세로 중간보다 위에 있으면 아래에, 아래에 있으면 위에 붙이고, 화면 밖으로 나가지 않게 clamp합니다.
+        /// </summary>
+        private void PositionTranslationWindowNearCaptureArea(Rectangle displayArea, Rectangle pixelArea)
+        {
+            Rectangle workArea = GetDisplayWorkAreaForCaptureArea(displayArea, pixelArea);
+
+            UpdateLayout();
+            double windowWidth = ActualWidth > 0 ? ActualWidth : Width;
+            double windowHeight = ActualHeight > 0 ? ActualHeight : Height;
+            double desiredLeft = displayArea.X - 5;
+            double areaMidY = displayArea.Y + (displayArea.Height / 2.0);
+            double workAreaMidY = workArea.Y + (workArea.Height / 2.0);
+            bool placeBelow = areaMidY < workAreaMidY;
+            double desiredTop = placeBelow
+                ? displayArea.Bottom + TranslationWindowGap
+                : displayArea.Y - windowHeight - TranslationWindowGap;
+
+            Left = ClampWindowCoordinate(desiredLeft, workArea.Left, workArea.Right - windowWidth);
+            Top = ClampWindowCoordinate(desiredTop, workArea.Top, workArea.Bottom - windowHeight);
+        }
+
+        /// <summary>
+        /// 캡처 영역이 위치한 실제 모니터의 작업 영역을 WPF 표시 좌표계로 반환합니다.
+        /// 다중 모니터 환경에서 주 모니터 대신 캡처 영역이 속한 모니터 기준으로 창 위치를 보정하기 위해 사용합니다.
+        /// </summary>
+        private Rectangle GetDisplayWorkAreaForCaptureArea(Rectangle displayArea, Rectangle pixelArea)
+        {
+            if (displayArea.Width > 0 &&
+                displayArea.Height > 0 &&
+                pixelArea.Width > 0 &&
+                pixelArea.Height > 0)
+            {
+                var centerPoint = new System.Drawing.Point(
+                    pixelArea.X + (pixelArea.Width / 2),
+                    pixelArea.Y + (pixelArea.Height / 2));
+                Rectangle pixelWorkArea = Screen.FromPoint(centerPoint).WorkingArea;
+
+                double scaleX = (double)pixelArea.Width / displayArea.Width;
+                double scaleY = (double)pixelArea.Height / displayArea.Height;
+                if (scaleX > 0 && scaleY > 0)
+                {
+                    return new Rectangle(
+                        (int)Math.Round(pixelWorkArea.X / scaleX),
+                        (int)Math.Round(pixelWorkArea.Y / scaleY),
+                        Math.Max(1, (int)Math.Round(pixelWorkArea.Width / scaleX)),
+                        Math.Max(1, (int)Math.Round(pixelWorkArea.Height / scaleY)));
+                }
+            }
+
+            Rect fallbackWorkArea = SystemParameters.WorkArea;
+            return new Rectangle(
+                (int)Math.Round(fallbackWorkArea.Left),
+                (int)Math.Round(fallbackWorkArea.Top),
+                Math.Max(1, (int)Math.Round(fallbackWorkArea.Width)),
+                Math.Max(1, (int)Math.Round(fallbackWorkArea.Height)));
+        }
+
+        /// <summary>
+        /// 창 크기가 작업 영역보다 크더라도 화면 밖으로 완전히 밀려나지 않도록 좌표를 제한합니다.
+        /// </summary>
+        private double ClampWindowCoordinate(double value, double min, double max)
+        {
+            if (max < min)
+            {
+                return min;
+            }
+
+            return Math.Max(min, Math.Min(value, max));
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
@@ -143,8 +143,6 @@ namespace GameTranslator
             string cpy = ini.Read("CapturePixelY");
             string cpw = ini.Read("CapturePixelW");
             string cph = ini.Read("CapturePixelH");
-            double screenH = SystemParameters.PrimaryScreenHeight;
-
             if (int.TryParse(cx, out int x) && int.TryParse(cy, out int y) &&
                 int.TryParse(cw, out int w) && int.TryParse(ch, out int h) && w > 0 && h > 0)
             {
@@ -162,18 +160,15 @@ namespace GameTranslator
                 this.Width = w;
                 this.MinWidth = w;
                 this.SizeToContent = SizeToContent.Height;
-                this.Left = x - 5;
-                this.Top = y + h + 50;
 
                 TxtResult.Text = $"📍 마지막으로 저장된 영역을 불러왔습니다.\n🤖 현재 번역 엔진: {currentEngine}";
+                PositionTranslationWindowNearCaptureArea(gameChatArea, gameChatCaptureArea);
             }
             else
             {
                 this.Width = 1000;
                 this.Height = 130;
-                this.Left = 20;
-                this.Top = screenH - this.Height - 10;
-                gameChatArea = new Rectangle((int)this.Left, (int)(this.Top - 250 - 10), 500, 250);
+                gameChatArea = new Rectangle(20, (int)(SystemParameters.WorkArea.Bottom - this.Height - TranslationWindowGap - 250 - 10), 500, 250);
                 gameChatCaptureArea = ConvertDisplayAreaToPixels(gameChatArea);
 
                 string missingLangs = "";
@@ -185,6 +180,8 @@ namespace GameTranslator
                     TxtResult.Text = $"⚠️ [경고] {missingLangs}언어팩 누락!\n'LangInstall.bat' 실행 권장.\n🤖 현재 번역 엔진: {currentEngine}";
                 else
                     TxtResult.Text = $"📍 기본 캡처 영역으로 세팅 완료.\n🤖 현재 번역 엔진: {currentEngine}";
+
+                PositionTranslationWindowNearCaptureArea(gameChatArea, gameChatCaptureArea);
             }
 
             UpdateCaptureBorder(!isLocked);

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -363,7 +363,7 @@
                     <GroupBox Header="캡처 영역 (Capture Area)" Foreground="White" BorderBrush="#555" Margin="0,0,0,10">
                         <StackPanel Margin="10" Orientation="Horizontal">
                             <TextBlock x:Name="TxtAreaInfo" Text="저장된 영역: 없음 (좌측 하단 기본값)" VerticalAlignment="Center" Foreground="#CCC" Width="280"/>
-                            <Button x:Name="BtnResetArea" Content="🔄 영역 초기화" Padding="5,0" Height="25" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
+                            <Button x:Name="BtnResetArea" Content="🔄 영역 초기화" MinWidth="118" Padding="10,0" Height="28" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>


### PR DESCRIPTION
요약
- 캡처 영역 초기화 버튼에 최소 폭과 패딩을 추가해 텍스트 잘림을 방지
- 번역창 위치를 캡처 영역 기준 스마트 배치로 변경
- 영역이 화면 중간보다 위에 있으면 아래, 아래에 있으면 위에 8px 간격으로 배치
- 해당 모니터 work area 기준으로 clamp 하도록 수정해 다중 모니터에서도 화면 밖으로 밀리지 않게 보정

검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-issue109
