### PR TITLE
개선: Tesseract 라벨과 본문 분리 병합

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrServiceTests.cs
@@ -406,6 +406,103 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void MergeBestChatLinesByComponents_StrinovaMode_CombinesBestLabelAndBestMessage()
+        {
+            var characters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "치요"
+            };
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Top = 10, Bottom = 20, Text = "SeoArin [치요]: HRT!" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Top = 30, Bottom = 40, Text = "SeoArin [AQ]: 猫は可愛い" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestChatLinesByComponents(candidates, characters);
+
+            Assert.Single(merged);
+            Assert.Equal(30, merged[0].Top);
+            Assert.Equal(40, merged[0].Bottom);
+            Assert.Equal("[치요]: 猫は可愛い", merged[0].Text);
+        }
+
+        [Fact]
+        public void MergeBestChatLinesByComponents_StrinovaMode_FallsBackWhenNoRecoverableLabelExists()
+        {
+            var characters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "치요"
+            };
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "SeoArin [AQ]: hello world" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "SeoArin [BQ]: 猫は可愛い" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestChatLinesByComponents(candidates, characters);
+
+            Assert.Single(merged);
+            Assert.Equal("SeoArin [BQ]: 猫は可愛い", merged[0].Text);
+        }
+
+        [Fact]
+        public void MergeBestChatLinesByComponents_StrinovaMode_FallsBackWhenParsingFails()
+        {
+            var candidates = new[]
+            {
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ko",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "!!!" }
+                    }
+                },
+                new OcrLanguageCandidate
+                {
+                    LanguageCode = "ja",
+                    Lines = new List<OcrLine>
+                    {
+                        new OcrLine { Text = "猫は可愛い" }
+                    }
+                }
+            };
+
+            List<OcrLine> merged = _service.MergeBestChatLinesByComponents(candidates, KnownCharacters);
+
+            Assert.Single(merged);
+            Assert.Equal("猫は可愛い", merged[0].Text);
+        }
+
+        [Fact]
         public void ScoreMergedLinesForSelection_StrinovaMode_RewardsReadableMessageEvenWithBrokenLabel()
         {
             var lines = new[]

--- a/GameChatTranslator/Core/OcrService.cs
+++ b/GameChatTranslator/Core/OcrService.cs
@@ -12,6 +12,8 @@ namespace GameTranslator
     {
         private const int MergeChatLabelBonus = 300;
         private const double FuzzyCharacterSimilarityThreshold = 0.6d;
+        private const int ExactCharacterMatchScore = 2000;
+        private const int FuzzyCharacterMatchBaseScore = 1000;
 
         /// <summary>
         /// 처리 모드별 OCR 평가 순서를 만듭니다.
@@ -134,45 +136,50 @@ namespace GameTranslator
 
             for (int lineIndex = 0; lineIndex < maxLineCount; lineIndex++)
             {
-                OcrLine bestLine = null;
-                string bestLanguageCode = "";
-                int bestScore = int.MinValue;
-
-                foreach (OcrLanguageCandidate candidate in candidateList)
-                {
-                    if (lineIndex >= candidate.Lines.Count)
-                    {
-                        continue;
-                    }
-
-                    OcrLine currentLine = candidate.Lines[lineIndex];
-                    string currentText = currentLine?.Text ?? "";
-                    if (string.IsNullOrWhiteSpace(currentText))
-                    {
-                        continue;
-                    }
-
-                    int currentScore = ScoreMergedLineForSelection(currentLine, characterNames, contentMode);
-
-                    if (bestLine == null ||
-                        currentScore > bestScore ||
-                        (currentScore == bestScore &&
-                         string.Compare(candidate.LanguageCode, bestLanguageCode, System.StringComparison.OrdinalIgnoreCase) < 0))
-                    {
-                        bestLine = currentLine;
-                        bestLanguageCode = candidate.LanguageCode ?? "";
-                        bestScore = currentScore;
-                    }
-                }
+                OcrLine bestLine = SelectBestLineCandidate(candidateList, lineIndex, characterNames, contentMode);
 
                 if (bestLine != null)
                 {
-                    mergedLines.Add(new OcrLine
-                    {
-                        Top = bestLine.Top,
-                        Bottom = bestLine.Bottom,
-                        Text = bestLine.Text
-                    });
+                    mergedLines.Add(CloneLine(bestLine));
+                }
+            }
+
+            return mergedLines;
+        }
+
+        /// <summary>
+        /// 진단용 외부 OCR 비교에서 라벨과 본문을 분리해서 병합합니다.
+        /// 파싱 가능한 채팅 줄이면 characters.txt 기준으로 가장 안정적인 라벨과 가장 읽을 만한 본문을 조합합니다.
+        /// 조합에 실패하면 기존 줄 단위 선택 결과로 되돌립니다.
+        /// </summary>
+        public List<OcrLine> MergeBestChatLinesByComponents(
+            IEnumerable<OcrLanguageCandidate> candidates,
+            ISet<string> characterNames)
+        {
+            List<OcrLanguageCandidate> candidateList = (candidates ?? Enumerable.Empty<OcrLanguageCandidate>())
+                .Where(candidate => candidate != null && candidate.Lines != null)
+                .ToList();
+
+            if (candidateList.Count == 0)
+            {
+                return new List<OcrLine>();
+            }
+
+            int maxLineCount = candidateList.Max(candidate => candidate.Lines.Count);
+            var mergedLines = new List<OcrLine>();
+
+            for (int lineIndex = 0; lineIndex < maxLineCount; lineIndex++)
+            {
+                OcrLine fallbackLine = SelectBestLineCandidate(candidateList, lineIndex, characterNames, TranslationContentMode.Strinova);
+                if (TryBuildMergedChatLineByComponents(candidateList, lineIndex, characterNames, out OcrLine mergedLine))
+                {
+                    mergedLines.Add(mergedLine);
+                    continue;
+                }
+
+                if (fallbackLine != null)
+                {
+                    mergedLines.Add(CloneLine(fallbackLine));
                 }
             }
 
@@ -265,6 +272,113 @@ namespace GameTranslator
             return ChatTextAnalyzer.ScoreReadableTextCandidate(new[] { text });
         }
 
+        private OcrLine SelectBestLineCandidate(
+            IEnumerable<OcrLanguageCandidate> candidates,
+            int lineIndex,
+            ISet<string> characterNames,
+            TranslationContentMode contentMode)
+        {
+            OcrLine bestLine = null;
+            string bestLanguageCode = "";
+            int bestScore = int.MinValue;
+
+            foreach (OcrLanguageCandidate candidate in candidates ?? Enumerable.Empty<OcrLanguageCandidate>())
+            {
+                if (candidate == null || candidate.Lines == null || lineIndex >= candidate.Lines.Count)
+                {
+                    continue;
+                }
+
+                OcrLine currentLine = candidate.Lines[lineIndex];
+                string currentText = currentLine?.Text ?? "";
+                if (string.IsNullOrWhiteSpace(currentText))
+                {
+                    continue;
+                }
+
+                int currentScore = ScoreMergedLineForSelection(currentLine, characterNames, contentMode);
+                if (bestLine == null ||
+                    currentScore > bestScore ||
+                    (currentScore == bestScore &&
+                     string.Compare(candidate.LanguageCode, bestLanguageCode, StringComparison.OrdinalIgnoreCase) < 0))
+                {
+                    bestLine = currentLine;
+                    bestLanguageCode = candidate.LanguageCode ?? "";
+                    bestScore = currentScore;
+                }
+            }
+
+            return bestLine;
+        }
+
+        private bool TryBuildMergedChatLineByComponents(
+            IEnumerable<OcrLanguageCandidate> candidates,
+            int lineIndex,
+            ISet<string> characterNames,
+            out OcrLine mergedLine)
+        {
+            mergedLine = null;
+            var parsedCandidates = new List<ParsedChatLineCandidate>();
+
+            foreach (OcrLanguageCandidate candidate in candidates ?? Enumerable.Empty<OcrLanguageCandidate>())
+            {
+                if (candidate == null || candidate.Lines == null || lineIndex >= candidate.Lines.Count)
+                {
+                    continue;
+                }
+
+                OcrLine sourceLine = candidate.Lines[lineIndex];
+                string text = sourceLine?.Text ?? "";
+                if (!ChatTextAnalyzer.TryParseChatLine(text, out ChatTextAnalyzer.ChatLine parsedLine) ||
+                    string.IsNullOrWhiteSpace(parsedLine.Message))
+                {
+                    continue;
+                }
+
+                string recoveredCharacterName;
+                int labelScore = ScoreKnownCharacterMatch(parsedLine.CharacterName, characterNames, out recoveredCharacterName);
+                int messageScore = ChatTextAnalyzer.ScoreReadableTextCandidate(new[] { parsedLine.Message });
+
+                parsedCandidates.Add(new ParsedChatLineCandidate(
+                    candidate.LanguageCode ?? "",
+                    sourceLine,
+                    parsedLine,
+                    recoveredCharacterName,
+                    labelScore,
+                    messageScore));
+            }
+
+            if (parsedCandidates.Count == 0)
+            {
+                return false;
+            }
+
+            ParsedChatLineCandidate bestLabelCandidate = parsedCandidates
+                .Where(candidate => candidate.LabelScore > 0 && !string.IsNullOrWhiteSpace(candidate.RecoveredCharacterName))
+                .OrderByDescending(candidate => candidate.LabelScore)
+                .ThenBy(candidate => candidate.LanguageCode, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+
+            ParsedChatLineCandidate bestMessageCandidate = parsedCandidates
+                .Where(candidate => candidate.MessageScore > 0)
+                .OrderByDescending(candidate => candidate.MessageScore)
+                .ThenBy(candidate => candidate.LanguageCode, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+
+            if (bestLabelCandidate == null || bestMessageCandidate == null)
+            {
+                return false;
+            }
+
+            mergedLine = new OcrLine
+            {
+                Top = bestMessageCandidate.SourceLine.Top,
+                Bottom = bestMessageCandidate.SourceLine.Bottom,
+                Text = $"[{bestLabelCandidate.RecoveredCharacterName}]: {bestMessageCandidate.ParsedLine.Message}"
+            };
+            return true;
+        }
+
         private bool TryNormalizeMergedChatLine(string text, ISet<string> characterNames, out string normalizedText)
         {
             normalizedText = text ?? "";
@@ -283,6 +397,42 @@ namespace GameTranslator
 
             normalizedText = $"[{recoveredCharacterName}]: {parsedLine.Message}";
             return true;
+        }
+
+        private int ScoreKnownCharacterMatch(
+            string candidateCharacterName,
+            ISet<string> characterNames,
+            out string recoveredCharacterName)
+        {
+            recoveredCharacterName = RecoverClosestKnownCharacterName(candidateCharacterName, characterNames);
+            if (string.IsNullOrWhiteSpace(recoveredCharacterName))
+            {
+                return 0;
+            }
+
+            string candidateKey = BuildFuzzyCharacterKey(candidateCharacterName);
+            string recoveredKey = BuildFuzzyCharacterKey(recoveredCharacterName);
+            if (string.IsNullOrWhiteSpace(candidateKey) || string.IsNullOrWhiteSpace(recoveredKey))
+            {
+                return 0;
+            }
+
+            if (string.Equals(candidateKey, recoveredKey, StringComparison.OrdinalIgnoreCase))
+            {
+                return ExactCharacterMatchScore;
+            }
+
+            int distance = ComputeLevenshteinDistance(candidateKey, recoveredKey);
+            int maxLength = Math.Max(candidateKey.Length, recoveredKey.Length);
+            if (maxLength <= 0)
+            {
+                return 0;
+            }
+
+            double similarity = 1d - ((double)distance / maxLength);
+            return FuzzyCharacterMatchBaseScore +
+                (int)Math.Round(similarity * 200d) -
+                (distance * 50);
         }
 
         private string RecoverClosestKnownCharacterName(string candidateCharacterName, ISet<string> characterNames)
@@ -389,6 +539,42 @@ namespace GameTranslator
             }
 
             return distances[source.Length, target.Length];
+        }
+
+        private static OcrLine CloneLine(OcrLine line)
+        {
+            return new OcrLine
+            {
+                Top = line.Top,
+                Bottom = line.Bottom,
+                Text = line.Text
+            };
+        }
+
+        private sealed class ParsedChatLineCandidate
+        {
+            public ParsedChatLineCandidate(
+                string languageCode,
+                OcrLine sourceLine,
+                ChatTextAnalyzer.ChatLine parsedLine,
+                string recoveredCharacterName,
+                int labelScore,
+                int messageScore)
+            {
+                LanguageCode = languageCode ?? "";
+                SourceLine = sourceLine;
+                ParsedLine = parsedLine;
+                RecoveredCharacterName = recoveredCharacterName ?? "";
+                LabelScore = labelScore;
+                MessageScore = messageScore;
+            }
+
+            public string LanguageCode { get; }
+            public OcrLine SourceLine { get; }
+            public ChatTextAnalyzer.ChatLine ParsedLine { get; }
+            public string RecoveredCharacterName { get; }
+            public int LabelScore { get; }
+            public int MessageScore { get; }
         }
     }
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -281,7 +281,9 @@ namespace GameTranslator
                     break;
                 }
 
-                List<OcrLine> mergedLines = ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
+                List<OcrLine> mergedLines = contentMode == TranslationContentMode.Strinova
+                    ? ocrService.MergeBestChatLinesByComponents(languageCandidates, characterNames)
+                    : ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
                 List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(mergedLines, characterNames, contentMode);
                 if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
                 {


### PR DESCRIPTION
## 요약
- Tesseract 진단 후보에서 라벨과 본문을 분리해서 병합합니다
- 파싱 가능한 줄이면 characters.txt 기준 라벨과 readable score 기준 본문을 따로 선택합니다
- 조합에 실패하면 기존 줄 단위 선택으로 fallback 합니다

## 변경
- `OcrService.MergeBestChatLinesByComponents()` 추가
- 라벨 선택: 같은 줄 인덱스 후보 중 characters.txt 일치 점수가 가장 높은 후보 사용
- 본문 선택: 같은 줄 인덱스 후보 중 `ScoreReadableTextCandidate`가 가장 높은 후보 사용
- 조합 불가 시 기존 `MergeBestLinesByIndex()` 결과 사용
- Tesseract 진단 경로만 새 분리 병합 사용
- 메인 번역 경로 / 하네스 동작은 변경하지 않음
- 테스트 3건 추가
  - 좋은 라벨 + 좋은 본문 조합
  - 라벨 복구 실패 시 fallback
  - 파싱 실패 시 fallback

## 종료 기준
- 이 PR 적용 후 `Tesseract-Adaptive >= 20000` 이면 추가 보정 계속
- 여전히 `< 20000` 이면 Tesseract 점수 보정은 중단하고 EasyOCR 또는 PaddleOCR 어댑터로 전환

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-split-merge`
