### PR TITLE
기능: OCR 진단에 Tesseract 후보 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrDiagnosticExporterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrDiagnosticExporterTests.cs
@@ -22,6 +22,7 @@ namespace GameChatTranslator.Tests
             Assert.Contains("Threshold: 120", summary);
             Assert.Contains("Total: 70ms", summary);
             Assert.Contains("- Color: 123", summary);
+            Assert.Contains("외부 OCR 상태: Tesseract 후보 추가 (jpn+eng+kor+chi_sim)", summary);
             Assert.Contains("앱 버전: v.test", summary);
             Assert.Contains("게임 언어: ko", summary);
             Assert.Contains("현재 자동 OCR 모드: 자동", summary);
@@ -124,6 +125,7 @@ namespace GameChatTranslator.Tests
                 ScoringMs = 15,
                 TotalMs = 70,
                 OcrCallCount = 2,
+                ExternalOcrStatus = "Tesseract 후보 추가 (jpn+eng+kor+chi_sim)",
                 Metadata = new OcrDiagnosticMetadata
                 {
                     AppVersion = "v.test",

--- a/GameChatTranslator.Tests/Core/Ocr/TesseractCliOcrAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/TesseractCliOcrAdapterTests.cs
@@ -1,0 +1,49 @@
+using GameTranslator;
+using System.Runtime.Versioning;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    [SupportedOSPlatform("windows")]
+    public class TesseractCliOcrAdapterTests
+    {
+        private readonly TesseractCliOcrAdapter _adapter = new TesseractCliOcrAdapter();
+
+        [Fact]
+        public void BuildLanguageCodes_UsesGameLanguageFirstAndDeduplicatesDefaults()
+        {
+            string value = _adapter.BuildLanguageCodes(SettingsService.DefaultTesseractLanguageCodes, "ja");
+
+            Assert.Equal("jpn+eng+kor+chi_sim", value);
+        }
+
+        [Fact]
+        public void BuildLanguageCodes_UsesConfiguredCodesWhenProvided()
+        {
+            string value = _adapter.BuildLanguageCodes("ja, en-US, chi_sim", "ko");
+
+            Assert.Equal("jpn+eng+chi_sim", value);
+        }
+
+        [Theory]
+        [InlineData("ko", "kor")]
+        [InlineData("en-US", "eng")]
+        [InlineData("zh-Hans-CN", "chi_sim")]
+        [InlineData("ru", "rus")]
+        [InlineData("jpn", "jpn")]
+        public void MapAppLanguageTagToTesseract_MapsKnownTags(string input, string expected)
+        {
+            Assert.Equal(expected, _adapter.MapAppLanguageTagToTesseract(input));
+        }
+
+        [Fact]
+        public void ParseOutputLines_RemovesBlankLinesAndTrims()
+        {
+            var lines = _adapter.ParseOutputLines("  猫 は 可 愛 い  \r\n\r\n [치요]: 안녕 \n");
+
+            Assert.Equal(2, lines.Count);
+            Assert.Equal("猫 は 可 愛 い", lines[0]);
+            Assert.Equal("[치요]: 안녕", lines[1]);
+        }
+    }
+}

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
@@ -24,6 +25,7 @@
     <Compile Include="../GameChatTranslator/Core/OcrLanguageStatusFormatter.cs" Link="Core/OcrLanguageStatusFormatter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
+    <Compile Include="../GameChatTranslator/Core/TesseractCliOcrAdapter.cs" Link="Core/TesseractCliOcrAdapter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrTranslationHarnessService.cs" Link="Core/OcrTranslationHarnessService.cs" />
     <Compile Include="../GameChatTranslator/Models/OcrDiagnosticModels.cs" Link="Models/OcrDiagnosticModels.cs" />
     <Compile Include="../GameChatTranslator/Models/OcrHarnessModels.cs" Link="Models/OcrHarnessModels.cs" />

--- a/GameChatTranslator/Core/OcrDiagnosticExporter.cs
+++ b/GameChatTranslator/Core/OcrDiagnosticExporter.cs
@@ -66,6 +66,10 @@ namespace GameTranslator
             builder.AppendLine($"선택 점수: {result.SelectedScore}");
             builder.AppendLine($"후보 수: {result.Candidates.Count}");
             builder.AppendLine($"OCR 호출 수: {result.OcrCallCount}");
+            if (!string.IsNullOrWhiteSpace(result.ExternalOcrStatus))
+            {
+                builder.AppendLine($"외부 OCR 상태: {result.ExternalOcrStatus}");
+            }
             builder.AppendLine();
             builder.AppendLine("[처리 시간]");
             builder.AppendLine($"Capture: {result.CaptureMs}ms");

--- a/GameChatTranslator/Core/SettingsService.cs
+++ b/GameChatTranslator/Core/SettingsService.cs
@@ -17,6 +17,8 @@ namespace GameTranslator
         public const int DefaultLocalLlmMaxTokens = 160;
         public const int MinLocalLlmMaxTokens = 40;
         public const int MaxLocalLlmMaxTokens = 512;
+        public const string DefaultTesseractExecutablePath = "tesseract";
+        public const string DefaultTesseractLanguageCodes = "eng+kor+jpn+chi_sim";
         public const string DefaultTranslationEngine = "Google";
         public const string DefaultTranslationContentMode = "Strinova";
         public const string DefaultResultDisplayMode = "Latest";
@@ -88,6 +90,23 @@ namespace GameTranslator
         public int NormalizeLocalLlmMaxTokens(string value)
         {
             return NormalizeInt(value, DefaultLocalLlmMaxTokens, MinLocalLlmMaxTokens, MaxLocalLlmMaxTokens);
+        }
+
+        /// <summary>
+        /// Tesseract 실행 파일 경로가 비어 있으면 기본 명령 이름을 반환합니다.
+        /// 실제 설치 경로 자동 탐지는 런타임 어댑터에서 수행하고, 설정 파일에는 단순 기본값만 유지합니다.
+        /// </summary>
+        public string NormalizeTesseractExecutablePath(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? DefaultTesseractExecutablePath : value.Trim();
+        }
+
+        /// <summary>
+        /// Tesseract 언어 코드 문자열이 비어 있으면 기본 다국어 조합을 반환합니다.
+        /// </summary>
+        public string NormalizeTesseractLanguageCodes(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? DefaultTesseractLanguageCodes : value.Trim();
         }
 
         /// <summary>

--- a/GameChatTranslator/Core/TesseractCliOcrAdapter.cs
+++ b/GameChatTranslator/Core/TesseractCliOcrAdapter.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Text;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// 실험 브랜치에서 Tesseract CLI를 외부 OCR 어댑터로 호출합니다.
+    /// 설치형 통합 전에 Win OCR 결과와 같은 진단 화면에서 비교할 수 있도록, 실행 파일 탐색/언어 코드 조합/텍스트 파싱만 담당합니다.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public sealed class TesseractCliOcrAdapter
+    {
+        private static readonly Dictionary<string, string> AppLanguageToTesseractMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ko"] = "kor",
+            ["ko-KR"] = "kor",
+            ["en"] = "eng",
+            ["en-US"] = "eng",
+            ["ja"] = "jpn",
+            ["ja-JP"] = "jpn",
+            ["zh-Hans-CN"] = "chi_sim",
+            ["zh-CN"] = "chi_sim",
+            ["ru"] = "rus",
+            ["ru-RU"] = "rus"
+        };
+
+        private static readonly string[] CommonWindowsExecutablePaths =
+        {
+            @"C:\Program Files\Tesseract-OCR\tesseract.exe",
+            @"C:\Program Files (x86)\Tesseract-OCR\tesseract.exe"
+        };
+
+        public string BuildLanguageCodes(string configuredValue, string gameLanguage)
+        {
+            if (!string.IsNullOrWhiteSpace(configuredValue) &&
+                !string.Equals(configuredValue.Trim(), SettingsService.DefaultTesseractLanguageCodes, StringComparison.OrdinalIgnoreCase))
+            {
+                return NormalizeLanguageCodes(configuredValue);
+            }
+
+            var codes = new List<string>();
+            string mappedGameLanguage = MapAppLanguageTagToTesseract(gameLanguage);
+            if (!string.IsNullOrWhiteSpace(mappedGameLanguage))
+            {
+                codes.Add(mappedGameLanguage);
+            }
+
+            codes.Add("eng");
+            codes.Add("kor");
+            codes.Add("jpn");
+            codes.Add("chi_sim");
+
+            return string.Join("+", codes.Distinct(StringComparer.OrdinalIgnoreCase));
+        }
+
+        public string NormalizeLanguageCodes(string rawValue)
+        {
+            IEnumerable<string> tokens = (rawValue ?? "")
+                .Split(new[] { '+', ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(token => MapAppLanguageTagToTesseract(token.Trim()))
+                .Where(token => !string.IsNullOrWhiteSpace(token))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+
+            string normalized = string.Join("+", tokens);
+            return string.IsNullOrWhiteSpace(normalized) ? SettingsService.DefaultTesseractLanguageCodes : normalized;
+        }
+
+        public string MapAppLanguageTagToTesseract(string languageTag)
+        {
+            if (string.IsNullOrWhiteSpace(languageTag))
+            {
+                return "";
+            }
+
+            string normalized = languageTag.Trim();
+            return AppLanguageToTesseractMap.TryGetValue(normalized, out string mapped)
+                ? mapped
+                : normalized;
+        }
+
+        public IReadOnlyList<string> ParseOutputLines(string output)
+        {
+            return (output ?? "")
+                .Replace("\r\n", "\n")
+                .Split('\n')
+                .Select(line => line.Trim())
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .ToList();
+        }
+
+        public TesseractCliOcrResult Recognize(Bitmap bitmap, string configuredExecutablePath, string configuredLanguageCodes, int timeoutMs = 15000)
+        {
+            if (bitmap == null)
+            {
+                return TesseractCliOcrResult.CreateFailure("", "", "OCR 입력 이미지가 없습니다.");
+            }
+
+            string languageCodes = BuildLanguageCodes(configuredLanguageCodes, "");
+            string inputDirectory = Path.Combine(Path.GetTempPath(), "GameChatTranslator", "Tesseract");
+            Directory.CreateDirectory(inputDirectory);
+
+            string inputFilePath = Path.Combine(inputDirectory, $"ocr_{Guid.NewGuid():N}.png");
+            bitmap.Save(inputFilePath, ImageFormat.Png);
+
+            try
+            {
+                foreach (string executablePath in GetExecutableCandidates(configuredExecutablePath))
+                {
+                    TesseractCliOcrResult runResult = TryRecognizeInternal(executablePath, languageCodes, inputFilePath, timeoutMs);
+                    if (runResult.Success || !runResult.IsExecutableMissing)
+                    {
+                        return runResult;
+                    }
+                }
+
+                return TesseractCliOcrResult.CreateFailure(
+                    SettingsService.DefaultTesseractExecutablePath,
+                    languageCodes,
+                    "tesseract.exe를 찾지 못했습니다. PATH 또는 config.ini의 TesseractExePath를 확인해 주세요.",
+                    isExecutableMissing: true);
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(inputFilePath))
+                    {
+                        File.Delete(inputFilePath);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        private IEnumerable<string> GetExecutableCandidates(string configuredExecutablePath)
+        {
+            var candidates = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(configuredExecutablePath))
+            {
+                candidates.Add(configuredExecutablePath.Trim());
+            }
+
+            string environmentPath = Environment.GetEnvironmentVariable("TESSERACT_PATH");
+            if (!string.IsNullOrWhiteSpace(environmentPath))
+            {
+                candidates.Add(environmentPath.Trim());
+            }
+
+            candidates.AddRange(CommonWindowsExecutablePaths);
+            candidates.Add(SettingsService.DefaultTesseractExecutablePath);
+
+            return candidates
+                .Where(candidate => !string.IsNullOrWhiteSpace(candidate))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private TesseractCliOcrResult TryRecognizeInternal(string executablePath, string languageCodes, string inputFilePath, int timeoutMs)
+        {
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
+            };
+            processStartInfo.ArgumentList.Add(inputFilePath);
+            processStartInfo.ArgumentList.Add("stdout");
+            processStartInfo.ArgumentList.Add("-l");
+            processStartInfo.ArgumentList.Add(languageCodes);
+            processStartInfo.ArgumentList.Add("--psm");
+            processStartInfo.ArgumentList.Add("6");
+            processStartInfo.ArgumentList.Add("--oem");
+            processStartInfo.ArgumentList.Add("3");
+
+            try
+            {
+                using Process process = Process.Start(processStartInfo);
+                if (process == null)
+                {
+                    return TesseractCliOcrResult.CreateFailure(executablePath, languageCodes, "Tesseract 프로세스를 시작하지 못했습니다.");
+                }
+
+                string standardOutput = process.StandardOutput.ReadToEnd();
+                string standardError = process.StandardError.ReadToEnd();
+
+                if (!process.WaitForExit(timeoutMs))
+                {
+                    try
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    catch
+                    {
+                    }
+
+                    return TesseractCliOcrResult.CreateFailure(executablePath, languageCodes, $"Tesseract 실행이 {timeoutMs}ms 안에 끝나지 않았습니다.");
+                }
+
+                List<string> lines = ParseOutputLines(standardOutput).ToList();
+                if (process.ExitCode != 0 && lines.Count == 0)
+                {
+                    return TesseractCliOcrResult.CreateFailure(executablePath, languageCodes, EmptyToFallback(standardError, $"Tesseract 종료 코드: {process.ExitCode}"));
+                }
+
+                return TesseractCliOcrResult.CreateSuccess(executablePath, languageCodes, lines, standardError);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                return TesseractCliOcrResult.CreateFailure(executablePath, languageCodes, "실행 파일을 찾지 못했습니다.", isExecutableMissing: true);
+            }
+            catch (Exception ex)
+            {
+                return TesseractCliOcrResult.CreateFailure(executablePath, languageCodes, ex.Message);
+            }
+        }
+
+        private static string EmptyToFallback(string value, string fallback)
+        {
+            return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+    }
+
+    public sealed class TesseractCliOcrResult
+    {
+        private TesseractCliOcrResult(
+            bool success,
+            string executablePath,
+            string languageCodes,
+            IReadOnlyList<string> lines,
+            string errorMessage,
+            string standardError,
+            bool isExecutableMissing)
+        {
+            Success = success;
+            ExecutablePath = executablePath ?? "";
+            LanguageCodes = languageCodes ?? "";
+            Lines = lines ?? Array.Empty<string>();
+            ErrorMessage = errorMessage ?? "";
+            StandardError = standardError ?? "";
+            IsExecutableMissing = isExecutableMissing;
+        }
+
+        public bool Success { get; }
+        public string ExecutablePath { get; }
+        public string LanguageCodes { get; }
+        public IReadOnlyList<string> Lines { get; }
+        public string ErrorMessage { get; }
+        public string StandardError { get; }
+        public bool IsExecutableMissing { get; }
+
+        public static TesseractCliOcrResult CreateSuccess(string executablePath, string languageCodes, IReadOnlyList<string> lines, string standardError)
+        {
+            return new TesseractCliOcrResult(true, executablePath, languageCodes, lines, "", standardError, false);
+        }
+
+        public static TesseractCliOcrResult CreateFailure(string executablePath, string languageCodes, string errorMessage, bool isExecutableMissing = false)
+        {
+            return new TesseractCliOcrResult(false, executablePath, languageCodes, Array.Empty<string>(), errorMessage, "", isExecutableMissing);
+        }
+    }
+}

--- a/GameChatTranslator/Models/OcrDiagnosticModels.cs
+++ b/GameChatTranslator/Models/OcrDiagnosticModels.cs
@@ -25,6 +25,7 @@ namespace GameTranslator
         public long ScoringMs { get; set; }
         public long TotalMs { get; set; }
         public int OcrCallCount { get; set; }
+        public string ExternalOcrStatus { get; set; } = "";
         public OcrDiagnosticMetadata Metadata { get; set; } = new OcrDiagnosticMetadata();
         public List<OcrDiagnosticCandidate> Candidates { get; } = new List<OcrDiagnosticCandidate>();
     }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -139,6 +139,24 @@ namespace GameTranslator
                     }
                 }
 
+                (OcrDiagnosticCandidate tesseractCandidate, string tesseractStatus, long tesseractElapsedMs) =
+                    await TryBuildTesseractDiagnosticCandidateAsync(resizedBitmap, ReadTranslationContentMode());
+                result.ExternalOcrStatus = tesseractStatus;
+                if (tesseractElapsedMs > 0)
+                {
+                    stats.OcrMs += tesseractElapsedMs;
+                    stats.OcrLanguageCallCount++;
+                }
+
+                if (tesseractCandidate != null)
+                {
+                    result.Candidates.Add(tesseractCandidate);
+                    if (bestCandidate == null || tesseractCandidate.Score > bestCandidate.Score)
+                    {
+                        bestCandidate = tesseractCandidate;
+                    }
+                }
+
                 if (bestCandidate != null)
                 {
                     result.SelectedCandidateName = bestCandidate.Name;
@@ -169,9 +187,63 @@ namespace GameTranslator
                 $"Score={result.SelectedScore}, " +
                 $"Candidates={result.Candidates.Count}, " +
                 $"OcrCalls={result.OcrCallCount}, " +
-                $"Total={result.TotalMs}ms");
+                $"Total={result.TotalMs}ms, " +
+                $"External={EmptyToDash(result.ExternalOcrStatus)}");
 
             return result;
+        }
+
+        private async Task<(OcrDiagnosticCandidate Candidate, string Status, long ElapsedMs)> TryBuildTesseractDiagnosticCandidateAsync(Bitmap resizedBitmap, TranslationContentMode contentMode)
+        {
+            string configuredExecutablePath = ReadTesseractExecutablePath();
+            string configuredLanguageCodes = ReadTesseractLanguageCodes();
+            string effectiveLanguageCodes = tesseractCliOcrAdapter.BuildLanguageCodes(configuredLanguageCodes, gameLang);
+
+            using Bitmap croppedBitmap = CropForOcr(resizedBitmap);
+            using Bitmap tesseractInputBitmap = (Bitmap)croppedBitmap.Clone();
+            byte[] croppedPng = BitmapToPngBytes(croppedBitmap);
+            byte[] preprocessedPng = BitmapToPngBytes(resizedBitmap);
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            TesseractCliOcrResult runResult = await Task.Run(() =>
+                tesseractCliOcrAdapter.Recognize(tesseractInputBitmap, configuredExecutablePath, effectiveLanguageCodes));
+            stopwatch.Stop();
+
+            if (!runResult.Success)
+            {
+                string failedStatus = $"Tesseract 미사용: {runResult.ErrorMessage}";
+                AppendLog($"[OCR DIAG] {failedStatus}");
+                return (null, failedStatus, 0);
+            }
+
+            var candidate = new OcrDiagnosticCandidate
+            {
+                Name = "Tesseract",
+                PreprocessedPng = preprocessedPng,
+                CroppedPng = croppedPng
+            };
+
+            candidate.MergedLines.AddRange(runResult.Lines);
+            candidate.Languages.Add(new OcrDiagnosticLanguageResult
+            {
+                LanguageTag = $"tesseract:{runResult.LanguageCodes}"
+            });
+            candidate.Languages[0].Lines.AddRange(runResult.Lines);
+
+            List<OcrLine> lines = runResult.Lines
+                .Select((text, index) => new OcrLine
+                {
+                    Top = index * 20,
+                    Bottom = index * 20 + 12,
+                    Text = text
+                })
+                .ToList();
+
+            candidate.Score = ScoreOcrCandidate(lines, contentMode);
+
+            string successStatus = $"Tesseract 후보 추가 ({runResult.LanguageCodes})";
+            AppendLog($"[OCR DIAG] {successStatus}");
+            return (candidate, successStatus, stopwatch.ElapsedMilliseconds);
         }
 
         /// <summary>
@@ -326,6 +398,11 @@ namespace GameTranslator
             using MemoryStream ms = new MemoryStream();
             bitmap.Save(ms, ImageFormat.Png);
             return ms.ToArray();
+        }
+
+        private static string EmptyToDash(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? "-" : value.Trim();
         }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
@@ -107,6 +107,8 @@ namespace GameTranslator
             EnsureNormalizedSetting("LocalLlmModel", settingsService.NormalizeLocalLlmModel(ini.Read("LocalLlmModel")));
             EnsureNormalizedSetting("LocalLlmTimeoutSeconds", settingsService.NormalizeLocalLlmTimeoutSeconds(ini.Read("LocalLlmTimeoutSeconds")).ToString());
             EnsureNormalizedSetting("LocalLlmMaxTokens", settingsService.NormalizeLocalLlmMaxTokens(ini.Read("LocalLlmMaxTokens")).ToString());
+            EnsureNormalizedSetting("TesseractExePath", settingsService.NormalizeTesseractExecutablePath(ini.Read("TesseractExePath")));
+            EnsureNormalizedSetting("TesseractLanguageCodes", settingsService.NormalizeTesseractLanguageCodes(ini.Read("TesseractLanguageCodes")));
 
             if (string.IsNullOrWhiteSpace(ini.Read("SaveDebugImages")))
             {
@@ -251,6 +253,24 @@ namespace GameTranslator
         private int ReadLocalLlmMaxTokens()
         {
             return settingsService.NormalizeLocalLlmMaxTokens(ini.Read("LocalLlmMaxTokens"));
+        }
+
+        /// <summary>
+        /// 외부 OCR 실험용 Tesseract 실행 파일 경로를 읽습니다.
+        /// 비어 있으면 PATH의 tesseract 명령을 기본값으로 사용합니다.
+        /// </summary>
+        private string ReadTesseractExecutablePath()
+        {
+            return settingsService.NormalizeTesseractExecutablePath(ini.Read("TesseractExePath"));
+        }
+
+        /// <summary>
+        /// 외부 OCR 실험용 Tesseract 언어 코드 조합을 읽습니다.
+        /// 비어 있으면 eng+kor+jpn+chi_sim 기본 조합을 사용합니다.
+        /// </summary>
+        private string ReadTesseractLanguageCodes()
+        {
+            return settingsService.NormalizeTesseractLanguageCodes(ini.Read("TesseractLanguageCodes"));
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -71,6 +71,7 @@ namespace GameTranslator
         private readonly TranslationResultParser translationResultParser = new TranslationResultParser();
         private readonly TranslationService translationService = new TranslationService();
         private readonly OcrTranslationHarnessService ocrTranslationHarnessService = new OcrTranslationHarnessService();
+        private readonly TesseractCliOcrAdapter tesseractCliOcrAdapter = new TesseractCliOcrAdapter();
         private readonly TranslationApiErrorDescriber translationApiErrorDescriber = new TranslationApiErrorDescriber();
         private readonly TranslationApiClient translationApiClient;
         private AppDataPaths appDataPaths;

--- a/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
+++ b/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
@@ -69,7 +69,10 @@ namespace GameTranslator
                 RenderResult(result);
                 lastDiagnosticResult = result;
                 SetResultActionButtonsEnabled(true);
-                TxtStatus.Text = $"완료: {result.SelectedCandidateName} 선택 / {result.TotalMs}ms / 요약·전체 복사 또는 ZIP 저장 가능";
+                string externalStatus = string.IsNullOrWhiteSpace(result.ExternalOcrStatus)
+                    ? ""
+                    : $" / {result.ExternalOcrStatus}";
+                TxtStatus.Text = $"완료: {result.SelectedCandidateName} 선택 / {result.TotalMs}ms{externalStatus} / 요약·전체 복사 또는 ZIP 저장 가능";
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## 요약
- OCR 진단 결과에 Tesseract 외부 OCR 후보 추가
- PATH 또는 config.ini의 TesseractExePath 기준으로 tesseract.exe 탐색
- 기본 언어 조합: gameLang 우선 + eng/kor/jpn/chi_sim
- Tesseract 실행 결과를 기존 OCR 진단 탭/점수/번역 하네스 흐름에서 바로 비교 가능

## 범위
- 메인 번역 경로 미변경
- 하네스/진단 실험 브랜치 전용 변경

## 검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-tesseract-adapter

## 참고
- 현재 브랜치는 미머지 상태인 시스템/UI 문구 필터 커밋(#120 승인분) 위에 쌓였습니다.
