### PR TITLE
개선: Tesseract 진단 후보 최종 점수 분리

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
@@ -406,6 +406,37 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void ScoreMergedLinesForSelection_StrinovaMode_RewardsReadableMessageEvenWithBrokenLabel()
+        {
+            var lines = new[]
+            {
+                new OcrLine { Text = "SeoArin [AQ]: 猫很可爱!" },
+                new OcrLine { Text = "SeoArin [AQ]: 猫は可愛い" }
+            };
+
+            int legacyScore = _service.ScoreLines(lines, KnownCharacters, TranslationContentMode.Strinova);
+            int mergedScore = _service.ScoreMergedLinesForSelection(lines, KnownCharacters, TranslationContentMode.Strinova);
+
+            Assert.True(mergedScore > 0);
+            Assert.True(mergedScore > legacyScore);
+        }
+
+        [Fact]
+        public void ScoreMergedLinesForSelection_EtcMode_UsesSameScoreAsScoreLines()
+        {
+            var lines = new[]
+            {
+                new OcrLine { Text = "猫很可爱!" },
+                new OcrLine { Text = "hello world" }
+            };
+
+            int baseScore = _service.ScoreLines(lines, KnownCharacters, TranslationContentMode.Etc);
+            int mergedScore = _service.ScoreMergedLinesForSelection(lines, KnownCharacters, TranslationContentMode.Etc);
+
+            Assert.Equal(baseScore, mergedScore);
+        }
+
+        [Fact]
         public void OcrService_DoesNotReferenceWinRtOrBitmapTypes()
         {
             string assemblyQualifiedNames = string.Join(

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -177,6 +177,24 @@ namespace GameTranslator
             return mergedLines;
         }
 
+        /// <summary>
+        /// 줄 단위 병합으로 만들어진 OCR 결과를 진단 비교용 점수로 환산합니다.
+        /// 메인 번역 경로의 후보 점수화와 분리해서, 외부 OCR이 깨진 라벨을 반환해도 본문 가독성을 더 공정하게 반영합니다.
+        /// </summary>
+        public int ScoreMergedLinesForSelection(
+            IEnumerable<OcrLine> lines,
+            ISet<string> characterNames,
+            TranslationContentMode contentMode = TranslationContentMode.Strinova)
+        {
+            if (contentMode == TranslationContentMode.Etc)
+            {
+                return ScoreLines(lines, characterNames, TranslationContentMode.Etc);
+            }
+
+            return (lines ?? Enumerable.Empty<OcrLine>())
+                .Sum(line => ScoreMergedLineForSelection(line, characterNames, contentMode));
+        }
+
         private int ScoreMergedLineForSelection(
             OcrLine line,
             ISet<string> characterNames,

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -285,7 +285,7 @@ namespace GameTranslator
                 if (mergedLines.Count > 0 && candidate.Languages.Count > 0)
                 {
                     candidate.MergedLines.AddRange(mergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                    candidate.Score = ScoreOcrCandidate(mergedLines, contentMode);
+                    candidate.Score = ocrService.ScoreMergedLinesForSelection(mergedLines, characterNames, contentMode);
                     candidates.Add(candidate);
                 }
             }


### PR DESCRIPTION
## 요약
- Tesseract 진단 후보의 최종 점수를 별도 함수로 분리했습니다
- 병합된 줄의 본문 가독성을 진단 점수에 반영하도록 조정했습니다
- 기존 `ScoreLines` / `ScoreOcrCandidate` / 메인 번역 경로는 변경하지 않았습니다

## 변경
- `OcrService.ScoreMergedLinesForSelection()` 추가
- `MainWindow.OcrDiagnostics`에서 Tesseract 진단 후보 점수 계산 시 새 함수 사용
- 깨진 라벨이 있어도 본문 품질이 점수에 반영되는 테스트 2건 추가

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-candidate-score`
