### PR TITLE
개선: Tesseract OCR 비교와 줄 단위 병합 적용

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
@@ -238,6 +238,110 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void MergeBestLinesByIndex_StrinovaMode_PicksBestLinePerIndex()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "[미셸]: hello" },
+                        new OcrLine { Text = "[미셸]: !!!" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "[미셸]: !!!" },
+                        new OcrLine { Text = "[미셸]: world" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestLinesByIndex(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Strinova);
+
+            Assert.Equal(2, merged.Count);
+            Assert.Equal("[미셸]: hello", merged[0].Text);
+            Assert.Equal("[미셸]: world", merged[1].Text);
+        }
+
+        [Fact]
+        public void MergeBestLinesByIndex_TieUsesDeterministicLanguageOrder()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Top = 10, Bottom = 20, Text = "[미셸]: hello" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Top = 30, Bottom = 40, Text = "[미셸]: hello" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestLinesByIndex(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Strinova);
+
+            Assert.Single(merged);
+            Assert.Equal("[미셸]: hello", merged[0].Text);
+            Assert.Equal(30, merged[0].Top);
+            Assert.Equal(40, merged[0].Bottom);
+        }
+
+        [Fact]
+        public void MergeBestLinesByIndex_EtcMode_PicksMostReadableLinePerIndex()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "!!!" },
+                        new OcrLine { Text = "猫 は 可 愛 い" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "猫很可爱!" },
+                        new OcrLine { Text = "..." }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestLinesByIndex(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Etc);
+
+            Assert.Equal(2, merged.Count);
+            Assert.Equal("猫很可爱!", merged[0].Text);
+            Assert.Equal("猫 は 可 愛 い", merged[1].Text);
+        }
+
+        [Fact]
         public void OcrService_DoesNotReferenceWinRtOrBitmapTypes()
         {
             string assemblyQualifiedNames = string.Join(

--- a/GameChatTranslator.Tests/Core/Ocr/TesseractCliOcrAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/TesseractCliOcrAdapterTests.cs
@@ -25,6 +25,27 @@ namespace GameChatTranslator.Tests
             Assert.Equal("jpn+eng+chi_sim", value);
         }
 
+        [Fact]
+        public void BuildLanguageCombinations_DefaultValue_ReturnsThreeComparisonGroups()
+        {
+            var values = _adapter.BuildLanguageCombinations(SettingsService.DefaultTesseractLanguageCodes, "ko");
+
+            Assert.Equal(3, values.Count);
+            Assert.Equal("kor+eng", values[0]);
+            Assert.Contains("jpn+eng", values);
+            Assert.Contains("chi_sim+eng", values);
+        }
+
+        [Fact]
+        public void BuildLanguageCombinations_CustomGroups_PreservesExplicitMatrix()
+        {
+            var values = _adapter.BuildLanguageCombinations("kor+eng|jpn+eng", "ko");
+
+            Assert.Equal(2, values.Count);
+            Assert.Equal("kor+eng", values[0]);
+            Assert.Equal("jpn+eng", values[1]);
+        }
+
         [Theory]
         [InlineData("ko", "kor")]
         [InlineData("en-US", "eng")]

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -106,6 +106,77 @@ namespace GameTranslator
 
             return bestSelection != null && bestSelection.Score > 0 ? bestSelection : null;
         }
+
+        /// <summary>
+        /// 여러 언어 조합이 반환한 OCR 라인을 줄 인덱스별로 비교해 가장 읽기 좋은 줄만 병합합니다.
+        /// 실험용 외부 OCR 비교에서 전체 언어 조합 하나를 통째로 선택하지 않고, 줄마다 더 나은 결과를 섞어 보기 위해 사용합니다.
+        /// </summary>
+        public List<OcrLine> MergeBestLinesByIndex(
+            IEnumerable<OcrLanguageCandidate> candidates,
+            ISet<string> characterNames,
+            TranslationContentMode contentMode = TranslationContentMode.Strinova)
+        {
+            List<OcrLanguageCandidate> candidateList = (candidates ?? Enumerable.Empty<OcrLanguageCandidate>())
+                .Where(candidate => candidate != null && candidate.Lines != null)
+                .ToList();
+
+            if (candidateList.Count == 0)
+            {
+                return new List<OcrLine>();
+            }
+
+            int maxLineCount = candidateList.Max(candidate => candidate.Lines.Count);
+            var mergedLines = new List<OcrLine>();
+
+            for (int lineIndex = 0; lineIndex < maxLineCount; lineIndex++)
+            {
+                OcrLine bestLine = null;
+                string bestLanguageCode = "";
+                int bestScore = int.MinValue;
+
+                foreach (OcrLanguageCandidate candidate in candidateList)
+                {
+                    if (lineIndex >= candidate.Lines.Count)
+                    {
+                        continue;
+                    }
+
+                    OcrLine currentLine = candidate.Lines[lineIndex];
+                    string currentText = currentLine?.Text ?? "";
+                    if (string.IsNullOrWhiteSpace(currentText))
+                    {
+                        continue;
+                    }
+
+                    int currentScore = ScoreLines(
+                        new[] { new OcrLine { Top = currentLine.Top, Bottom = currentLine.Bottom, Text = currentText } },
+                        characterNames,
+                        contentMode);
+
+                    if (bestLine == null ||
+                        currentScore > bestScore ||
+                        (currentScore == bestScore &&
+                         string.Compare(candidate.LanguageCode, bestLanguageCode, System.StringComparison.OrdinalIgnoreCase) < 0))
+                    {
+                        bestLine = currentLine;
+                        bestLanguageCode = candidate.LanguageCode ?? "";
+                        bestScore = currentScore;
+                    }
+                }
+
+                if (bestLine != null)
+                {
+                    mergedLines.Add(new OcrLine
+                    {
+                        Top = bestLine.Top,
+                        Bottom = bestLine.Bottom,
+                        Text = bestLine.Text
+                    });
+                }
+            }
+
+            return mergedLines;
+        }
     }
 
     /// <summary>

--- a/GameChatTranslator/Core/TesseractCliOcrAdapter.cs
+++ b/GameChatTranslator/Core/TesseractCliOcrAdapter.cs
@@ -37,6 +37,13 @@ namespace GameTranslator
             @"C:\Program Files (x86)\Tesseract-OCR\tesseract.exe"
         };
 
+        private static readonly string[] DefaultLanguagePriority =
+        {
+            "jpn",
+            "kor",
+            "chi_sim"
+        };
+
         public string BuildLanguageCodes(string configuredValue, string gameLanguage)
         {
             if (!string.IsNullOrWhiteSpace(configuredValue) &&
@@ -58,6 +65,44 @@ namespace GameTranslator
             codes.Add("chi_sim");
 
             return string.Join("+", codes.Distinct(StringComparer.OrdinalIgnoreCase));
+        }
+
+        public IReadOnlyList<string> BuildLanguageCombinations(string configuredValue, string gameLanguage)
+        {
+            string normalizedConfiguredValue = (configuredValue ?? "").Trim();
+
+            if (string.IsNullOrWhiteSpace(normalizedConfiguredValue) ||
+                string.Equals(normalizedConfiguredValue, SettingsService.DefaultTesseractLanguageCodes, StringComparison.OrdinalIgnoreCase))
+            {
+                var combinations = new List<string>();
+                string mappedGameLanguage = MapAppLanguageTagToTesseract(gameLanguage);
+                if (!string.IsNullOrWhiteSpace(mappedGameLanguage) &&
+                    !string.Equals(mappedGameLanguage, "eng", StringComparison.OrdinalIgnoreCase))
+                {
+                    combinations.Add(BuildPair(mappedGameLanguage));
+                }
+
+                foreach (string languageCode in DefaultLanguagePriority)
+                {
+                    combinations.Add(BuildPair(languageCode));
+                }
+
+                return combinations
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+
+            if (normalizedConfiguredValue.Contains('|') || normalizedConfiguredValue.Contains('\n'))
+            {
+                return normalizedConfiguredValue
+                    .Split(new[] { '|', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(NormalizeLanguageCodes)
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+
+            return new[] { NormalizeLanguageCodes(normalizedConfiguredValue) };
         }
 
         public string NormalizeLanguageCodes(string rawValue)
@@ -230,6 +275,17 @@ namespace GameTranslator
         private static string EmptyToFallback(string value, string fallback)
         {
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+
+        private static string BuildPair(string primaryLanguageCode)
+        {
+            if (string.IsNullOrWhiteSpace(primaryLanguageCode) ||
+                string.Equals(primaryLanguageCode, "eng", StringComparison.OrdinalIgnoreCase))
+            {
+                return "eng";
+            }
+
+            return $"{primaryLanguageCode}+eng";
         }
     }
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -12,6 +12,8 @@ namespace GameTranslator
 {
     public partial class MainWindow
     {
+        private const int TesseractDiagnosticTimeoutMs = 2500;
+
         /// <summary>
         /// OCR 테스트/진단 창을 열거나 이미 열린 창을 앞으로 가져옵니다.
         /// 진단 창은 현재 캡처 영역을 실제 번역 로직과 같은 전처리/OCR 기준으로 분석합니다.
@@ -139,16 +141,12 @@ namespace GameTranslator
                     }
                 }
 
-                (OcrDiagnosticCandidate tesseractCandidate, string tesseractStatus, long tesseractElapsedMs) =
-                    await TryBuildTesseractDiagnosticCandidateAsync(resizedBitmap, ReadTranslationContentMode());
-                result.ExternalOcrStatus = tesseractStatus;
-                if (tesseractElapsedMs > 0)
-                {
-                    stats.OcrMs += tesseractElapsedMs;
-                    stats.OcrLanguageCallCount++;
-                }
+                TesseractDiagnosticSummary tesseractSummary = await TryBuildTesseractDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode());
+                result.ExternalOcrStatus = tesseractSummary.Status;
+                stats.OcrMs += tesseractSummary.ElapsedMs;
+                stats.OcrLanguageCallCount += tesseractSummary.CallCount;
 
-                if (tesseractCandidate != null)
+                foreach (OcrDiagnosticCandidate tesseractCandidate in tesseractSummary.Candidates)
                 {
                     result.Candidates.Add(tesseractCandidate);
                     if (bestCandidate == null || tesseractCandidate.Score > bestCandidate.Score)
@@ -193,57 +191,130 @@ namespace GameTranslator
             return result;
         }
 
-        private async Task<(OcrDiagnosticCandidate Candidate, string Status, long ElapsedMs)> TryBuildTesseractDiagnosticCandidateAsync(Bitmap resizedBitmap, TranslationContentMode contentMode)
+        private async Task<TesseractDiagnosticSummary> TryBuildTesseractDiagnosticCandidatesAsync(IEnumerable<PreprocessedOcrImage> preprocessedImages, TranslationContentMode contentMode)
         {
             string configuredExecutablePath = ReadTesseractExecutablePath();
             string configuredLanguageCodes = ReadTesseractLanguageCodes();
-            string effectiveLanguageCodes = tesseractCliOcrAdapter.BuildLanguageCodes(configuredLanguageCodes, gameLang);
+            IReadOnlyList<string> languageCombinations = tesseractCliOcrAdapter.BuildLanguageCombinations(configuredLanguageCodes, gameLang);
 
-            using Bitmap croppedBitmap = CropForOcr(resizedBitmap);
-            using Bitmap tesseractInputBitmap = (Bitmap)croppedBitmap.Clone();
-            byte[] croppedPng = BitmapToPngBytes(croppedBitmap);
-            byte[] preprocessedPng = BitmapToPngBytes(resizedBitmap);
+            int totalCallCount = 0;
+            long totalElapsedMs = 0;
+            int successCount = 0;
+            int failureCount = 0;
+            bool executableMissing = false;
+            string firstErrorMessage = "";
+            var candidates = new List<OcrDiagnosticCandidate>();
 
-            Stopwatch stopwatch = Stopwatch.StartNew();
-            TesseractCliOcrResult runResult = await Task.Run(() =>
-                tesseractCliOcrAdapter.Recognize(tesseractInputBitmap, configuredExecutablePath, effectiveLanguageCodes));
-            stopwatch.Stop();
-
-            if (!runResult.Success)
+            foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
             {
-                string failedStatus = $"Tesseract 미사용: {runResult.ErrorMessage}";
-                AppendLog($"[OCR DIAG] {failedStatus}");
-                return (null, failedStatus, 0);
+                using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
+                byte[] croppedPng = BitmapToPngBytes(croppedBitmap);
+                byte[] preprocessedPng = BitmapToPngBytes(preprocessedImage.Bitmap);
+
+                var candidate = new OcrDiagnosticCandidate
+                {
+                    Name = $"Tesseract-{preprocessedImage.Name}",
+                    PreprocessedPng = preprocessedPng,
+                    CroppedPng = croppedPng
+                };
+
+                List<OcrLine> bestLines = null;
+                int bestScore = int.MinValue;
+                string bestLanguageCode = "";
+
+                foreach (string languageCombination in languageCombinations)
+                {
+                    totalCallCount++;
+
+                    Stopwatch stopwatch = Stopwatch.StartNew();
+                    using Bitmap tesseractInputBitmap = (Bitmap)croppedBitmap.Clone();
+                    TesseractCliOcrResult runResult = await Task.Run(() =>
+                        tesseractCliOcrAdapter.Recognize(
+                            tesseractInputBitmap,
+                            configuredExecutablePath,
+                            languageCombination,
+                            TesseractDiagnosticTimeoutMs));
+                    stopwatch.Stop();
+                    totalElapsedMs += stopwatch.ElapsedMilliseconds;
+
+                    if (!runResult.Success)
+                    {
+                        failureCount++;
+                        if (string.IsNullOrWhiteSpace(firstErrorMessage))
+                        {
+                            firstErrorMessage = runResult.ErrorMessage;
+                        }
+
+                        if (runResult.IsExecutableMissing)
+                        {
+                            executableMissing = true;
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    successCount++;
+
+                    var languageResult = new OcrDiagnosticLanguageResult
+                    {
+                        LanguageTag = $"tesseract:{runResult.LanguageCodes}"
+                    };
+                    languageResult.Lines.AddRange(runResult.Lines);
+                    candidate.Languages.Add(languageResult);
+
+                    List<OcrLine> lines = runResult.Lines
+                        .Select((text, index) => new OcrLine
+                        {
+                            Top = index * 20,
+                            Bottom = index * 20 + 12,
+                            Text = text
+                        })
+                        .ToList();
+                    int score = ScoreOcrCandidate(lines, contentMode);
+
+                    if (bestLines == null ||
+                        score > bestScore ||
+                        (score == bestScore &&
+                         string.Compare(languageCombination, bestLanguageCode, StringComparison.OrdinalIgnoreCase) < 0))
+                    {
+                        bestLines = lines;
+                        bestScore = score;
+                        bestLanguageCode = languageCombination;
+                    }
+                }
+
+                if (executableMissing)
+                {
+                    break;
+                }
+
+                if (bestLines != null && candidate.Languages.Count > 0)
+                {
+                    candidate.MergedLines.AddRange(bestLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                    candidate.Score = bestScore;
+                    candidates.Add(candidate);
+                }
             }
 
-            var candidate = new OcrDiagnosticCandidate
+            if (executableMissing)
             {
-                Name = "Tesseract",
-                PreprocessedPng = preprocessedPng,
-                CroppedPng = croppedPng
-            };
+                string failedStatus = $"Tesseract 미사용: {firstErrorMessage}";
+                AppendLog($"[OCR DIAG] {failedStatus}");
+                return new TesseractDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
+            }
 
-            candidate.MergedLines.AddRange(runResult.Lines);
-            candidate.Languages.Add(new OcrDiagnosticLanguageResult
+            if (successCount == 0)
             {
-                LanguageTag = $"tesseract:{runResult.LanguageCodes}"
-            });
-            candidate.Languages[0].Lines.AddRange(runResult.Lines);
+                string failedStatus = $"Tesseract 실패: {firstErrorMessage}";
+                AppendLog($"[OCR DIAG] {failedStatus}");
+                return new TesseractDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
+            }
 
-            List<OcrLine> lines = runResult.Lines
-                .Select((text, index) => new OcrLine
-                {
-                    Top = index * 20,
-                    Bottom = index * 20 + 12,
-                    Text = text
-                })
-                .ToList();
-
-            candidate.Score = ScoreOcrCandidate(lines, contentMode);
-
-            string successStatus = $"Tesseract 후보 추가 ({runResult.LanguageCodes})";
+            string successStatus =
+                $"Tesseract 후보 {candidates.Count}개 추가 / {successCount}회 성공 / {failureCount}회 실패 / timeout {TesseractDiagnosticTimeoutMs}ms";
             AppendLog($"[OCR DIAG] {successStatus}");
-            return (candidate, successStatus, stopwatch.ElapsedMilliseconds);
+            return new TesseractDiagnosticSummary(candidates, successStatus, totalElapsedMs, totalCallCount);
         }
 
         /// <summary>
@@ -403,6 +474,22 @@ namespace GameTranslator
         private static string EmptyToDash(string value)
         {
             return string.IsNullOrWhiteSpace(value) ? "-" : value.Trim();
+        }
+
+        private sealed class TesseractDiagnosticSummary
+        {
+            public TesseractDiagnosticSummary(List<OcrDiagnosticCandidate> candidates, string status, long elapsedMs, int callCount)
+            {
+                Candidates = candidates ?? new List<OcrDiagnosticCandidate>();
+                Status = status ?? "";
+                ElapsedMs = elapsedMs;
+                CallCount = callCount;
+            }
+
+            public List<OcrDiagnosticCandidate> Candidates { get; }
+            public string Status { get; }
+            public long ElapsedMs { get; }
+            public int CallCount { get; }
         }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -218,9 +218,7 @@ namespace GameTranslator
                     CroppedPng = croppedPng
                 };
 
-                List<OcrLine> bestLines = null;
-                int bestScore = int.MinValue;
-                string bestLanguageCode = "";
+                var languageCandidates = new List<OcrLanguageCandidate>();
 
                 foreach (string languageCombination in languageCombinations)
                 {
@@ -271,17 +269,11 @@ namespace GameTranslator
                             Text = text
                         })
                         .ToList();
-                    int score = ScoreOcrCandidate(lines, contentMode);
-
-                    if (bestLines == null ||
-                        score > bestScore ||
-                        (score == bestScore &&
-                         string.Compare(languageCombination, bestLanguageCode, StringComparison.OrdinalIgnoreCase) < 0))
+                    languageCandidates.Add(new OcrLanguageCandidate
                     {
-                        bestLines = lines;
-                        bestScore = score;
-                        bestLanguageCode = languageCombination;
-                    }
+                        LanguageCode = languageCombination,
+                        Lines = lines
+                    });
                 }
 
                 if (executableMissing)
@@ -289,10 +281,11 @@ namespace GameTranslator
                     break;
                 }
 
-                if (bestLines != null && candidate.Languages.Count > 0)
+                List<OcrLine> mergedLines = ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
+                if (mergedLines.Count > 0 && candidate.Languages.Count > 0)
                 {
-                    candidate.MergedLines.AddRange(bestLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                    candidate.Score = bestScore;
+                    candidate.MergedLines.AddRange(mergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                    candidate.Score = ScoreOcrCandidate(mergedLines, contentMode);
                     candidates.Add(candidate);
                 }
             }


### PR DESCRIPTION
요약
- Tesseract OCR 비교 매트릭스 추가
- Tesseract 후보를 언어조합 전체 단위가 아니라 줄 단위 최고점으로 병합
- 메인 번역 경로는 유지하고 OCR 실험 브랜치 진단/비교 흐름만 보강

## 반영 내용
- Tesseract 전처리별(Color / ColorThick / Adaptive) + 언어조합별(kor+eng / jpn+eng / chi_sim+eng) 비교
- 각 전처리 후보 내부에서 줄 인덱스별로 최고점 OCR 라인 선택
- OcrService에 MergeBestLinesByIndex 순수 로직 추가
- 줄 단위 병합 규칙 테스트 추가

## 검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-line-merge
