### PR TITLE
개선: Tesseract 줄 단위 OCR 병합 적용

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
@@ -238,6 +238,110 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void MergeBestLinesByIndex_StrinovaMode_PicksBestLinePerIndex()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "[미셸]: hello" },
+                        new OcrLine { Text = "[미셸]: !!!" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "[미셸]: !!!" },
+                        new OcrLine { Text = "[미셸]: world" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestLinesByIndex(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Strinova);
+
+            Assert.Equal(2, merged.Count);
+            Assert.Equal("[미셸]: hello", merged[0].Text);
+            Assert.Equal("[미셸]: world", merged[1].Text);
+        }
+
+        [Fact]
+        public void MergeBestLinesByIndex_TieUsesDeterministicLanguageOrder()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Top = 10, Bottom = 20, Text = "[미셸]: hello" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Top = 30, Bottom = 40, Text = "[미셸]: hello" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestLinesByIndex(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Strinova);
+
+            Assert.Single(merged);
+            Assert.Equal("[미셸]: hello", merged[0].Text);
+            Assert.Equal(30, merged[0].Top);
+            Assert.Equal(40, merged[0].Bottom);
+        }
+
+        [Fact]
+        public void MergeBestLinesByIndex_EtcMode_PicksMostReadableLinePerIndex()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "!!!" },
+                        new OcrLine { Text = "猫 は 可 愛 い" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "猫很可爱!" },
+                        new OcrLine { Text = "..." }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestLinesByIndex(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Etc);
+
+            Assert.Equal(2, merged.Count);
+            Assert.Equal("猫很可爱!", merged[0].Text);
+            Assert.Equal("猫 は 可 愛 い", merged[1].Text);
+        }
+
+        [Fact]
         public void OcrService_DoesNotReferenceWinRtOrBitmapTypes()
         {
             string assemblyQualifiedNames = string.Join(

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -106,6 +106,77 @@ namespace GameTranslator
 
             return bestSelection != null && bestSelection.Score > 0 ? bestSelection : null;
         }
+
+        /// <summary>
+        /// 여러 언어 조합이 반환한 OCR 라인을 줄 인덱스별로 비교해 가장 읽기 좋은 줄만 병합합니다.
+        /// 실험용 외부 OCR 비교에서 전체 언어 조합 하나를 통째로 선택하지 않고, 줄마다 더 나은 결과를 섞어 보기 위해 사용합니다.
+        /// </summary>
+        public List<OcrLine> MergeBestLinesByIndex(
+            IEnumerable<OcrLanguageCandidate> candidates,
+            ISet<string> characterNames,
+            TranslationContentMode contentMode = TranslationContentMode.Strinova)
+        {
+            List<OcrLanguageCandidate> candidateList = (candidates ?? Enumerable.Empty<OcrLanguageCandidate>())
+                .Where(candidate => candidate != null && candidate.Lines != null)
+                .ToList();
+
+            if (candidateList.Count == 0)
+            {
+                return new List<OcrLine>();
+            }
+
+            int maxLineCount = candidateList.Max(candidate => candidate.Lines.Count);
+            var mergedLines = new List<OcrLine>();
+
+            for (int lineIndex = 0; lineIndex < maxLineCount; lineIndex++)
+            {
+                OcrLine bestLine = null;
+                string bestLanguageCode = "";
+                int bestScore = int.MinValue;
+
+                foreach (OcrLanguageCandidate candidate in candidateList)
+                {
+                    if (lineIndex >= candidate.Lines.Count)
+                    {
+                        continue;
+                    }
+
+                    OcrLine currentLine = candidate.Lines[lineIndex];
+                    string currentText = currentLine?.Text ?? "";
+                    if (string.IsNullOrWhiteSpace(currentText))
+                    {
+                        continue;
+                    }
+
+                    int currentScore = ScoreLines(
+                        new[] { new OcrLine { Top = currentLine.Top, Bottom = currentLine.Bottom, Text = currentText } },
+                        characterNames,
+                        contentMode);
+
+                    if (bestLine == null ||
+                        currentScore > bestScore ||
+                        (currentScore == bestScore &&
+                         string.Compare(candidate.LanguageCode, bestLanguageCode, System.StringComparison.OrdinalIgnoreCase) < 0))
+                    {
+                        bestLine = currentLine;
+                        bestLanguageCode = candidate.LanguageCode ?? "";
+                        bestScore = currentScore;
+                    }
+                }
+
+                if (bestLine != null)
+                {
+                    mergedLines.Add(new OcrLine
+                    {
+                        Top = bestLine.Top,
+                        Bottom = bestLine.Bottom,
+                        Text = bestLine.Text
+                    });
+                }
+            }
+
+            return mergedLines;
+        }
     }
 
     /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -218,9 +218,7 @@ namespace GameTranslator
                     CroppedPng = croppedPng
                 };
 
-                List<OcrLine> bestLines = null;
-                int bestScore = int.MinValue;
-                string bestLanguageCode = "";
+                var languageCandidates = new List<OcrLanguageCandidate>();
 
                 foreach (string languageCombination in languageCombinations)
                 {
@@ -271,17 +269,11 @@ namespace GameTranslator
                             Text = text
                         })
                         .ToList();
-                    int score = ScoreOcrCandidate(lines, contentMode);
-
-                    if (bestLines == null ||
-                        score > bestScore ||
-                        (score == bestScore &&
-                         string.Compare(languageCombination, bestLanguageCode, StringComparison.OrdinalIgnoreCase) < 0))
+                    languageCandidates.Add(new OcrLanguageCandidate
                     {
-                        bestLines = lines;
-                        bestScore = score;
-                        bestLanguageCode = languageCombination;
-                    }
+                        LanguageCode = languageCombination,
+                        Lines = lines
+                    });
                 }
 
                 if (executableMissing)
@@ -289,10 +281,11 @@ namespace GameTranslator
                     break;
                 }
 
-                if (bestLines != null && candidate.Languages.Count > 0)
+                List<OcrLine> mergedLines = ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
+                if (mergedLines.Count > 0 && candidate.Languages.Count > 0)
                 {
-                    candidate.MergedLines.AddRange(bestLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                    candidate.Score = bestScore;
+                    candidate.MergedLines.AddRange(mergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                    candidate.Score = ScoreOcrCandidate(mergedLines, contentMode);
                     candidates.Add(candidate);
                 }
             }


### PR DESCRIPTION
요약
- Tesseract 후보 내부 언어조합 결과를 줄 단위 최고점으로 병합
- 메인 번역 경로는 유지하고 OCR 실험 브랜치 진단/비교 흐름만 보강

## 반영 내용
- Tesseract 각 전처리 후보 내부에서 줄 인덱스별로 가장 읽기 좋은 OCR 라인 선택
- OcrService에 MergeBestLinesByIndex 순수 로직 추가
- 줄 단위 병합 규칙 테스트 추가

## 검증
- git diff --check origin/codex/ocr-spike...HEAD
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-line-merge-final
