### PR TITLE
기능: OCR 비교용 번역 하네스 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrTranslationHarnessServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrTranslationHarnessServiceTests.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class OcrTranslationHarnessServiceTests
+    {
+        private readonly OcrTranslationHarnessService _service = new OcrTranslationHarnessService(new TranslationPromptBuilder());
+
+        [Fact]
+        public void BuildRequests_ParsesNicknamePrefixAndKeepsCharacterLabel()
+        {
+            var request = _service.BuildRequests(new[] { "SeoArin [치요]: 猫は可愛い" }).Single();
+
+            Assert.False(request.Skipped);
+            Assert.Equal("[치요]: ", request.Prefix);
+            Assert.Equal("猫は可愛い", request.ContentToTranslate);
+            Assert.Equal(TranslationContentMode.Strinova, request.ContentMode);
+        }
+
+        [Fact]
+        public void BuildRequests_FallsBackToRawWhenChatParseFailsButMeaningfulTextRemains()
+        {
+            var request = _service.BuildRequests(new[] { "猫 可 愛" }).Single();
+
+            Assert.False(request.Skipped);
+            Assert.Equal("[RAW]: ", request.Prefix);
+            Assert.Equal("猫可愛", request.ContentToTranslate);
+            Assert.Equal(TranslationContentMode.Etc, request.ContentMode);
+        }
+
+        [Fact]
+        public void BuildRequests_SkipsNoiseOnlyText()
+        {
+            var request = _service.BuildRequests(new[] { "###@@@%%%" }).Single();
+
+            Assert.True(request.Skipped);
+            Assert.Equal("글자 없음", request.SkipReason);
+        }
+
+        [Fact]
+        public void BuildRequests_SkipsBrokenNoiseAfterEtcCleaning()
+        {
+            var request = _service.BuildRequests(new[] { "乞5U(私(z構ote.ntOØ?" }).Single();
+
+            Assert.True(request.Skipped);
+            Assert.Equal("파싱 실패 / 노이즈", request.SkipReason);
+        }
+    }
+}

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -24,7 +24,9 @@
     <Compile Include="../GameChatTranslator/Core/OcrLanguageStatusFormatter.cs" Link="Core/OcrLanguageStatusFormatter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
+    <Compile Include="../GameChatTranslator/Core/OcrTranslationHarnessService.cs" Link="Core/OcrTranslationHarnessService.cs" />
     <Compile Include="../GameChatTranslator/Models/OcrDiagnosticModels.cs" Link="Models/OcrDiagnosticModels.cs" />
+    <Compile Include="../GameChatTranslator/Models/OcrHarnessModels.cs" Link="Models/OcrHarnessModels.cs" />
     <Compile Include="../GameChatTranslator/Core/SettingsService.cs" Link="Core/SettingsService.cs" />
     <Compile Include="../GameChatTranslator/Core/SettingsValueNormalizer.cs" Link="Core/SettingsValueNormalizer.cs" />
     <Compile Include="../GameChatTranslator/Core/RecommendedSettingsPreset.cs" Link="Core/RecommendedSettingsPreset.cs" />

--- a/GameChatTranslator/Core/OcrTranslationHarnessService.cs
+++ b/GameChatTranslator/Core/OcrTranslationHarnessService.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// OCR 비교 하네스에서 번역 대상으로 넘길 라인을 추출합니다.
+    /// "[캐릭터명]: 내용" 형식은 캐릭터 라벨과 본문을 분리하고,
+    /// 일반 텍스트는 ETC 정리 규칙으로 정제합니다.
+    /// </summary>
+    public sealed class OcrTranslationHarnessService
+    {
+        private readonly TranslationPromptBuilder translationPromptBuilder;
+
+        public OcrTranslationHarnessService(TranslationPromptBuilder translationPromptBuilder = null)
+        {
+            this.translationPromptBuilder = translationPromptBuilder ?? new TranslationPromptBuilder();
+        }
+
+        public IReadOnlyList<OcrTranslationHarnessRequest> BuildRequests(IEnumerable<string> mergedLines)
+        {
+            var requests = new List<OcrTranslationHarnessRequest>();
+
+            foreach (string rawLine in mergedLines ?? Enumerable.Empty<string>())
+            {
+                string text = (rawLine ?? "").Trim();
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    continue;
+                }
+
+                if (!ChatTextAnalyzer.ContainsReadableLetter(text))
+                {
+                    requests.Add(OcrTranslationHarnessRequest.Skip(text, "글자 없음"));
+                    continue;
+                }
+
+                if (ChatTextAnalyzer.TryParseChatLine(text, out ChatTextAnalyzer.ChatLine chatLine) &&
+                    !string.IsNullOrWhiteSpace(chatLine.Message))
+                {
+                    requests.Add(OcrTranslationHarnessRequest.Chat(text, chatLine.CharacterLabel, chatLine.Message));
+                    continue;
+                }
+
+                string cleaned = translationPromptBuilder.CleanEtcOcrLine(text);
+                if (!translationPromptBuilder.HasMeaningfulEtcContent(cleaned))
+                {
+                    requests.Add(OcrTranslationHarnessRequest.Skip(text, "파싱 실패 / 노이즈"));
+                    continue;
+                }
+
+                requests.Add(OcrTranslationHarnessRequest.Raw(text, "[RAW]: ", cleaned));
+            }
+
+            return requests;
+        }
+    }
+
+    /// <summary>
+    /// OCR 비교 하네스가 번역 API에 넘길 단일 요청입니다.
+    /// </summary>
+    public sealed class OcrTranslationHarnessRequest
+    {
+        private OcrTranslationHarnessRequest(
+            string rawText,
+            string prefix,
+            string contentToTranslate,
+            TranslationContentMode contentMode,
+            bool skipped,
+            string skipReason)
+        {
+            RawText = rawText ?? "";
+            Prefix = prefix ?? "";
+            ContentToTranslate = contentToTranslate ?? "";
+            ContentMode = contentMode;
+            Skipped = skipped;
+            SkipReason = skipReason ?? "";
+        }
+
+        public string RawText { get; }
+        public string Prefix { get; }
+        public string ContentToTranslate { get; }
+        public TranslationContentMode ContentMode { get; }
+        public bool Skipped { get; }
+        public string SkipReason { get; }
+
+        public static OcrTranslationHarnessRequest Chat(string rawText, string prefix, string contentToTranslate)
+        {
+            return new OcrTranslationHarnessRequest(rawText, prefix, contentToTranslate, TranslationContentMode.Strinova, false, "");
+        }
+
+        public static OcrTranslationHarnessRequest Raw(string rawText, string prefix, string contentToTranslate)
+        {
+            return new OcrTranslationHarnessRequest(rawText, prefix, contentToTranslate, TranslationContentMode.Etc, false, "");
+        }
+
+        public static OcrTranslationHarnessRequest Skip(string rawText, string skipReason)
+        {
+            return new OcrTranslationHarnessRequest(rawText, "", "", TranslationContentMode.Etc, true, skipReason);
+        }
+    }
+}

--- a/GameChatTranslator/Models/OcrHarnessModels.cs
+++ b/GameChatTranslator/Models/OcrHarnessModels.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// OCR 진단 창의 번역 테스트 하네스 결과입니다.
+    /// 선택된 OCR 후보 라인을 현재 번역 엔진으로 흘려보낸 결과를 요약합니다.
+    /// </summary>
+    public sealed class OcrTranslationHarnessPreviewResult
+    {
+        public string CandidateName { get; set; } = "";
+        public long TranslateMs { get; set; }
+        public int TotalLineCount { get; set; }
+        public int TranslatedLineCount { get; set; }
+        public int SkippedLineCount { get; set; }
+        public List<OcrTranslationHarnessPreviewLine> Lines { get; } = new List<OcrTranslationHarnessPreviewLine>();
+    }
+
+    public sealed class OcrTranslationHarnessPreviewLine
+    {
+        public int Index { get; set; }
+        public string RawText { get; set; } = "";
+        public string Prefix { get; set; } = "";
+        public string OriginalContent { get; set; } = "";
+        public string PreparedContent { get; set; } = "";
+        public string TranslatedText { get; set; } = "";
+        public string EngineName { get; set; } = "";
+        public string Status { get; set; } = "";
+        public bool Translated { get; set; }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrHarness.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrHarness.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GameTranslator
+{
+    public partial class MainWindow
+    {
+        /// <summary>
+        /// OCR 진단 창에서 선택한 병합 라인 목록을 현재 번역 엔진으로 시험 번역합니다.
+        /// "[캐릭터명]: 내용" 형식은 캐릭터 라벨을 유지하고 내용만 번역하며,
+        /// 일반 텍스트는 RAW 프리픽스로 ETC 규칙으로 번역합니다.
+        /// </summary>
+        public async Task<OcrTranslationHarnessPreviewResult> RunOcrTranslationHarnessAsync(string candidateName, IEnumerable<string> mergedLines)
+        {
+            var result = new OcrTranslationHarnessPreviewResult
+            {
+                CandidateName = candidateName ?? ""
+            };
+
+            IReadOnlyList<OcrTranslationHarnessRequest> requests = ocrTranslationHarnessService.BuildRequests(mergedLines);
+            result.TotalLineCount = requests.Count;
+
+            var performanceStats = new OcrPerformanceStats();
+            Stopwatch stopwatch = Stopwatch.StartNew();
+
+            for (int i = 0; i < requests.Count; i++)
+            {
+                OcrTranslationHarnessRequest request = requests[i];
+                var previewLine = new OcrTranslationHarnessPreviewLine
+                {
+                    Index = i + 1,
+                    RawText = request.RawText,
+                    Prefix = request.Prefix,
+                    OriginalContent = request.ContentToTranslate
+                };
+
+                if (request.Skipped)
+                {
+                    previewLine.Status = request.SkipReason;
+                    result.SkippedLineCount++;
+                    result.Lines.Add(previewLine);
+                    continue;
+                }
+
+                string preparedContent = PrepareFinalTranslationContent(request.ContentToTranslate);
+                previewLine.PreparedContent = preparedContent;
+
+                if (!ShouldTranslateFinalContent(preparedContent))
+                {
+                    previewLine.Status = "번역 조건 미충족";
+                    result.SkippedLineCount++;
+                    result.Lines.Add(previewLine);
+                    continue;
+                }
+
+                TranslationDecisionResult translationResult = await TranslateFinalContentAsync(preparedContent, performanceStats, request.ContentMode);
+                previewLine.TranslatedText = translationResult.TranslatedText;
+                previewLine.EngineName = translationResult.EngineName;
+                previewLine.Status = "OK";
+                previewLine.Translated = true;
+                result.TranslatedLineCount++;
+                result.Lines.Add(previewLine);
+            }
+
+            stopwatch.Stop();
+            result.TranslateMs = stopwatch.ElapsedMilliseconds;
+            return result;
+        }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -70,6 +70,7 @@ namespace GameTranslator
         private readonly TranslationPromptBuilder translationPromptBuilder = new TranslationPromptBuilder();
         private readonly TranslationResultParser translationResultParser = new TranslationResultParser();
         private readonly TranslationService translationService = new TranslationService();
+        private readonly OcrTranslationHarnessService ocrTranslationHarnessService = new OcrTranslationHarnessService();
         private readonly TranslationApiErrorDescriber translationApiErrorDescriber = new TranslationApiErrorDescriber();
         private readonly TranslationApiClient translationApiClient;
         private AppDataPaths appDataPaths;

--- a/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml
+++ b/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml
@@ -36,6 +36,16 @@
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <Button x:Name="BtnRunHarness"
+                        Content="선택 후보 번역 테스트"
+                        Padding="12,5"
+                        Margin="0,0,8,0"
+                        Background="#5C4A7A"
+                        Foreground="White"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        IsEnabled="False"
+                        Click="BtnRunHarness_Click"/>
                 <Button x:Name="BtnCopySummary"
                         Content="요약 복사"
                         Padding="12,5"
@@ -104,6 +114,42 @@
                     <TextBlock Text="OCR 호출" Foreground="#AAAAAA" FontSize="11"/>
                     <TextBlock x:Name="TxtOcrCalls" Text="-" Foreground="#9CDCFE" FontWeight="Bold" FontSize="16"/>
                 </StackPanel>
+            </Grid>
+        </Border>
+
+        <Border DockPanel.Dock="Top"
+                BorderBrush="#555"
+                BorderThickness="1"
+                Background="#252525"
+                Padding="10"
+                Margin="0,0,0,10">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <TextBlock x:Name="TxtHarnessStatus"
+                           Text="선택 후보 번역 테스트 준비"
+                           Foreground="#CCCCCC"
+                           FontWeight="Bold"
+                           Margin="0,0,0,8"/>
+
+                <TextBox x:Name="TxtHarnessPreview"
+                         Grid.Row="1"
+                         IsReadOnly="True"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         VerticalScrollBarVisibility="Auto"
+                         HorizontalScrollBarVisibility="Auto"
+                         Background="#111111"
+                         Foreground="#E6E6E6"
+                         BorderBrush="#555555"
+                         FontFamily="Consolas"
+                         FontSize="12"
+                         Padding="8"
+                         MinHeight="160"
+                         Text="선택 후보를 대상으로 [캐릭터이름]: 내용 형식을 우선 파싱하고, 내용만 현재 번역 엔진으로 테스트합니다."/>
             </Grid>
         </Border>
 

--- a/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
+++ b/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -24,6 +25,7 @@ namespace GameTranslator
         private readonly OcrDiagnosticExporter diagnosticExporter = new OcrDiagnosticExporter();
         private readonly string defaultExportDirectory;
         private OcrDiagnosticResult lastDiagnosticResult;
+        private OcrTranslationHarnessPreviewResult lastHarnessPreviewResult;
 
         /// <summary>
         /// OCR 진단 창을 생성합니다.
@@ -56,6 +58,9 @@ namespace GameTranslator
             BtnRunDiagnostic.IsEnabled = false;
             SetResultActionButtonsEnabled(false);
             TxtStatus.Text = "OCR 진단 실행 중...";
+            TxtHarnessStatus.Text = "선택 후보 번역 테스트 준비";
+            TxtHarnessPreview.Text = "선택 후보를 대상으로 [캐릭터이름]: 내용 형식을 우선 파싱하고, 내용만 현재 번역 엔진으로 테스트합니다.";
+            lastHarnessPreviewResult = null;
             UpdateSummaryHeader(null);
 
             try
@@ -69,6 +74,7 @@ namespace GameTranslator
             catch (Exception ex)
             {
                 lastDiagnosticResult = null;
+                lastHarnessPreviewResult = null;
                 TabDiagnostics.Items.Clear();
                 TabDiagnostics.Items.Add(CreateTextTab("오류", ex.Message));
                 SetResultActionButtonsEnabled(false);
@@ -176,6 +182,49 @@ namespace GameTranslator
             {
                 WpfMessageBox.Show(this, $"OCR 진단 결과 복사에 실패했습니다.\n{ex.Message}", "OCR 진단 결과 복사 실패", MessageBoxButton.OK, MessageBoxImage.Warning);
                 TxtStatus.Text = $"복사 실패: {ex.Message}";
+            }
+        }
+
+        /// <summary>
+        /// 현재 선택된 OCR 후보의 병합 라인을 현재 번역 엔진으로 시험 번역합니다.
+        /// 채팅 형식은 [캐릭터명]: 접두어를 유지하고 본문만 번역하며, 파싱 실패 라인은 RAW 모드로 처리합니다.
+        /// </summary>
+        private async void BtnRunHarness_Click(object sender, RoutedEventArgs e)
+        {
+            if (lastDiagnosticResult == null)
+            {
+                WpfMessageBox.Show(this, "먼저 OCR 진단을 실행해 주세요.", "번역 테스트", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            OcrDiagnosticCandidate selectedCandidate = lastDiagnosticResult.Candidates
+                .FirstOrDefault(candidate => candidate.Name == lastDiagnosticResult.SelectedCandidateName)
+                ?? lastDiagnosticResult.Candidates.FirstOrDefault();
+
+            if (selectedCandidate == null)
+            {
+                WpfMessageBox.Show(this, "번역 테스트에 사용할 OCR 후보가 없습니다.", "번역 테스트", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            BtnRunHarness.IsEnabled = false;
+            TxtHarnessStatus.Text = "선택 후보 번역 테스트 실행 중...";
+
+            try
+            {
+                lastHarnessPreviewResult = await mainWindow.RunOcrTranslationHarnessAsync(selectedCandidate.Name, selectedCandidate.MergedLines);
+                TxtHarnessPreview.Text = BuildHarnessPreviewText(lastHarnessPreviewResult);
+                TxtHarnessStatus.Text = $"번역 테스트 완료: {lastHarnessPreviewResult.TranslatedLineCount}개 번역 / {lastHarnessPreviewResult.SkippedLineCount}개 스킵 / {lastHarnessPreviewResult.TranslateMs}ms";
+            }
+            catch (Exception ex)
+            {
+                lastHarnessPreviewResult = null;
+                TxtHarnessPreview.Text = ex.Message;
+                TxtHarnessStatus.Text = $"번역 테스트 실패: {ex.Message}";
+            }
+            finally
+            {
+                BtnRunHarness.IsEnabled = true;
             }
         }
 
@@ -534,9 +583,61 @@ namespace GameTranslator
 
         private void SetResultActionButtonsEnabled(bool enabled)
         {
+            BtnRunHarness.IsEnabled = enabled;
             BtnCopySummary.IsEnabled = enabled;
             BtnCopyDiagnostic.IsEnabled = enabled;
             BtnSaveDiagnostic.IsEnabled = enabled;
+        }
+
+        private string BuildHarnessPreviewText(OcrTranslationHarnessPreviewResult result)
+        {
+            if (result == null)
+            {
+                return "선택 후보 번역 테스트 결과가 없습니다.";
+            }
+
+            var builder = new System.Text.StringBuilder();
+            builder.AppendLine("[선택 후보 번역 테스트]");
+            builder.AppendLine($"후보: {EmptyToDash(result.CandidateName)}");
+            builder.AppendLine($"전체 라인: {result.TotalLineCount}");
+            builder.AppendLine($"번역 완료: {result.TranslatedLineCount}");
+            builder.AppendLine($"스킵: {result.SkippedLineCount}");
+            builder.AppendLine($"처리 시간: {result.TranslateMs}ms");
+
+            foreach (OcrTranslationHarnessPreviewLine line in result.Lines)
+            {
+                builder.AppendLine();
+                builder.AppendLine($"{line.Index:00}. 상태: {EmptyToDash(line.Status)}");
+                builder.AppendLine($"OCR 원문: {EmptyToDash(line.RawText)}");
+
+                if (!string.IsNullOrWhiteSpace(line.Prefix))
+                {
+                    builder.AppendLine($"출력 접두어: {line.Prefix}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(line.OriginalContent))
+                {
+                    builder.AppendLine($"원문 본문: {line.OriginalContent}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(line.PreparedContent))
+                {
+                    builder.AppendLine($"번역 입력: {line.PreparedContent}");
+                }
+
+                if (line.Translated)
+                {
+                    builder.AppendLine($"번역 결과: {line.Prefix}{line.TranslatedText}");
+                    builder.AppendLine($"엔진: {EmptyToDash(line.EngineName)}");
+                }
+            }
+
+            return builder.ToString().TrimEnd();
+        }
+
+        private static string EmptyToDash(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? "-" : value.Trim();
         }
 
         /// <summary>


### PR DESCRIPTION
요약
- OCR 진단 창에 선택 후보 번역 테스트 하네스 추가
- "[캐릭터이름]: 내용" 형식은 라벨 유지 + 내용만 번역
- 파싱 실패 라인은 RAW fallback으로 ETC 정리 후 테스트

## 반영 내용
- OcrTranslationHarnessService 순수 로직 추가
- OcrDiagnosticWindow에 선택 후보 번역 테스트 버튼/결과 패널 추가
- MainWindow에 하네스 실행 래퍼 추가
- 하네스 모델 및 단위 테스트 추가

## 검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-harness
