### PR TITLE
수정: 영역 초기화 버튼 이모지 제거

### DIFF
--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -363,7 +363,7 @@
                     <GroupBox Header="캡처 영역 (Capture Area)" Foreground="White" BorderBrush="#555" Margin="0,0,0,10">
                         <StackPanel Margin="10" Orientation="Horizontal">
                             <TextBlock x:Name="TxtAreaInfo" Text="저장된 영역: 없음 (좌측 하단 기본값)" VerticalAlignment="Center" Foreground="#CCC" Width="280"/>
-                            <Button x:Name="BtnResetArea" Content="🔄 영역 초기화" MinWidth="150" Padding="12,0" Height="28" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
+                            <Button x:Name="BtnResetArea" Content="영역 초기화" MinWidth="150" Padding="12,0" Height="28" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>


### PR DESCRIPTION
## 요약
- `영역 초기화` 버튼에서 이모지를 제거했습니다.
- v1.0.30-alpha 릴리즈 설치본 기준으로 `글씨 안 보임` 현상이 재현되어, 폭/패딩이 아니라 렌더링 조합 문제로 보고 가장 좁게 수정했습니다.

## 변경
- 버튼 Content: `🔄 영역 초기화` -> `영역 초기화`
- `MinWidth=150`, `Padding=12,0` 은 그대로 유지

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-remove-reset-emoji`
