### PR TITLE
개선: OCR 하네스 시스템 문구 필터 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrTranslationHarnessServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrTranslationHarnessServiceTests.cs
@@ -47,5 +47,36 @@ namespace GameChatTranslator.Tests
             Assert.True(request.Skipped);
             Assert.Equal("파싱 실패 / 노이즈", request.SkipReason);
         }
+
+        [Fact]
+        public void BuildRequests_SkipsSystemUiLineWhenSystemLabelAndUiKeywordAreCombined()
+        {
+            var request = _service.BuildRequests(new[] { "[팀]! 빔을 클릭해 채널 변경" }).Single();
+
+            Assert.True(request.Skipped);
+            Assert.Equal("시스템/UI 문구", request.SkipReason);
+        }
+
+        [Fact]
+        public void BuildRequests_KeepsExclamationSeparatedChatLineWhenItIsNotSystemUiText()
+        {
+            var request = _service.BuildRequests(new[] { "[치요]! 공격 시작" }).Single();
+
+            Assert.False(request.Skipped);
+            Assert.Equal("[치요]: ", request.Prefix);
+            Assert.Equal("공격 시작", request.ContentToTranslate);
+            Assert.Equal(TranslationContentMode.Strinova, request.ContentMode);
+        }
+
+        [Fact]
+        public void BuildRequests_KeepsTeamLineWhenItDoesNotContainUiKeyword()
+        {
+            var request = _service.BuildRequests(new[] { "[팀]! 공격 집결" }).Single();
+
+            Assert.False(request.Skipped);
+            Assert.Equal("[팀]: ", request.Prefix);
+            Assert.Equal("공격 집결", request.ContentToTranslate);
+            Assert.Equal(TranslationContentMode.Strinova, request.ContentMode);
+        }
     }
 }

--- a/GameChatTranslator/Core/OcrTranslationHarnessService.cs
+++ b/GameChatTranslator/Core/OcrTranslationHarnessService.cs
@@ -10,6 +10,23 @@ namespace GameTranslator
     /// </summary>
     public sealed class OcrTranslationHarnessService
     {
+        private static readonly HashSet<string> SystemLabelCandidates = new HashSet<string>(new[]
+        {
+            "팀",
+            "공지",
+            "시스템"
+        });
+
+        private static readonly string[] UiKeywords =
+        {
+            "클릭",
+            "채널 변경",
+            "선택",
+            "설정",
+            "닫기",
+            "확인"
+        };
+
         private readonly TranslationPromptBuilder translationPromptBuilder;
 
         public OcrTranslationHarnessService(TranslationPromptBuilder translationPromptBuilder = null)
@@ -38,6 +55,12 @@ namespace GameTranslator
                 if (ChatTextAnalyzer.TryParseChatLine(text, out ChatTextAnalyzer.ChatLine chatLine) &&
                     !string.IsNullOrWhiteSpace(chatLine.Message))
                 {
+                    if (ShouldSkipSystemUiLine(chatLine))
+                    {
+                        requests.Add(OcrTranslationHarnessRequest.Skip(text, "시스템/UI 문구"));
+                        continue;
+                    }
+
                     requests.Add(OcrTranslationHarnessRequest.Chat(text, chatLine.CharacterLabel, chatLine.Message));
                     continue;
                 }
@@ -53,6 +76,22 @@ namespace GameTranslator
             }
 
             return requests;
+        }
+
+        private static bool ShouldSkipSystemUiLine(ChatTextAnalyzer.ChatLine chatLine)
+        {
+            if (chatLine == null)
+            {
+                return false;
+            }
+
+            if (!SystemLabelCandidates.Contains((chatLine.CharacterName ?? "").Trim()))
+            {
+                return false;
+            }
+
+            string message = chatLine.Message ?? "";
+            return UiKeywords.Any(keyword => message.Contains(keyword));
         }
     }
 


### PR DESCRIPTION
요약
- OCR 하네스에서 시스템/UI 문구 라인 제외 추가
- `!` 구분 채팅은 유지하고 `[팀]! ... 클릭 ... 채널 변경` 같은 줄만 보수적으로 스킵
- 하네스 전용 범위만 수정하고 메인 OCR 선택 로직은 건드리지 않음

## 반영 내용
- 시스템 라벨 후보: 팀 / 공지 / 시스템
- UI 키워드: 클릭 / 채널 변경 / 선택 / 설정 / 닫기 / 확인
- 시스템 라벨 AND UI 키워드 조합일 때만 `시스템/UI 문구`로 스킵
- `!` 구분 실채팅과 `[팀]! 공격 집결` 같은 비-UI 문장은 그대로 허용

## 검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-harness-ui-filter

관련 이슈
- #119
