### PR TITLE
개선: Tesseract 라벨 복구와 진단 점수 보정

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
@@ -422,6 +422,62 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void NormalizeMergedLinesForSelection_StrinovaMode_RecoversCloseKnownLabel()
+        {
+            var characters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "치요"
+            };
+            var lines = new[]
+            {
+                new OcrLine { Top = 10, Bottom = 20, Text = "SeoArin [지요]: 猫は可愛い" }
+            };
+
+            List<OcrLine> normalized = _service.NormalizeMergedLinesForSelection(lines, characters, TranslationContentMode.Strinova);
+
+            Assert.Single(normalized);
+            Assert.Equal(10, normalized[0].Top);
+            Assert.Equal(20, normalized[0].Bottom);
+            Assert.Equal("[치요]: 猫は可愛い", normalized[0].Text);
+        }
+
+        [Fact]
+        public void NormalizeMergedLinesForSelection_StrinovaMode_DoesNotGuessAsciiNoiseLabel()
+        {
+            var characters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "치요"
+            };
+            var lines = new[]
+            {
+                new OcrLine { Text = "SeoArin [AQ]: 猫は可愛い" }
+            };
+
+            List<OcrLine> normalized = _service.NormalizeMergedLinesForSelection(lines, characters, TranslationContentMode.Strinova);
+
+            Assert.Single(normalized);
+            Assert.Equal("SeoArin [AQ]: 猫は可愛い", normalized[0].Text);
+        }
+
+        [Fact]
+        public void ScoreMergedLinesForSelection_StrinovaMode_UsesKnownCharacterScaleWhenRecoveredLabelExists()
+        {
+            var characters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "치요"
+            };
+            var lines = new[]
+            {
+                new OcrLine { Text = "SeoArin [지요]: 猫は可愛い" },
+                new OcrLine { Text = "SeoArin [치요]: KowKu munpie.!!!" }
+            };
+
+            int mergedScore = _service.ScoreMergedLinesForSelection(lines, characters, TranslationContentMode.Strinova);
+
+            Assert.True(mergedScore > 20000);
+        }
+
+        [Fact]
         public void ScoreMergedLinesForSelection_EtcMode_UsesSameScoreAsScoreLines()
         {
             var lines = new[]

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,6 +11,7 @@ namespace GameTranslator
     public sealed class OcrService
     {
         private const int MergeChatLabelBonus = 300;
+        private const double FuzzyCharacterSimilarityThreshold = 0.6d;
 
         /// <summary>
         /// 처리 모드별 OCR 평가 순서를 만듭니다.
@@ -178,6 +180,42 @@ namespace GameTranslator
         }
 
         /// <summary>
+        /// 진단용 병합 라인에서 characters.txt 기반으로만 캐릭터 라벨을 보정합니다.
+        /// 메인 번역 경로에는 영향을 주지 않으며, 퍼지 매칭에 성공한 경우에만 "[캐릭터명]: 본문" 형태로 정규화합니다.
+        /// </summary>
+        public List<OcrLine> NormalizeMergedLinesForSelection(
+            IEnumerable<OcrLine> lines,
+            ISet<string> characterNames,
+            TranslationContentMode contentMode = TranslationContentMode.Strinova)
+        {
+            var normalizedLines = new List<OcrLine>();
+
+            foreach (OcrLine line in lines ?? Enumerable.Empty<OcrLine>())
+            {
+                if (line == null)
+                {
+                    continue;
+                }
+
+                string normalizedText = line.Text ?? "";
+                if (contentMode == TranslationContentMode.Strinova &&
+                    TryNormalizeMergedChatLine(normalizedText, characterNames, out string recoveredText))
+                {
+                    normalizedText = recoveredText;
+                }
+
+                normalizedLines.Add(new OcrLine
+                {
+                    Top = line.Top,
+                    Bottom = line.Bottom,
+                    Text = normalizedText
+                });
+            }
+
+            return normalizedLines;
+        }
+
+        /// <summary>
         /// 줄 단위 병합으로 만들어진 OCR 결과를 진단 비교용 점수로 환산합니다.
         /// 메인 번역 경로의 후보 점수화와 분리해서, 외부 OCR이 깨진 라벨을 반환해도 본문 가독성을 더 공정하게 반영합니다.
         /// </summary>
@@ -191,8 +229,12 @@ namespace GameTranslator
                 return ScoreLines(lines, characterNames, TranslationContentMode.Etc);
             }
 
-            return (lines ?? Enumerable.Empty<OcrLine>())
+            List<OcrLine> normalizedLines = NormalizeMergedLinesForSelection(lines, characterNames, contentMode);
+            int normalizedCandidateScore = ScoreLines(normalizedLines, characterNames, contentMode);
+            int readableFallbackScore = normalizedLines
                 .Sum(line => ScoreMergedLineForSelection(line, characterNames, contentMode));
+
+            return Math.Max(normalizedCandidateScore, readableFallbackScore);
         }
 
         private int ScoreMergedLineForSelection(
@@ -221,6 +263,132 @@ namespace GameTranslator
             }
 
             return ChatTextAnalyzer.ScoreReadableTextCandidate(new[] { text });
+        }
+
+        private bool TryNormalizeMergedChatLine(string text, ISet<string> characterNames, out string normalizedText)
+        {
+            normalizedText = text ?? "";
+            if (!ChatTextAnalyzer.TryParseChatLine(text, out ChatTextAnalyzer.ChatLine parsedLine) ||
+                string.IsNullOrWhiteSpace(parsedLine.Message))
+            {
+                return false;
+            }
+
+            string recoveredCharacterName = RecoverClosestKnownCharacterName(parsedLine.CharacterName, characterNames);
+            if (string.IsNullOrWhiteSpace(recoveredCharacterName) ||
+                string.Equals(recoveredCharacterName, parsedLine.CharacterName?.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            normalizedText = $"[{recoveredCharacterName}]: {parsedLine.Message}";
+            return true;
+        }
+
+        private string RecoverClosestKnownCharacterName(string candidateCharacterName, ISet<string> characterNames)
+        {
+            string candidateKey = BuildFuzzyCharacterKey(candidateCharacterName);
+            if (string.IsNullOrWhiteSpace(candidateKey) || candidateKey.Length < 2 || characterNames == null || characterNames.Count == 0)
+            {
+                return "";
+            }
+
+            string bestMatch = "";
+            int bestDistance = int.MaxValue;
+            double bestSimilarity = 0d;
+
+            foreach (string rawKnownName in characterNames)
+            {
+                string knownName = rawKnownName?.Trim() ?? "";
+                string knownKey = BuildFuzzyCharacterKey(knownName);
+                if (string.IsNullOrWhiteSpace(knownKey))
+                {
+                    continue;
+                }
+
+                if (string.Equals(candidateKey, knownKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    return knownName;
+                }
+
+                int distance = ComputeLevenshteinDistance(candidateKey, knownKey);
+                int maxLength = Math.Max(candidateKey.Length, knownKey.Length);
+                int maxAllowedDistance = maxLength <= 4 ? 1 : 2;
+                if (distance > maxAllowedDistance)
+                {
+                    continue;
+                }
+
+                double similarity = 1d - ((double)distance / maxLength);
+                bool isShortLabelMatch = maxLength <= 4 && distance <= 1;
+                if (!isShortLabelMatch && similarity < FuzzyCharacterSimilarityThreshold)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(bestMatch) ||
+                    distance < bestDistance ||
+                    (distance == bestDistance && similarity > bestSimilarity) ||
+                    (distance == bestDistance &&
+                     Math.Abs(similarity - bestSimilarity) < double.Epsilon &&
+                     string.Compare(knownName, bestMatch, StringComparison.OrdinalIgnoreCase) < 0))
+                {
+                    bestMatch = knownName;
+                    bestDistance = distance;
+                    bestSimilarity = similarity;
+                }
+            }
+
+            return bestMatch;
+        }
+
+        private static string BuildFuzzyCharacterKey(string value)
+        {
+            return new string((value ?? "")
+                .Trim()
+                .Where(char.IsLetterOrDigit)
+                .Select(char.ToUpperInvariant)
+                .ToArray());
+        }
+
+        private static int ComputeLevenshteinDistance(string source, string target)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                return target?.Length ?? 0;
+            }
+
+            if (string.IsNullOrEmpty(target))
+            {
+                return source.Length;
+            }
+
+            var distances = new int[source.Length + 1, target.Length + 1];
+
+            for (int i = 0; i <= source.Length; i++)
+            {
+                distances[i, 0] = i;
+            }
+
+            for (int j = 0; j <= target.Length; j++)
+            {
+                distances[0, j] = j;
+            }
+
+            for (int i = 1; i <= source.Length; i++)
+            {
+                for (int j = 1; j <= target.Length; j++)
+                {
+                    int substitutionCost = source[i - 1] == target[j - 1] ? 0 : 1;
+                    distances[i, j] = Math.Min(
+                        Math.Min(
+                            distances[i - 1, j] + 1,
+                            distances[i, j - 1] + 1),
+                        distances[i - 1, j - 1] + substitutionCost);
+                }
+            }
+
+            return distances[source.Length, target.Length];
         }
     }
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -282,10 +282,11 @@ namespace GameTranslator
                 }
 
                 List<OcrLine> mergedLines = ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
-                if (mergedLines.Count > 0 && candidate.Languages.Count > 0)
+                List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(mergedLines, characterNames, contentMode);
+                if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
                 {
-                    candidate.MergedLines.AddRange(mergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                    candidate.Score = ocrService.ScoreMergedLinesForSelection(mergedLines, characterNames, contentMode);
+                    candidate.MergedLines.AddRange(normalizedMergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                    candidate.Score = ocrService.ScoreMergedLinesForSelection(normalizedMergedLines, characterNames, contentMode);
                     candidates.Add(candidate);
                 }
             }


### PR DESCRIPTION
## 요약
- Tesseract 진단 후보에 characters.txt 기반 라벨 복구를 추가했습니다
- 복구된 merged line을 진단 화면/ZIP/하네스에 그대로 사용합니다
- 메인 번역 경로와 Win OCR 점수 로직은 변경하지 않았습니다

## 변경
- `OcrService.NormalizeMergedLinesForSelection()` 추가
- 진단 전용 라벨 복구: 퍼지 매칭은 characters.txt 후보만 사용
- 짧은 이름은 1글자 오차까지 허용, 복구 실패 라벨은 readable fallback 점수 유지
- Tesseract 진단 후보는 복구된 merged line 기준으로 최종 점수 계산
- 테스트 3건 추가
  - 근접 라벨 복구
  - ASCII 노이즈 라벨 미복구
  - 복구 성공 시 known character 점수 스케일 사용

## 판단 기준
- 적용 후 Tesseract-Adaptive가 20000 이상이면 추가 보정 계속
- 여전히 10000 미만이면 EasyOCR 또는 PaddleOCR 어댑터로 전환 검토

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-label-normalization`
