### PR TITLE
수정: 번역창 위치 계산 fallback 보강

### DIFF
--- a/GameChatTranslator/Views/MainWindow/MainWindow.Capture.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Capture.cs
@@ -28,6 +28,7 @@ namespace GameTranslator
     public partial class MainWindow
     {
         private const int TranslationWindowGap = 8;
+        private const double DefaultTranslationWindowHeight = 130;
 
         /// <summary>
         /// 캡처 영역 선택용 오버레이 창을 엽니다.
@@ -130,6 +131,11 @@ namespace GameTranslator
             UpdateLayout();
             double windowWidth = ActualWidth > 0 ? ActualWidth : Width;
             double windowHeight = ActualHeight > 0 ? ActualHeight : Height;
+            if (double.IsNaN(windowHeight) || windowHeight <= 0)
+            {
+                windowHeight = DefaultTranslationWindowHeight;
+            }
+
             double desiredLeft = displayArea.X - 5;
             double areaMidY = displayArea.Y + (displayArea.Height / 2.0);
             double workAreaMidY = workArea.Y + (workArea.Height / 2.0);


### PR DESCRIPTION
## 요약
- 번역창 위치 계산 시 `ActualHeight == 0` 이고 `Height == NaN` 인 경우를 보정했습니다.
- `SizeToContent.Height` 상태에서도 위쪽 배치 계산이 `NaN` 으로 무효화되지 않도록 기본 높이 fallback을 추가했습니다.

## 배경
- PR #110이 이미 머지된 뒤 리뷰에서 `windowHeight` NaN 방어 누락이 확인됐습니다.
- 이번 PR은 그 후속 수정만 최소 범위로 반영합니다.

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-issue109-fix`
