### PR TITLE
개선: spike 하네스 known character 필터 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrTranslationHarnessServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrTranslationHarnessServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Collections.Generic;
 using GameTranslator;
 using Xunit;
 
@@ -7,11 +8,12 @@ namespace GameChatTranslator.Tests
     public class OcrTranslationHarnessServiceTests
     {
         private readonly OcrTranslationHarnessService _service = new OcrTranslationHarnessService(new TranslationPromptBuilder());
+        private static readonly ISet<string> KnownCharacters = new HashSet<string> { "치요" };
 
         [Fact]
         public void BuildRequests_ParsesNicknamePrefixAndKeepsCharacterLabel()
         {
-            var request = _service.BuildRequests(new[] { "SeoArin [치요]: 猫は可愛い" }).Single();
+            var request = _service.BuildRequests(new[] { "SeoArin [치요]: 猫は可愛い" }, KnownCharacters).Single();
 
             Assert.False(request.Skipped);
             Assert.Equal("[치요]: ", request.Prefix);
@@ -22,7 +24,7 @@ namespace GameChatTranslator.Tests
         [Fact]
         public void BuildRequests_FallsBackToRawWhenChatParseFailsButMeaningfulTextRemains()
         {
-            var request = _service.BuildRequests(new[] { "猫 可 愛" }).Single();
+            var request = _service.BuildRequests(new[] { "猫 可 愛" }, KnownCharacters).Single();
 
             Assert.False(request.Skipped);
             Assert.Equal("[RAW]: ", request.Prefix);
@@ -33,7 +35,7 @@ namespace GameChatTranslator.Tests
         [Fact]
         public void BuildRequests_SkipsNoiseOnlyText()
         {
-            var request = _service.BuildRequests(new[] { "###@@@%%%" }).Single();
+            var request = _service.BuildRequests(new[] { "###@@@%%%" }, KnownCharacters).Single();
 
             Assert.True(request.Skipped);
             Assert.Equal("글자 없음", request.SkipReason);
@@ -42,7 +44,7 @@ namespace GameChatTranslator.Tests
         [Fact]
         public void BuildRequests_SkipsBrokenNoiseAfterEtcCleaning()
         {
-            var request = _service.BuildRequests(new[] { "乞5U(私(z構ote.ntOØ?" }).Single();
+            var request = _service.BuildRequests(new[] { "乞5U(私(z構ote.ntOØ?" }, KnownCharacters).Single();
 
             Assert.True(request.Skipped);
             Assert.Equal("파싱 실패 / 노이즈", request.SkipReason);
@@ -51,7 +53,7 @@ namespace GameChatTranslator.Tests
         [Fact]
         public void BuildRequests_SkipsSystemUiLineWhenSystemLabelAndUiKeywordAreCombined()
         {
-            var request = _service.BuildRequests(new[] { "[팀]! 빔을 클릭해 채널 변경" }).Single();
+            var request = _service.BuildRequests(new[] { "[팀]! 빔을 클릭해 채널 변경" }, KnownCharacters).Single();
 
             Assert.True(request.Skipped);
             Assert.Equal("시스템/UI 문구", request.SkipReason);
@@ -60,7 +62,7 @@ namespace GameChatTranslator.Tests
         [Fact]
         public void BuildRequests_KeepsExclamationSeparatedChatLineWhenItIsNotSystemUiText()
         {
-            var request = _service.BuildRequests(new[] { "[치요]! 공격 시작" }).Single();
+            var request = _service.BuildRequests(new[] { "[치요]! 공격 시작" }, KnownCharacters).Single();
 
             Assert.False(request.Skipped);
             Assert.Equal("[치요]: ", request.Prefix);
@@ -69,14 +71,54 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
-        public void BuildRequests_KeepsTeamLineWhenItDoesNotContainUiKeyword()
+        public void BuildRequests_FallsBackToRawWhenBangSeparatedLabelIsNotKnownCharacter()
         {
-            var request = _service.BuildRequests(new[] { "[팀]! 공격 집결" }).Single();
+            var request = _service.BuildRequests(new[] { "[팀]! 공격 집결" }, KnownCharacters).Single();
 
             Assert.False(request.Skipped);
-            Assert.Equal("[팀]: ", request.Prefix);
-            Assert.Equal("공격 집결", request.ContentToTranslate);
-            Assert.Equal(TranslationContentMode.Strinova, request.ContentMode);
+            Assert.Equal("[RAW]: ", request.Prefix);
+            Assert.Equal("팀 공격 집결", request.ContentToTranslate);
+            Assert.Equal(TranslationContentMode.Etc, request.ContentMode);
+        }
+
+        [Fact]
+        public void BuildRequests_FallsBackToRawWhenUnknownBangLabelLooksLikeChat()
+        {
+            var request = _service.BuildRequests(new[] { "[el]! FAS Selon At BIZ @»" }, KnownCharacters).Single();
+
+            Assert.False(request.Skipped);
+            Assert.Equal("[RAW]: ", request.Prefix);
+            Assert.Equal("el FAS Selon At BIZ", request.ContentToTranslate);
+            Assert.Equal(TranslationContentMode.Etc, request.ContentMode);
+        }
+
+        [Fact]
+        public void FilterMergedLinesForDiagnostics_RemovesUnknownBangLabelLine()
+        {
+            List<OcrLine> lines = _service.FilterMergedLinesForDiagnostics(
+                new[]
+                {
+                    new OcrLine { Top = 0, Bottom = 10, Text = "[치요]: 猫は可愛い" },
+                    new OcrLine { Top = 20, Bottom = 30, Text = "[el]! FAS Selon At BIZ @»" }
+                },
+                KnownCharacters);
+
+            Assert.Single(lines);
+            Assert.Equal("[치요]: 猫は可愛い", lines[0].Text);
+        }
+
+        [Fact]
+        public void FilterMergedLinesForDiagnostics_KeepsKnownBangLabelLine()
+        {
+            List<OcrLine> lines = _service.FilterMergedLinesForDiagnostics(
+                new[]
+                {
+                    new OcrLine { Top = 0, Bottom = 10, Text = "[치요]! 공격 시작" }
+                },
+                KnownCharacters);
+
+            Assert.Single(lines);
+            Assert.Equal("[치요]! 공격 시작", lines[0].Text);
         }
     }
 }

--- a/GameChatTranslator/Core/OcrTranslationHarnessService.cs
+++ b/GameChatTranslator/Core/OcrTranslationHarnessService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace GameTranslator
 {
@@ -10,6 +11,10 @@ namespace GameTranslator
     /// </summary>
     public sealed class OcrTranslationHarnessService
     {
+        private static readonly Regex BangDelimitedBracketLabelPattern = new Regex(
+            @"^[^\[\]\(\)]*[\[\(]([^\]\)]+)[\]\)]\s*!\s*.+$",
+            RegexOptions.Compiled);
+
         private static readonly HashSet<string> SystemLabelCandidates = new HashSet<string>(new[]
         {
             "팀",
@@ -34,7 +39,9 @@ namespace GameTranslator
             this.translationPromptBuilder = translationPromptBuilder ?? new TranslationPromptBuilder();
         }
 
-        public IReadOnlyList<OcrTranslationHarnessRequest> BuildRequests(IEnumerable<string> mergedLines)
+        public IReadOnlyList<OcrTranslationHarnessRequest> BuildRequests(
+            IEnumerable<string> mergedLines,
+            ISet<string> characterNames = null)
         {
             var requests = new List<OcrTranslationHarnessRequest>();
 
@@ -61,8 +68,11 @@ namespace GameTranslator
                         continue;
                     }
 
-                    requests.Add(OcrTranslationHarnessRequest.Chat(text, chatLine.CharacterLabel, chatLine.Message));
-                    continue;
+                    if (ShouldTreatAsKnownCharacterBangChat(text, chatLine, characterNames))
+                    {
+                        requests.Add(OcrTranslationHarnessRequest.Chat(text, chatLine.CharacterLabel, chatLine.Message));
+                        continue;
+                    }
                 }
 
                 string cleaned = translationPromptBuilder.CleanEtcOcrLine(text);
@@ -76,6 +86,71 @@ namespace GameTranslator
             }
 
             return requests;
+        }
+
+        public List<OcrLine> FilterMergedLinesForDiagnostics(
+            IEnumerable<OcrLine> mergedLines,
+            ISet<string> characterNames = null)
+        {
+            return (mergedLines ?? Enumerable.Empty<OcrLine>())
+                .Where(line => !ShouldExcludeFromDiagnosticLine(line?.Text, characterNames))
+                .Select(line => new OcrLine
+                {
+                    Top = line.Top,
+                    Bottom = line.Bottom,
+                    Text = line.Text
+                })
+                .ToList();
+        }
+
+        private bool ShouldExcludeFromDiagnosticLine(string rawText, ISet<string> characterNames)
+        {
+            string text = (rawText ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return true;
+            }
+
+            if (ChatTextAnalyzer.TryParseChatLine(text, out ChatTextAnalyzer.ChatLine chatLine) &&
+                !string.IsNullOrWhiteSpace(chatLine.Message))
+            {
+                if (ShouldSkipSystemUiLine(chatLine))
+                {
+                    return true;
+                }
+
+                if (!ShouldTreatAsKnownCharacterBangChat(text, chatLine, characterNames))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ShouldTreatAsKnownCharacterBangChat(
+            string rawText,
+            ChatTextAnalyzer.ChatLine chatLine,
+            ISet<string> characterNames)
+        {
+            if (chatLine == null || string.IsNullOrWhiteSpace(chatLine.Message))
+            {
+                return false;
+            }
+
+            if (!LooksLikeBangDelimitedBracketLabel(rawText))
+            {
+                return true;
+            }
+
+            return characterNames != null &&
+                   characterNames.Count > 0 &&
+                   characterNames.Contains((chatLine.CharacterName ?? "").Trim());
+        }
+
+        private static bool LooksLikeBangDelimitedBracketLabel(string rawText)
+        {
+            return BangDelimitedBracketLabelPattern.IsMatch((rawText ?? "").Trim());
         }
 
         private static bool ShouldSkipSystemUiLine(ChatTextAnalyzer.ChatLine chatLine)

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -284,7 +284,8 @@ namespace GameTranslator
                 List<OcrLine> mergedLines = contentMode == TranslationContentMode.Strinova
                     ? ocrService.MergeBestChatLinesByComponents(languageCandidates, characterNames)
                     : ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
-                List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(mergedLines, characterNames, contentMode);
+                List<OcrLine> filteredMergedLines = ocrTranslationHarnessService.FilterMergedLinesForDiagnostics(mergedLines, characterNames);
+                List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(filteredMergedLines, characterNames, contentMode);
                 if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
                 {
                     candidate.MergedLines.AddRange(normalizedMergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrHarness.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrHarness.cs
@@ -19,7 +19,7 @@ namespace GameTranslator
                 CandidateName = candidateName ?? ""
             };
 
-            IReadOnlyList<OcrTranslationHarnessRequest> requests = ocrTranslationHarnessService.BuildRequests(mergedLines);
+            IReadOnlyList<OcrTranslationHarnessRequest> requests = ocrTranslationHarnessService.BuildRequests(mergedLines, characterNames);
             result.TotalLineCount = requests.Count;
 
             var performanceStats = new OcrPerformanceStats();


### PR DESCRIPTION
## 요약
- spike 하네스에서 known character 없는 `[...]!` 패턴을 채팅으로 취급하지 않도록 보정
- Tesseract 진단 후보 점수 계산 전에 시스템/UI 줄과 unknown bang label 줄을 필터링
- 공유 파서 `TryParseChatLine()`과 메인 번역 경로는 그대로 유지

## 변경
- `OcrTranslationHarnessService.BuildRequests(..., characterNames)` 추가 파라미터로 spike 전용 known character 검증 연결
- `FilterMergedLinesForDiagnostics()` 추가로 Tesseract merged lines를 진단 점수화 전에 필터링
- `[팀]! 빔을 클릭해 채널 변경` 같은 시스템/UI 줄은 계속 skip
- `[el]! FAS Selon At BIZ @»` 같은 unknown bang label 줄은 RAW fallback 또는 진단 제외로 처리
- `MainWindow.OcrHarness` / `MainWindow.OcrDiagnostics`에서만 새 필터 사용

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-harness-filter`
