### PR TITLE
개선: Tesseract 줄 병합 점수 보정

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
@@ -342,6 +342,70 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void MergeBestLinesByIndex_StrinovaMode_PrefersReadableMessageOverWeakLabeledLine()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "SeoArin [치요]: ROE! |" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "SeoArin [치요]: 猫は可愛い" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestLinesByIndex(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Strinova);
+
+            Assert.Single(merged);
+            Assert.Equal("SeoArin [치요]: 猫は可愛い", merged[0].Text);
+        }
+
+        [Fact]
+        public void MergeBestLinesByIndex_StrinovaMode_PrefersLabeledLineWhenMessageQualityMatches()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "猫は可愛い" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "SeoArin [치요]: 猫は可愛い" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestLinesByIndex(
+                candidates,
+                KnownCharacters,
+                TranslationContentMode.Strinova);
+
+            Assert.Single(merged);
+            Assert.Equal("SeoArin [치요]: 猫は可愛い", merged[0].Text);
+        }
+
+        [Fact]
         public void OcrService_DoesNotReferenceWinRtOrBitmapTypes()
         {
             string assemblyQualifiedNames = string.Join(

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -9,6 +9,8 @@ namespace GameTranslator
     /// </summary>
     public sealed class OcrService
     {
+        private const int MergeChatLabelBonus = 300;
+
         /// <summary>
         /// 처리 모드별 OCR 평가 순서를 만듭니다.
         /// Fast/Auto의 첫 단계는 Color + 게임 언어 OCR만 실행하는 fast path입니다.
@@ -148,10 +150,7 @@ namespace GameTranslator
                         continue;
                     }
 
-                    int currentScore = ScoreLines(
-                        new[] { new OcrLine { Top = currentLine.Top, Bottom = currentLine.Bottom, Text = currentText } },
-                        characterNames,
-                        contentMode);
+                    int currentScore = ScoreMergedLineForSelection(currentLine, characterNames, contentMode);
 
                     if (bestLine == null ||
                         currentScore > bestScore ||
@@ -176,6 +175,34 @@ namespace GameTranslator
             }
 
             return mergedLines;
+        }
+
+        private int ScoreMergedLineForSelection(
+            OcrLine line,
+            ISet<string> characterNames,
+            TranslationContentMode contentMode)
+        {
+            string text = line?.Text?.Trim() ?? "";
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return 0;
+            }
+
+            if (contentMode == TranslationContentMode.Etc)
+            {
+                return ScoreLines(
+                    new[] { new OcrLine { Top = line.Top, Bottom = line.Bottom, Text = text } },
+                    characterNames,
+                    TranslationContentMode.Etc);
+            }
+
+            if (ChatTextAnalyzer.TryParseChatLine(text, out ChatTextAnalyzer.ChatLine parsedLine))
+            {
+                return MergeChatLabelBonus +
+                       ChatTextAnalyzer.ScoreReadableTextCandidate(new[] { parsedLine.Message });
+            }
+
+            return ChatTextAnalyzer.ScoreReadableTextCandidate(new[] { text });
         }
     }
 


### PR DESCRIPTION
요약
- Tesseract 줄 단위 병합에서 라벨 매칭 편향을 줄이고 본문 가독성 점수를 더 크게 반영
- 기존 Win OCR 후보 점수와 메인 번역 경로는 유지

## 반영 내용
- OcrService.MergeBestLinesByIndex 내부 전용 줄 점수 보정 추가
- Strinova 줄 선택 시
  - 채팅 라벨 존재: 고정 보너스
  - 라벨 제거 후 본문: ScoreReadableTextCandidate로 주 점수 계산
- 기존 ScoreLines / ScoreOcrCandidate 동작은 변경하지 않음
- 테스트 추가:
  - 약한 라벨+잡음보다 읽을 수 있는 본문 우선
  - 동일 본문이면 라벨 있는 줄 우선

## 검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-line-score
