### PR TITLE
개선: Tesseract PSM/OEM 진단 프로파일 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/TesseractCliOcrAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/TesseractCliOcrAdapterTests.cs
@@ -46,6 +46,46 @@ namespace GameChatTranslator.Tests
             Assert.Equal("jpn+eng", values[1]);
         }
 
+        [Fact]
+        public void BuildDiagnosticProfiles_ReturnsThreeProfilesInExpectedOrder()
+        {
+            var profiles = _adapter.BuildDiagnosticProfiles();
+
+            Assert.Equal(3, profiles.Count);
+
+            Assert.Equal("Baseline", profiles[0].CandidateSuffix);
+            Assert.Null(profiles[0].PageSegmentationMode);
+            Assert.Null(profiles[0].OcrEngineMode);
+
+            Assert.Equal("PSM6-LSTM", profiles[1].CandidateSuffix);
+            Assert.Equal(6, profiles[1].PageSegmentationMode);
+            Assert.Equal(1, profiles[1].OcrEngineMode);
+
+            Assert.Equal("PSM11-LSTM", profiles[2].CandidateSuffix);
+            Assert.Equal(11, profiles[2].PageSegmentationMode);
+            Assert.Equal(1, profiles[2].OcrEngineMode);
+        }
+
+        [Fact]
+        public void BuildArguments_BaselineProfile_DoesNotAppendPsmOrOemFlags()
+        {
+            var profile = _adapter.BuildDiagnosticProfiles()[0];
+
+            var values = _adapter.BuildArguments("input.png", "jpn+eng", profile);
+
+            Assert.Equal(new[] { "input.png", "stdout", "-l", "jpn+eng" }, values);
+        }
+
+        [Fact]
+        public void BuildArguments_Psm11LstmProfile_AppendsExpectedFlags()
+        {
+            var profile = _adapter.BuildDiagnosticProfiles()[2];
+
+            var values = _adapter.BuildArguments("input.png", "chi_sim+eng", profile);
+
+            Assert.Equal(new[] { "input.png", "stdout", "-l", "chi_sim+eng", "--psm", "11", "--oem", "1" }, values);
+        }
+
         [Theory]
         [InlineData("ko", "kor")]
         [InlineData("en-US", "eng")]

--- a/GameChatTranslator/Core/TesseractCliOcrAdapter.cs
+++ b/GameChatTranslator/Core/TesseractCliOcrAdapter.cs
@@ -17,6 +17,20 @@ namespace GameTranslator
     [SupportedOSPlatform("windows")]
     public sealed class TesseractCliOcrAdapter
     {
+        public sealed class TesseractCliProfile
+        {
+            public TesseractCliProfile(string candidateSuffix, int? pageSegmentationMode, int? ocrEngineMode)
+            {
+                CandidateSuffix = candidateSuffix ?? "";
+                PageSegmentationMode = pageSegmentationMode;
+                OcrEngineMode = ocrEngineMode;
+            }
+
+            public string CandidateSuffix { get; }
+            public int? PageSegmentationMode { get; }
+            public int? OcrEngineMode { get; }
+        }
+
         private static readonly Dictionary<string, string> AppLanguageToTesseractMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["ko"] = "kor",
@@ -43,6 +57,8 @@ namespace GameTranslator
             "kor",
             "chi_sim"
         };
+
+        private static readonly TesseractCliProfile DefaultRecognitionProfile = new TesseractCliProfile("Default", 6, 3);
 
         public string BuildLanguageCodes(string configuredValue, string gameLanguage)
         {
@@ -105,6 +121,16 @@ namespace GameTranslator
             return new[] { NormalizeLanguageCodes(normalizedConfiguredValue) };
         }
 
+        public IReadOnlyList<TesseractCliProfile> BuildDiagnosticProfiles()
+        {
+            return new[]
+            {
+                new TesseractCliProfile("Baseline", null, null),
+                new TesseractCliProfile("PSM6-LSTM", 6, 1),
+                new TesseractCliProfile("PSM11-LSTM", 11, 1)
+            };
+        }
+
         public string NormalizeLanguageCodes(string rawValue)
         {
             IEnumerable<string> tokens = (rawValue ?? "")
@@ -142,6 +168,16 @@ namespace GameTranslator
 
         public TesseractCliOcrResult Recognize(Bitmap bitmap, string configuredExecutablePath, string configuredLanguageCodes, int timeoutMs = 15000)
         {
+            return Recognize(bitmap, configuredExecutablePath, configuredLanguageCodes, DefaultRecognitionProfile, timeoutMs);
+        }
+
+        public TesseractCliOcrResult Recognize(
+            Bitmap bitmap,
+            string configuredExecutablePath,
+            string configuredLanguageCodes,
+            TesseractCliProfile profile,
+            int timeoutMs = 15000)
+        {
             if (bitmap == null)
             {
                 return TesseractCliOcrResult.CreateFailure("", "", "OCR 입력 이미지가 없습니다.");
@@ -158,7 +194,7 @@ namespace GameTranslator
             {
                 foreach (string executablePath in GetExecutableCandidates(configuredExecutablePath))
                 {
-                    TesseractCliOcrResult runResult = TryRecognizeInternal(executablePath, languageCodes, inputFilePath, timeoutMs);
+                    TesseractCliOcrResult runResult = TryRecognizeInternal(executablePath, languageCodes, inputFilePath, profile, timeoutMs);
                     if (runResult.Success || !runResult.IsExecutableMissing)
                     {
                         return runResult;
@@ -209,7 +245,37 @@ namespace GameTranslator
                 .Distinct(StringComparer.OrdinalIgnoreCase);
         }
 
-        private TesseractCliOcrResult TryRecognizeInternal(string executablePath, string languageCodes, string inputFilePath, int timeoutMs)
+        internal IReadOnlyList<string> BuildArguments(string inputFilePath, string languageCodes, TesseractCliProfile profile)
+        {
+            var arguments = new List<string>
+            {
+                inputFilePath,
+                "stdout",
+                "-l",
+                languageCodes
+            };
+
+            if (profile?.PageSegmentationMode is int psm)
+            {
+                arguments.Add("--psm");
+                arguments.Add(psm.ToString());
+            }
+
+            if (profile?.OcrEngineMode is int oem)
+            {
+                arguments.Add("--oem");
+                arguments.Add(oem.ToString());
+            }
+
+            return arguments;
+        }
+
+        private TesseractCliOcrResult TryRecognizeInternal(
+            string executablePath,
+            string languageCodes,
+            string inputFilePath,
+            TesseractCliProfile profile,
+            int timeoutMs)
         {
             var processStartInfo = new ProcessStartInfo
             {
@@ -221,14 +287,10 @@ namespace GameTranslator
                 StandardOutputEncoding = Encoding.UTF8,
                 StandardErrorEncoding = Encoding.UTF8
             };
-            processStartInfo.ArgumentList.Add(inputFilePath);
-            processStartInfo.ArgumentList.Add("stdout");
-            processStartInfo.ArgumentList.Add("-l");
-            processStartInfo.ArgumentList.Add(languageCodes);
-            processStartInfo.ArgumentList.Add("--psm");
-            processStartInfo.ArgumentList.Add("6");
-            processStartInfo.ArgumentList.Add("--oem");
-            processStartInfo.ArgumentList.Add("3");
+            foreach (string argument in BuildArguments(inputFilePath, languageCodes, profile))
+            {
+                processStartInfo.ArgumentList.Add(argument);
+            }
 
             try
             {

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -196,6 +196,7 @@ namespace GameTranslator
             string configuredExecutablePath = ReadTesseractExecutablePath();
             string configuredLanguageCodes = ReadTesseractLanguageCodes();
             IReadOnlyList<string> languageCombinations = tesseractCliOcrAdapter.BuildLanguageCombinations(configuredLanguageCodes, gameLang);
+            IReadOnlyList<TesseractCliOcrAdapter.TesseractCliProfile> diagnosticProfiles = tesseractCliOcrAdapter.BuildDiagnosticProfiles();
 
             int totalCallCount = 0;
             long totalElapsedMs = 0;
@@ -211,86 +212,89 @@ namespace GameTranslator
                 byte[] croppedPng = BitmapToPngBytes(croppedBitmap);
                 byte[] preprocessedPng = BitmapToPngBytes(preprocessedImage.Bitmap);
 
-                var candidate = new OcrDiagnosticCandidate
+                foreach (TesseractCliOcrAdapter.TesseractCliProfile profile in diagnosticProfiles)
                 {
-                    Name = $"Tesseract-{preprocessedImage.Name}",
-                    PreprocessedPng = preprocessedPng,
-                    CroppedPng = croppedPng
-                };
-
-                var languageCandidates = new List<OcrLanguageCandidate>();
-
-                foreach (string languageCombination in languageCombinations)
-                {
-                    totalCallCount++;
-
-                    Stopwatch stopwatch = Stopwatch.StartNew();
-                    using Bitmap tesseractInputBitmap = (Bitmap)croppedBitmap.Clone();
-                    TesseractCliOcrResult runResult = await Task.Run(() =>
-                        tesseractCliOcrAdapter.Recognize(
-                            tesseractInputBitmap,
-                            configuredExecutablePath,
-                            languageCombination,
-                            TesseractDiagnosticTimeoutMs));
-                    stopwatch.Stop();
-                    totalElapsedMs += stopwatch.ElapsedMilliseconds;
-
-                    if (!runResult.Success)
+                    var candidate = new OcrDiagnosticCandidate
                     {
-                        failureCount++;
-                        if (string.IsNullOrWhiteSpace(firstErrorMessage))
+                        Name = $"Tesseract-{preprocessedImage.Name}-{profile.CandidateSuffix}",
+                        PreprocessedPng = preprocessedPng,
+                        CroppedPng = croppedPng
+                    };
+                    var languageCandidates = new List<OcrLanguageCandidate>();
+
+                    foreach (string languageCombination in languageCombinations)
+                    {
+                        totalCallCount++;
+
+                        Stopwatch stopwatch = Stopwatch.StartNew();
+                        using Bitmap tesseractInputBitmap = (Bitmap)croppedBitmap.Clone();
+                        TesseractCliOcrResult runResult = await Task.Run(() =>
+                            tesseractCliOcrAdapter.Recognize(
+                                tesseractInputBitmap,
+                                configuredExecutablePath,
+                                languageCombination,
+                                profile,
+                                TesseractDiagnosticTimeoutMs));
+                        stopwatch.Stop();
+                        totalElapsedMs += stopwatch.ElapsedMilliseconds;
+
+                        if (!runResult.Success)
                         {
-                            firstErrorMessage = runResult.ErrorMessage;
+                            failureCount++;
+                            if (string.IsNullOrWhiteSpace(firstErrorMessage))
+                            {
+                                firstErrorMessage = runResult.ErrorMessage;
+                            }
+
+                            if (runResult.IsExecutableMissing)
+                            {
+                                executableMissing = true;
+                                break;
+                            }
+
+                            continue;
                         }
 
-                        if (runResult.IsExecutableMissing)
-                        {
-                            executableMissing = true;
-                            break;
-                        }
+                        successCount++;
 
-                        continue;
+                        var languageResult = new OcrDiagnosticLanguageResult
+                        {
+                            LanguageTag = $"tesseract:{profile.CandidateSuffix}:{runResult.LanguageCodes}"
+                        };
+                        languageResult.Lines.AddRange(runResult.Lines);
+                        candidate.Languages.Add(languageResult);
+
+                        List<OcrLine> lines = runResult.Lines
+                            .Select((text, index) => new OcrLine
+                            {
+                                Top = index * 20,
+                                Bottom = index * 20 + 12,
+                                Text = text
+                            })
+                            .ToList();
+                        languageCandidates.Add(new OcrLanguageCandidate
+                        {
+                            LanguageCode = languageCombination,
+                            Lines = lines
+                        });
                     }
 
-                    successCount++;
-
-                    var languageResult = new OcrDiagnosticLanguageResult
+                    if (executableMissing)
                     {
-                        LanguageTag = $"tesseract:{runResult.LanguageCodes}"
-                    };
-                    languageResult.Lines.AddRange(runResult.Lines);
-                    candidate.Languages.Add(languageResult);
+                        break;
+                    }
 
-                    List<OcrLine> lines = runResult.Lines
-                        .Select((text, index) => new OcrLine
-                        {
-                            Top = index * 20,
-                            Bottom = index * 20 + 12,
-                            Text = text
-                        })
-                        .ToList();
-                    languageCandidates.Add(new OcrLanguageCandidate
+                    List<OcrLine> mergedLines = contentMode == TranslationContentMode.Strinova
+                        ? ocrService.MergeBestChatLinesByComponents(languageCandidates, characterNames)
+                        : ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
+                    List<OcrLine> filteredMergedLines = ocrTranslationHarnessService.FilterMergedLinesForDiagnostics(mergedLines, characterNames);
+                    List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(filteredMergedLines, characterNames, contentMode);
+                    if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
                     {
-                        LanguageCode = languageCombination,
-                        Lines = lines
-                    });
-                }
-
-                if (executableMissing)
-                {
-                    break;
-                }
-
-                List<OcrLine> mergedLines = contentMode == TranslationContentMode.Strinova
-                    ? ocrService.MergeBestChatLinesByComponents(languageCandidates, characterNames)
-                    : ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
-                List<OcrLine> filteredMergedLines = ocrTranslationHarnessService.FilterMergedLinesForDiagnostics(mergedLines, characterNames);
-                List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(filteredMergedLines, characterNames, contentMode);
-                if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
-                {
-                    candidate.MergedLines.AddRange(normalizedMergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                    candidate.Score = ocrService.ScoreMergedLinesForSelection(normalizedMergedLines, characterNames, contentMode);
-                    candidates.Add(candidate);
+                        candidate.MergedLines.AddRange(normalizedMergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                        candidate.Score = ocrService.ScoreMergedLinesForSelection(normalizedMergedLines, characterNames, contentMode);
+                        candidates.Add(candidate);
+                    }
                 }
             }
 


### PR DESCRIPTION
## 요약
- Tesseract 진단 경로에 3개 프로파일(Baseline / PSM6-LSTM / PSM11-LSTM) 비교 추가
- 후보 이름을 `Tesseract-Adaptive-PSM6-LSTM` 형식으로 표시
- 메인 번역 경로는 유지하고 spike 진단 경로만 확장

## 변경
- `TesseractCliOcrAdapter`에 진단 전용 `TesseractCliProfile` 및 `BuildDiagnosticProfiles()` 추가
- `Recognize(..., profile, timeoutMs)` overload 추가
- `BuildArguments()` 분리로 프로파일별 `--psm` / `--oem` 인자 생성
- `MainWindow.OcrDiagnostics`에서 전처리 후보마다 3프로파일 루프 실행
- 언어별 결과 태그에 프로파일 suffix 반영

## 프로파일
- `Baseline`      : 플래그 없음
- `PSM6-LSTM`     : `--psm 6 --oem 1`
- `PSM11-LSTM`    : `--psm 11 --oem 1`

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true --filter TesseractCliOcrAdapterTests`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-psm-oem`
