### PR TITLE
수정: 영역 초기화 버튼 폭 재보정

### DIFF
--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -363,7 +363,7 @@
                     <GroupBox Header="캡처 영역 (Capture Area)" Foreground="White" BorderBrush="#555" Margin="0,0,0,10">
                         <StackPanel Margin="10" Orientation="Horizontal">
                             <TextBlock x:Name="TxtAreaInfo" Text="저장된 영역: 없음 (좌측 하단 기본값)" VerticalAlignment="Center" Foreground="#CCC" Width="280"/>
-                            <Button x:Name="BtnResetArea" Content="🔄 영역 초기화" MinWidth="118" Padding="10,0" Height="28" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
+                            <Button x:Name="BtnResetArea" Content="🔄 영역 초기화" MinWidth="150" Padding="12,0" Height="28" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>


### PR DESCRIPTION
## 요약
- `영역 초기화` 버튼 최소 폭을 다시 보정했습니다.
- 릴리즈 설치본(v1.0.29-alpha)에서 글씨가 여전히 잘리는 재현을 기준으로 후속 수정합니다.

## 변경
- `MinWidth`: `118` -> `150`
- `Padding`: `10,0` -> `12,0`

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-reset-area-fix`
