### PR TITLE
기능: OCR 진단에 EasyOCR 후보 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
@@ -1,0 +1,75 @@
+using GameTranslator;
+using System.Runtime.Versioning;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    [SupportedOSPlatform("windows")]
+    public class EasyOcrCliAdapterTests
+    {
+        private readonly EasyOcrCliAdapter _adapter = new EasyOcrCliAdapter();
+
+        [Fact]
+        public void BuildLanguageCodes_UsesGameLanguageFirstAndDeduplicatesDefaults()
+        {
+            string value = _adapter.BuildLanguageCodes(SettingsService.DefaultEasyOcrLanguageCodes, "ja");
+
+            Assert.Equal("ja+en+ko+ch_sim", value);
+        }
+
+        [Fact]
+        public void BuildLanguageCombinations_DefaultValue_ReturnsThreeComparisonGroups()
+        {
+            var values = _adapter.BuildLanguageCombinations(SettingsService.DefaultEasyOcrLanguageCodes, "ko");
+
+            Assert.Equal(3, values.Count);
+            Assert.Equal("ko+en", values[0]);
+            Assert.Contains("ja+en", values);
+            Assert.Contains("ch_sim+en", values);
+        }
+
+        [Fact]
+        public void BuildArguments_IncludesRunnerImageAndGroups()
+        {
+            var values = _adapter.BuildArguments(
+                "easyocr_runner.py",
+                "input.png",
+                new[] { "ko+en", "ja+en" });
+
+            Assert.Equal(
+                new[]
+                {
+                    "-X",
+                    "utf8",
+                    "easyocr_runner.py",
+                    "--image",
+                    "input.png",
+                    "--groups",
+                    "ko+en|ja+en",
+                    "--gpu",
+                    "false"
+                },
+                values);
+        }
+
+        [Theory]
+        [InlineData("ko", "ko")]
+        [InlineData("en-US", "en")]
+        [InlineData("zh-Hans-CN", "ch_sim")]
+        [InlineData("ru", "ru")]
+        [InlineData("ja", "ja")]
+        public void MapAppLanguageTagToEasyOcr_MapsKnownTags(string input, string expected)
+        {
+            Assert.Equal(expected, _adapter.MapAppLanguageTagToEasyOcr(input));
+        }
+
+        [Fact]
+        public void GetFailureMessageForExitCode_ModuleMissing_ReturnsInstallGuidance()
+        {
+            string message = _adapter.GetFailureMessageForExitCode(3, "");
+
+            Assert.Contains("easyocr", message, System.StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("torch", message, System.StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
@@ -86,6 +86,33 @@ namespace GameChatTranslator.Tests
         }
 
         [Theory]
+        [InlineData(null, SettingsService.DefaultTesseractExecutablePath)]
+        [InlineData("", SettingsService.DefaultTesseractExecutablePath)]
+        [InlineData("  C:\\Tesseract\\tesseract.exe  ", "C:\\Tesseract\\tesseract.exe")]
+        public void NormalizeTesseractExecutablePath_UsesDefaultForBlankValues(string rawValue, string expected)
+        {
+            Assert.Equal(expected, _service.NormalizeTesseractExecutablePath(rawValue));
+        }
+
+        [Theory]
+        [InlineData(null, SettingsService.DefaultEasyOcrPythonPath)]
+        [InlineData("", SettingsService.DefaultEasyOcrPythonPath)]
+        [InlineData("  C:\\Python311\\python.exe  ", "C:\\Python311\\python.exe")]
+        public void NormalizeEasyOcrPythonPath_UsesDefaultForBlankValues(string rawValue, string expected)
+        {
+            Assert.Equal(expected, _service.NormalizeEasyOcrPythonPath(rawValue));
+        }
+
+        [Theory]
+        [InlineData(null, SettingsService.DefaultEasyOcrLanguageCodes)]
+        [InlineData("", SettingsService.DefaultEasyOcrLanguageCodes)]
+        [InlineData("  ko+en|ja+en  ", "ko+en|ja+en")]
+        public void NormalizeEasyOcrLanguageCodes_UsesDefaultForBlankValues(string rawValue, string expected)
+        {
+            Assert.Equal(expected, _service.NormalizeEasyOcrLanguageCodes(rawValue));
+        }
+
+        [Theory]
         [InlineData(null, TranslationEngineMode.Google)]
         [InlineData("", TranslationEngineMode.Google)]
         [InlineData("Google", TranslationEngineMode.Google)]

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="../GameChatTranslator/Core/OcrLanguageStatusFormatter.cs" Link="Core/OcrLanguageStatusFormatter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
+    <Compile Include="../GameChatTranslator/Core/EasyOcrCliAdapter.cs" Link="Core/EasyOcrCliAdapter.cs" />
     <Compile Include="../GameChatTranslator/Core/TesseractCliOcrAdapter.cs" Link="Core/TesseractCliOcrAdapter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrTranslationHarnessService.cs" Link="Core/OcrTranslationHarnessService.cs" />
     <Compile Include="../GameChatTranslator/Models/OcrDiagnosticModels.cs" Link="Models/OcrDiagnosticModels.cs" />

--- a/GameChatTranslator/Core/EasyOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/EasyOcrCliAdapter.cs
@@ -1,0 +1,469 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Text.Json;
+
+namespace GameTranslator
+{
+    /// <summary>
+    /// 실험 브랜치에서 EasyOCR를 외부 Python 프로세스로 호출합니다.
+    /// 메인 번역 경로는 건드리지 않고, OCR 진단 화면에서 Win OCR/Tesseract와 비교하기 위한 배치 실행만 담당합니다.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public sealed class EasyOcrCliAdapter
+    {
+        private const string RunnerFileName = "easyocr_runner.py";
+
+        private static readonly Dictionary<string, string> AppLanguageToEasyOcrMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ko"] = "ko",
+            ["ko-KR"] = "ko",
+            ["en"] = "en",
+            ["en-US"] = "en",
+            ["ja"] = "ja",
+            ["ja-JP"] = "ja",
+            ["zh-Hans-CN"] = "ch_sim",
+            ["zh-CN"] = "ch_sim",
+            ["ru"] = "ru",
+            ["ru-RU"] = "ru"
+        };
+
+        private static readonly string[] DefaultLanguagePriority =
+        {
+            "ja",
+            "ko",
+            "ch_sim"
+        };
+
+        public string BuildLanguageCodes(string configuredValue, string gameLanguage)
+        {
+            if (!string.IsNullOrWhiteSpace(configuredValue) &&
+                !string.Equals(configuredValue.Trim(), SettingsService.DefaultEasyOcrLanguageCodes, StringComparison.OrdinalIgnoreCase))
+            {
+                return NormalizeLanguageCodes(configuredValue);
+            }
+
+            var codes = new List<string>();
+            string mappedGameLanguage = MapAppLanguageTagToEasyOcr(gameLanguage);
+            if (!string.IsNullOrWhiteSpace(mappedGameLanguage))
+            {
+                codes.Add(mappedGameLanguage);
+            }
+
+            codes.Add("en");
+            codes.Add("ko");
+            codes.Add("ja");
+            codes.Add("ch_sim");
+
+            return string.Join("+", codes.Distinct(StringComparer.OrdinalIgnoreCase));
+        }
+
+        public IReadOnlyList<string> BuildLanguageCombinations(string configuredValue, string gameLanguage)
+        {
+            string normalizedConfiguredValue = (configuredValue ?? "").Trim();
+
+            if (string.IsNullOrWhiteSpace(normalizedConfiguredValue) ||
+                string.Equals(normalizedConfiguredValue, SettingsService.DefaultEasyOcrLanguageCodes, StringComparison.OrdinalIgnoreCase))
+            {
+                var combinations = new List<string>();
+                string mappedGameLanguage = MapAppLanguageTagToEasyOcr(gameLanguage);
+                if (!string.IsNullOrWhiteSpace(mappedGameLanguage) &&
+                    !string.Equals(mappedGameLanguage, "en", StringComparison.OrdinalIgnoreCase))
+                {
+                    combinations.Add(BuildPair(mappedGameLanguage));
+                }
+
+                foreach (string languageCode in DefaultLanguagePriority)
+                {
+                    combinations.Add(BuildPair(languageCode));
+                }
+
+                return combinations
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+
+            if (normalizedConfiguredValue.Contains('|') || normalizedConfiguredValue.Contains('\n'))
+            {
+                return normalizedConfiguredValue
+                    .Split(new[] { '|', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(NormalizeLanguageCodes)
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+
+            return new[] { NormalizeLanguageCodes(normalizedConfiguredValue) };
+        }
+
+        public string NormalizeLanguageCodes(string rawValue)
+        {
+            IEnumerable<string> tokens = (rawValue ?? "")
+                .Split(new[] { '+', ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(token => MapAppLanguageTagToEasyOcr(token.Trim()))
+                .Where(token => !string.IsNullOrWhiteSpace(token))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+
+            string normalized = string.Join("+", tokens);
+            return string.IsNullOrWhiteSpace(normalized) ? SettingsService.DefaultEasyOcrLanguageCodes : normalized;
+        }
+
+        public string MapAppLanguageTagToEasyOcr(string languageTag)
+        {
+            if (string.IsNullOrWhiteSpace(languageTag))
+            {
+                return "";
+            }
+
+            string normalized = languageTag.Trim();
+            return AppLanguageToEasyOcrMap.TryGetValue(normalized, out string mapped)
+                ? mapped
+                : normalized;
+        }
+
+        public EasyOcrCliBatchResult Recognize(
+            Bitmap bitmap,
+            string configuredPythonPath,
+            string configuredLanguageCodes,
+            string gameLanguage,
+            int timeoutMs = 120000)
+        {
+            if (bitmap == null)
+            {
+                return EasyOcrCliBatchResult.CreateFailure("", new List<string>(), "OCR 입력 이미지가 없습니다.");
+            }
+
+            IReadOnlyList<string> languageCombinations = BuildLanguageCombinations(configuredLanguageCodes, gameLanguage);
+            string runnerScriptPath = GetRunnerScriptPath();
+            if (!File.Exists(runnerScriptPath))
+            {
+                return EasyOcrCliBatchResult.CreateFailure(
+                    "",
+                    languageCombinations,
+                    "easyocr_runner.py를 찾지 못했습니다. 게시 산출물에 EasyOCR 러너가 포함됐는지 확인해 주세요.");
+            }
+
+            string inputDirectory = Path.Combine(Path.GetTempPath(), "GameChatTranslator", "EasyOCR");
+            Directory.CreateDirectory(inputDirectory);
+
+            string inputFilePath = Path.Combine(inputDirectory, $"ocr_{Guid.NewGuid():N}.png");
+            bitmap.Save(inputFilePath, ImageFormat.Png);
+
+            try
+            {
+                foreach (string pythonPath in GetPythonCandidates(configuredPythonPath))
+                {
+                    EasyOcrCliBatchResult runResult = TryRecognizeInternal(
+                        pythonPath,
+                        runnerScriptPath,
+                        inputFilePath,
+                        languageCombinations,
+                        timeoutMs);
+                    if (runResult.Success || !runResult.IsPythonMissing)
+                    {
+                        return runResult;
+                    }
+                }
+
+                return EasyOcrCliBatchResult.CreateFailure(
+                    SettingsService.DefaultEasyOcrPythonPath,
+                    languageCombinations,
+                    "python 실행 파일을 찾지 못했습니다. PATH 또는 config.ini의 EasyOcrPythonPath를 확인해 주세요.",
+                    isPythonMissing: true);
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(inputFilePath))
+                    {
+                        File.Delete(inputFilePath);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        internal string GetRunnerScriptPath()
+        {
+            return Path.Combine(AppContext.BaseDirectory, RunnerFileName);
+        }
+
+        internal IReadOnlyList<string> BuildArguments(
+            string runnerScriptPath,
+            string inputFilePath,
+            IReadOnlyList<string> languageCombinations)
+        {
+            return new[]
+            {
+                "-X",
+                "utf8",
+                runnerScriptPath,
+                "--image",
+                inputFilePath,
+                "--groups",
+                string.Join("|", languageCombinations ?? Array.Empty<string>()),
+                "--gpu",
+                "false"
+            };
+        }
+
+        internal string BuildPair(string languageCode)
+        {
+            return string.Equals(languageCode, "en", StringComparison.OrdinalIgnoreCase)
+                ? "en"
+                : $"{languageCode}+en";
+        }
+
+        internal string GetFailureMessageForExitCode(int exitCode, string standardError)
+        {
+            string stderr = EmptyToFallback(standardError, "");
+            return exitCode switch
+            {
+                3 => "EasyOCR 모듈을 찾지 못했습니다. python -m pip install torch torchvision easyocr 후 다시 실행해 주세요.",
+                4 => EmptyToFallback(stderr, "EasyOCR 실행 중 오류가 발생했습니다."),
+                _ => EmptyToFallback(stderr, $"EasyOCR 종료 코드: {exitCode}")
+            };
+        }
+
+        private IEnumerable<string> GetPythonCandidates(string configuredPythonPath)
+        {
+            var candidates = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(configuredPythonPath))
+            {
+                candidates.Add(configuredPythonPath.Trim());
+            }
+
+            string environmentPath = Environment.GetEnvironmentVariable("EASYOCR_PYTHON_PATH");
+            if (!string.IsNullOrWhiteSpace(environmentPath))
+            {
+                candidates.Add(environmentPath.Trim());
+            }
+
+            candidates.Add(SettingsService.DefaultEasyOcrPythonPath);
+            candidates.Add("python3");
+
+            return candidates
+                .Where(candidate => !string.IsNullOrWhiteSpace(candidate))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private EasyOcrCliBatchResult TryRecognizeInternal(
+            string pythonExecutablePath,
+            string runnerScriptPath,
+            string inputFilePath,
+            IReadOnlyList<string> languageCombinations,
+            int timeoutMs)
+        {
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = pythonExecutablePath,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
+            };
+
+            foreach (string argument in BuildArguments(runnerScriptPath, inputFilePath, languageCombinations))
+            {
+                processStartInfo.ArgumentList.Add(argument);
+            }
+
+            try
+            {
+                using Process process = Process.Start(processStartInfo);
+                if (process == null)
+                {
+                    return EasyOcrCliBatchResult.CreateFailure(pythonExecutablePath, languageCombinations, "EasyOCR Python 프로세스를 시작하지 못했습니다.");
+                }
+
+                string standardOutput = process.StandardOutput.ReadToEnd();
+                string standardError = process.StandardError.ReadToEnd();
+
+                if (!process.WaitForExit(timeoutMs))
+                {
+                    try
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    catch
+                    {
+                    }
+
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        $"EasyOCR 실행이 {timeoutMs}ms 안에 끝나지 않았습니다.");
+                }
+
+                if (process.ExitCode != 0)
+                {
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        GetFailureMessageForExitCode(process.ExitCode, standardError),
+                        isModuleMissing: process.ExitCode == 3);
+                }
+
+                List<EasyOcrCliGroupResult> groupResults = ParseGroupResults(standardOutput);
+                if (groupResults.Count == 0)
+                {
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        EmptyToFallback(standardError, "EasyOCR 결과를 읽지 못했습니다."));
+                }
+
+                int successCount = groupResults.Count(group => group.Success);
+                if (successCount == 0)
+                {
+                    string firstErrorMessage = groupResults
+                        .Select(group => group.ErrorMessage)
+                        .FirstOrDefault(message => !string.IsNullOrWhiteSpace(message));
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        EmptyToFallback(firstErrorMessage, "EasyOCR 결과가 모두 실패했습니다."));
+                }
+
+                return EasyOcrCliBatchResult.CreateSuccess(pythonExecutablePath, languageCombinations, groupResults, standardError);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                return EasyOcrCliBatchResult.CreateFailure(
+                    pythonExecutablePath,
+                    languageCombinations,
+                    "python 실행 파일을 찾지 못했습니다.",
+                    isPythonMissing: true);
+            }
+            catch (Exception ex)
+            {
+                return EasyOcrCliBatchResult.CreateFailure(pythonExecutablePath, languageCombinations, ex.Message);
+            }
+        }
+
+        private static List<EasyOcrCliGroupResult> ParseGroupResults(string json)
+        {
+            EasyOcrRunnerResponse response = JsonSerializer.Deserialize<EasyOcrRunnerResponse>(json ?? "", new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            return (response?.Groups ?? new List<EasyOcrRunnerGroup>())
+                .Select(group => new EasyOcrCliGroupResult(
+                    group?.LanguageCodes ?? "",
+                    group?.Success ?? false,
+                    (group?.Lines ?? new List<EasyOcrRunnerLine>())
+                        .Where(line => !string.IsNullOrWhiteSpace(line?.Text))
+                        .Select(line => new OcrLine
+                        {
+                            Top = line.Top,
+                            Bottom = line.Bottom,
+                            Text = line.Text.Trim()
+                        })
+                        .ToList(),
+                    group?.Error ?? ""))
+                .ToList();
+        }
+
+        private static string EmptyToFallback(string value, string fallback)
+        {
+            return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+
+        private sealed class EasyOcrRunnerResponse
+        {
+            public List<EasyOcrRunnerGroup> Groups { get; set; } = new List<EasyOcrRunnerGroup>();
+        }
+
+        private sealed class EasyOcrRunnerGroup
+        {
+            public string LanguageCodes { get; set; } = "";
+            public bool Success { get; set; }
+            public string Error { get; set; } = "";
+            public List<EasyOcrRunnerLine> Lines { get; set; } = new List<EasyOcrRunnerLine>();
+        }
+
+        private sealed class EasyOcrRunnerLine
+        {
+            public double Top { get; set; }
+            public double Bottom { get; set; }
+            public string Text { get; set; } = "";
+        }
+    }
+
+    public sealed class EasyOcrCliBatchResult
+    {
+        private EasyOcrCliBatchResult(
+            bool success,
+            string pythonExecutablePath,
+            IReadOnlyList<string> languageCombinations,
+            IReadOnlyList<EasyOcrCliGroupResult> groupResults,
+            string errorMessage,
+            bool isPythonMissing,
+            bool isModuleMissing)
+        {
+            Success = success;
+            PythonExecutablePath = pythonExecutablePath ?? "";
+            LanguageCombinations = languageCombinations ?? Array.Empty<string>();
+            GroupResults = groupResults ?? Array.Empty<EasyOcrCliGroupResult>();
+            ErrorMessage = errorMessage ?? "";
+            IsPythonMissing = isPythonMissing;
+            IsModuleMissing = isModuleMissing;
+        }
+
+        public bool Success { get; }
+        public string PythonExecutablePath { get; }
+        public IReadOnlyList<string> LanguageCombinations { get; }
+        public IReadOnlyList<EasyOcrCliGroupResult> GroupResults { get; }
+        public string ErrorMessage { get; }
+        public bool IsPythonMissing { get; }
+        public bool IsModuleMissing { get; }
+
+        public static EasyOcrCliBatchResult CreateSuccess(
+            string pythonExecutablePath,
+            IReadOnlyList<string> languageCombinations,
+            IReadOnlyList<EasyOcrCliGroupResult> groupResults,
+            string errorMessage = "")
+        {
+            return new EasyOcrCliBatchResult(true, pythonExecutablePath, languageCombinations, groupResults, errorMessage, false, false);
+        }
+
+        public static EasyOcrCliBatchResult CreateFailure(
+            string pythonExecutablePath,
+            IReadOnlyList<string> languageCombinations,
+            string errorMessage,
+            bool isPythonMissing = false,
+            bool isModuleMissing = false)
+        {
+            return new EasyOcrCliBatchResult(false, pythonExecutablePath, languageCombinations, Array.Empty<EasyOcrCliGroupResult>(), errorMessage, isPythonMissing, isModuleMissing);
+        }
+    }
+
+    public sealed class EasyOcrCliGroupResult
+    {
+        public EasyOcrCliGroupResult(string languageCodes, bool success, IReadOnlyList<OcrLine> lines, string errorMessage)
+        {
+            LanguageCodes = languageCodes ?? "";
+            Success = success;
+            Lines = lines ?? Array.Empty<OcrLine>();
+            ErrorMessage = errorMessage ?? "";
+        }
+
+        public string LanguageCodes { get; }
+        public bool Success { get; }
+        public IReadOnlyList<OcrLine> Lines { get; }
+        public string ErrorMessage { get; }
+    }
+}

--- a/GameChatTranslator/Core/SettingsService.cs
+++ b/GameChatTranslator/Core/SettingsService.cs
@@ -19,6 +19,8 @@ namespace GameTranslator
         public const int MaxLocalLlmMaxTokens = 512;
         public const string DefaultTesseractExecutablePath = "tesseract";
         public const string DefaultTesseractLanguageCodes = "eng+kor+jpn+chi_sim";
+        public const string DefaultEasyOcrPythonPath = "python";
+        public const string DefaultEasyOcrLanguageCodes = "en+ko+ja+ch_sim";
         public const string DefaultTranslationEngine = "Google";
         public const string DefaultTranslationContentMode = "Strinova";
         public const string DefaultResultDisplayMode = "Latest";
@@ -107,6 +109,22 @@ namespace GameTranslator
         public string NormalizeTesseractLanguageCodes(string value)
         {
             return string.IsNullOrWhiteSpace(value) ? DefaultTesseractLanguageCodes : value.Trim();
+        }
+
+        /// <summary>
+        /// EasyOCR Python 실행 경로가 비어 있으면 기본 python 명령을 반환합니다.
+        /// </summary>
+        public string NormalizeEasyOcrPythonPath(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? DefaultEasyOcrPythonPath : value.Trim();
+        }
+
+        /// <summary>
+        /// EasyOCR 언어 코드 문자열이 비어 있으면 기본 다국어 조합을 반환합니다.
+        /// </summary>
+        public string NormalizeEasyOcrLanguageCodes(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? DefaultEasyOcrLanguageCodes : value.Trim();
         }
 
         /// <summary>

--- a/GameChatTranslator/Distribution/easyocr_runner.py
+++ b/GameChatTranslator/Distribution/easyocr_runner.py
@@ -1,0 +1,189 @@
+import argparse
+import json
+import sys
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--groups", required=True)
+    parser.add_argument("--gpu", default="false")
+    return parser.parse_args()
+
+
+def parse_language_groups(raw_value):
+    groups = []
+    for chunk in (raw_value or "").split("|"):
+        tokens = []
+        for token in chunk.replace(",", "+").split("+"):
+            value = token.strip()
+            if value and value not in tokens:
+                tokens.append(value)
+        if tokens:
+            groups.append(tokens)
+    return groups
+
+
+def make_word(result):
+    bbox = result[0]
+    text = str(result[1]).strip()
+    if not text:
+        return None
+
+    xs = [point[0] for point in bbox]
+    ys = [point[1] for point in bbox]
+    return {
+        "left": min(xs),
+        "right": max(xs),
+        "top": min(ys),
+        "bottom": max(ys),
+        "text": text,
+    }
+
+
+def is_cjk(char):
+    if not char:
+        return False
+
+    code = ord(char)
+    return (
+        0x4E00 <= code <= 0x9FFF
+        or 0x3400 <= code <= 0x4DBF
+        or 0x3040 <= code <= 0x30FF
+        or 0xAC00 <= code <= 0xD7AF
+    )
+
+
+def append_token(current_text, token_text):
+    token_text = (token_text or "").strip()
+    if not token_text:
+        return current_text
+
+    if not current_text:
+        return token_text
+
+    previous_char = current_text[-1]
+    next_char = token_text[0]
+
+    no_space_before = ")]}:;!?.,%>/"
+    no_space_after = "([<{"
+
+    if previous_char in no_space_after or next_char in no_space_before:
+        return current_text + token_text
+
+    if is_cjk(previous_char) and is_cjk(next_char):
+        return current_text + token_text
+
+    return current_text + " " + token_text
+
+
+def same_line(word, line):
+    word_top = word["top"]
+    word_bottom = word["bottom"]
+    line_top = line["top"]
+    line_bottom = line["bottom"]
+
+    word_height = max(1.0, word_bottom - word_top)
+    line_height = max(1.0, line_bottom - line_top)
+    overlap = min(word_bottom, line_bottom) - max(word_top, line_top)
+    center_delta = abs(((word_top + word_bottom) / 2.0) - ((line_top + line_bottom) / 2.0))
+
+    return overlap >= max(2.0, min(word_height, line_height) * 0.3) or center_delta <= max(word_height, line_height) * 0.6
+
+
+def build_lines(results):
+    words = []
+    for result in results:
+        word = make_word(result)
+        if word is not None:
+            words.append(word)
+
+    words.sort(key=lambda item: (item["top"], item["left"]))
+    line_groups = []
+
+    for word in words:
+        target_line = None
+        for line in line_groups:
+            if same_line(word, line):
+                target_line = line
+                break
+
+        if target_line is None:
+            target_line = {
+                "top": word["top"],
+                "bottom": word["bottom"],
+                "words": []
+            }
+            line_groups.append(target_line)
+
+        target_line["top"] = min(target_line["top"], word["top"])
+        target_line["bottom"] = max(target_line["bottom"], word["bottom"])
+        target_line["words"].append(word)
+
+    line_groups.sort(key=lambda item: item["top"])
+
+    lines = []
+    for line in line_groups:
+        text = ""
+        for word in sorted(line["words"], key=lambda item: item["left"]):
+            text = append_token(text, word["text"])
+
+        text = text.strip()
+        if text:
+            lines.append(
+                {
+                    "top": line["top"],
+                    "bottom": line["bottom"],
+                    "text": text,
+                }
+            )
+
+    return lines
+
+
+def main():
+    args = parse_args()
+    language_groups = parse_language_groups(args.groups)
+    if not language_groups:
+        print("EasyOCR language groups are empty.", file=sys.stderr)
+        return 2
+
+    use_gpu = str(args.gpu).strip().lower() in ("1", "true", "yes", "y", "on")
+
+    try:
+        import easyocr
+    except Exception:
+        print("EasyOCR module is not installed.", file=sys.stderr)
+        return 3
+
+    response = {"groups": []}
+
+    for languages in language_groups:
+        language_codes = "+".join(languages)
+        try:
+            reader = easyocr.Reader(languages, gpu=use_gpu, verbose=False)
+            results = reader.readtext(args.image, detail=1, paragraph=False)
+            response["groups"].append(
+                {
+                    "language_codes": language_codes,
+                    "success": True,
+                    "error": "",
+                    "lines": build_lines(results),
+                }
+            )
+        except Exception as exc:
+            response["groups"].append(
+                {
+                    "language_codes": language_codes,
+                    "success": False,
+                    "error": str(exc),
+                    "lines": [],
+                }
+            )
+
+    print(json.dumps(response, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/GameChatTranslator/GameChatTranslator.csproj
+++ b/GameChatTranslator/GameChatTranslator.csproj
@@ -55,11 +55,17 @@
 	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	    <TargetPath>readme.txt</TargetPath>
 	  </None>
+	  <!-- EasyOCR 비교 실험용 Python 러너입니다. 진단 경로에서만 사용합니다. -->
+	  <None Update="Distribution/easyocr_runner.py">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>easyocr_runner.py</TargetPath>
+	  </None>
 	</ItemGroup>
 
 	<ItemGroup>
 	  <!-- Visual Studio 게시 프로필에서도 배포 보조 파일이 누락되지 않도록 Publish 후 루트 출력 폴더에 한 번 더 복사합니다. -->
-	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/readme.txt" />
+	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/readme.txt;Distribution/easyocr_runner.py" />
 	</ItemGroup>
 
 	<Target Name="CopyDistributionFilesToPublishDirectory" AfterTargets="Publish" Condition="'$(PublishDir)' != ''">

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -13,6 +13,7 @@ namespace GameTranslator
     public partial class MainWindow
     {
         private const int TesseractDiagnosticTimeoutMs = 2500;
+        private const int EasyOcrDiagnosticTimeoutMs = 120000;
 
         /// <summary>
         /// OCR 테스트/진단 창을 열거나 이미 열린 창을 앞으로 가져옵니다.
@@ -141,17 +142,25 @@ namespace GameTranslator
                     }
                 }
 
-                TesseractDiagnosticSummary tesseractSummary = await TryBuildTesseractDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode());
-                result.ExternalOcrStatus = tesseractSummary.Status;
-                stats.OcrMs += tesseractSummary.ElapsedMs;
-                stats.OcrLanguageCallCount += tesseractSummary.CallCount;
-
-                foreach (OcrDiagnosticCandidate tesseractCandidate in tesseractSummary.Candidates)
+                var externalSummaries = new List<ExternalOcrDiagnosticSummary>
                 {
-                    result.Candidates.Add(tesseractCandidate);
-                    if (bestCandidate == null || tesseractCandidate.Score > bestCandidate.Score)
+                    await TryBuildTesseractDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()),
+                    await TryBuildEasyOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode())
+                };
+                result.ExternalOcrStatus = BuildExternalOcrStatusText(externalSummaries);
+
+                foreach (ExternalOcrDiagnosticSummary externalSummary in externalSummaries)
+                {
+                    stats.OcrMs += externalSummary.ElapsedMs;
+                    stats.OcrLanguageCallCount += externalSummary.CallCount;
+
+                    foreach (OcrDiagnosticCandidate externalCandidate in externalSummary.Candidates)
                     {
-                        bestCandidate = tesseractCandidate;
+                        result.Candidates.Add(externalCandidate);
+                        if (bestCandidate == null || externalCandidate.Score > bestCandidate.Score)
+                        {
+                            bestCandidate = externalCandidate;
+                        }
                     }
                 }
 
@@ -191,7 +200,7 @@ namespace GameTranslator
             return result;
         }
 
-        private async Task<TesseractDiagnosticSummary> TryBuildTesseractDiagnosticCandidatesAsync(IEnumerable<PreprocessedOcrImage> preprocessedImages, TranslationContentMode contentMode)
+        private async Task<ExternalOcrDiagnosticSummary> TryBuildTesseractDiagnosticCandidatesAsync(IEnumerable<PreprocessedOcrImage> preprocessedImages, TranslationContentMode contentMode)
         {
             string configuredExecutablePath = ReadTesseractExecutablePath();
             string configuredLanguageCodes = ReadTesseractLanguageCodes();
@@ -302,20 +311,152 @@ namespace GameTranslator
             {
                 string failedStatus = $"Tesseract 미사용: {firstErrorMessage}";
                 AppendLog($"[OCR DIAG] {failedStatus}");
-                return new TesseractDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
+                return new ExternalOcrDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
             }
 
             if (successCount == 0)
             {
                 string failedStatus = $"Tesseract 실패: {firstErrorMessage}";
                 AppendLog($"[OCR DIAG] {failedStatus}");
-                return new TesseractDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
+                return new ExternalOcrDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
             }
 
             string successStatus =
                 $"Tesseract 후보 {candidates.Count}개 추가 / {successCount}회 성공 / {failureCount}회 실패 / timeout {TesseractDiagnosticTimeoutMs}ms";
             AppendLog($"[OCR DIAG] {successStatus}");
-            return new TesseractDiagnosticSummary(candidates, successStatus, totalElapsedMs, totalCallCount);
+            return new ExternalOcrDiagnosticSummary(candidates, successStatus, totalElapsedMs, totalCallCount);
+        }
+
+        private async Task<ExternalOcrDiagnosticSummary> TryBuildEasyOcrDiagnosticCandidatesAsync(IEnumerable<PreprocessedOcrImage> preprocessedImages, TranslationContentMode contentMode)
+        {
+            string configuredPythonPath = ReadEasyOcrPythonPath();
+            string configuredLanguageCodes = ReadEasyOcrLanguageCodes();
+
+            int totalCallCount = 0;
+            long totalElapsedMs = 0;
+            int successCount = 0;
+            int failureCount = 0;
+            bool pythonMissing = false;
+            bool moduleMissing = false;
+            string firstErrorMessage = "";
+            var candidates = new List<OcrDiagnosticCandidate>();
+
+            foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
+            {
+                using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
+                byte[] croppedPng = BitmapToPngBytes(croppedBitmap);
+                byte[] preprocessedPng = BitmapToPngBytes(preprocessedImage.Bitmap);
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                using Bitmap easyOcrInputBitmap = (Bitmap)croppedBitmap.Clone();
+                EasyOcrCliBatchResult batchResult = await Task.Run(() =>
+                    easyOcrCliAdapter.Recognize(
+                        easyOcrInputBitmap,
+                        configuredPythonPath,
+                        configuredLanguageCodes,
+                        gameLang,
+                        EasyOcrDiagnosticTimeoutMs));
+                stopwatch.Stop();
+                totalElapsedMs += stopwatch.ElapsedMilliseconds;
+                totalCallCount += batchResult.LanguageCombinations.Count;
+
+                if (!batchResult.Success)
+                {
+                    failureCount += Math.Max(1, batchResult.LanguageCombinations.Count);
+                    if (string.IsNullOrWhiteSpace(firstErrorMessage))
+                    {
+                        firstErrorMessage = batchResult.ErrorMessage;
+                    }
+
+                    if (batchResult.IsPythonMissing)
+                    {
+                        pythonMissing = true;
+                        break;
+                    }
+
+                    if (batchResult.IsModuleMissing)
+                    {
+                        moduleMissing = true;
+                        break;
+                    }
+
+                    continue;
+                }
+
+                successCount += batchResult.GroupResults.Count(group => group.Success);
+                failureCount += batchResult.GroupResults.Count(group => !group.Success);
+
+                var candidate = new OcrDiagnosticCandidate
+                {
+                    Name = $"EasyOCR-{preprocessedImage.Name}",
+                    PreprocessedPng = preprocessedPng,
+                    CroppedPng = croppedPng
+                };
+                var languageCandidates = new List<OcrLanguageCandidate>();
+
+                foreach (EasyOcrCliGroupResult groupResult in batchResult.GroupResults.Where(group => group.Success))
+                {
+                    var languageResult = new OcrDiagnosticLanguageResult
+                    {
+                        LanguageTag = $"easyocr:{groupResult.LanguageCodes}"
+                    };
+                    languageResult.Lines.AddRange(groupResult.Lines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                    candidate.Languages.Add(languageResult);
+
+                    languageCandidates.Add(new OcrLanguageCandidate
+                    {
+                        LanguageCode = groupResult.LanguageCodes,
+                        Lines = groupResult.Lines
+                            .Select(line => new OcrLine
+                            {
+                                Top = line.Top,
+                                Bottom = line.Bottom,
+                                Text = line.Text
+                            })
+                            .ToList()
+                    });
+                }
+
+                List<OcrLine> mergedLines = contentMode == TranslationContentMode.Strinova
+                    ? ocrService.MergeBestChatLinesByComponents(languageCandidates, characterNames)
+                    : ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
+                List<OcrLine> filteredMergedLines = ocrTranslationHarnessService.FilterMergedLinesForDiagnostics(mergedLines, characterNames);
+                List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(filteredMergedLines, characterNames, contentMode);
+                if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
+                {
+                    candidate.MergedLines.AddRange(normalizedMergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                    candidate.Score = ocrService.ScoreMergedLinesForSelection(normalizedMergedLines, characterNames, contentMode);
+                    candidates.Add(candidate);
+                }
+            }
+
+            if (pythonMissing || moduleMissing)
+            {
+                string failedStatus = $"EasyOCR 미사용: {firstErrorMessage}";
+                AppendLog($"[OCR DIAG] {failedStatus}");
+                return new ExternalOcrDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
+            }
+
+            if (successCount == 0)
+            {
+                string failedStatus = $"EasyOCR 실패: {firstErrorMessage}";
+                AppendLog($"[OCR DIAG] {failedStatus}");
+                return new ExternalOcrDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
+            }
+
+            string successStatus =
+                $"EasyOCR 후보 {candidates.Count}개 추가 / {successCount}개 그룹 성공 / {failureCount}개 그룹 실패 / timeout {EasyOcrDiagnosticTimeoutMs}ms";
+            AppendLog($"[OCR DIAG] {successStatus}");
+            return new ExternalOcrDiagnosticSummary(candidates, successStatus, totalElapsedMs, totalCallCount);
+        }
+
+        private static string BuildExternalOcrStatusText(IEnumerable<ExternalOcrDiagnosticSummary> summaries)
+        {
+            return string.Join(
+                Environment.NewLine,
+                (summaries ?? Enumerable.Empty<ExternalOcrDiagnosticSummary>())
+                    .Select(summary => summary?.Status?.Trim())
+                    .Where(status => !string.IsNullOrWhiteSpace(status)));
         }
 
         /// <summary>
@@ -477,9 +618,9 @@ namespace GameTranslator
             return string.IsNullOrWhiteSpace(value) ? "-" : value.Trim();
         }
 
-        private sealed class TesseractDiagnosticSummary
+        private sealed class ExternalOcrDiagnosticSummary
         {
-            public TesseractDiagnosticSummary(List<OcrDiagnosticCandidate> candidates, string status, long elapsedMs, int callCount)
+            public ExternalOcrDiagnosticSummary(List<OcrDiagnosticCandidate> candidates, string status, long elapsedMs, int callCount)
             {
                 Candidates = candidates ?? new List<OcrDiagnosticCandidate>();
                 Status = status ?? "";

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
@@ -109,6 +109,8 @@ namespace GameTranslator
             EnsureNormalizedSetting("LocalLlmMaxTokens", settingsService.NormalizeLocalLlmMaxTokens(ini.Read("LocalLlmMaxTokens")).ToString());
             EnsureNormalizedSetting("TesseractExePath", settingsService.NormalizeTesseractExecutablePath(ini.Read("TesseractExePath")));
             EnsureNormalizedSetting("TesseractLanguageCodes", settingsService.NormalizeTesseractLanguageCodes(ini.Read("TesseractLanguageCodes")));
+            EnsureNormalizedSetting("EasyOcrPythonPath", settingsService.NormalizeEasyOcrPythonPath(ini.Read("EasyOcrPythonPath")));
+            EnsureNormalizedSetting("EasyOcrLanguageCodes", settingsService.NormalizeEasyOcrLanguageCodes(ini.Read("EasyOcrLanguageCodes")));
 
             if (string.IsNullOrWhiteSpace(ini.Read("SaveDebugImages")))
             {
@@ -271,6 +273,24 @@ namespace GameTranslator
         private string ReadTesseractLanguageCodes()
         {
             return settingsService.NormalizeTesseractLanguageCodes(ini.Read("TesseractLanguageCodes"));
+        }
+
+        /// <summary>
+        /// 외부 OCR 실험용 EasyOCR Python 실행 경로를 읽습니다.
+        /// 비어 있으면 PATH의 python 명령을 기본값으로 사용합니다.
+        /// </summary>
+        private string ReadEasyOcrPythonPath()
+        {
+            return settingsService.NormalizeEasyOcrPythonPath(ini.Read("EasyOcrPythonPath"));
+        }
+
+        /// <summary>
+        /// 외부 OCR 실험용 EasyOCR 언어 코드 조합을 읽습니다.
+        /// 비어 있으면 en+ko+ja+ch_sim 기본 조합을 사용합니다.
+        /// </summary>
+        private string ReadEasyOcrLanguageCodes()
+        {
+            return settingsService.NormalizeEasyOcrLanguageCodes(ini.Read("EasyOcrLanguageCodes"));
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -72,6 +72,7 @@ namespace GameTranslator
         private readonly TranslationService translationService = new TranslationService();
         private readonly OcrTranslationHarnessService ocrTranslationHarnessService = new OcrTranslationHarnessService();
         private readonly TesseractCliOcrAdapter tesseractCliOcrAdapter = new TesseractCliOcrAdapter();
+        private readonly EasyOcrCliAdapter easyOcrCliAdapter = new EasyOcrCliAdapter();
         private readonly TranslationApiErrorDescriber translationApiErrorDescriber = new TranslationApiErrorDescriber();
         private readonly TranslationApiClient translationApiClient;
         private AppDataPaths appDataPaths;


### PR DESCRIPTION
요약
- OCR 진단 경로에 EasyOCR 외부 어댑터 추가
- Python runner(`easyocr_runner.py`)를 출력물에 포함하고 `EasyOcrPythonPath`, `EasyOcrLanguageCodes` 설정키 추가
- EasyOCR 결과를 Win OCR/Tesseract와 같은 후보 비교·하네스 흐름에서 볼 수 있게 연결
- 메인 번역 경로는 변경하지 않음

## 검증
- `git diff --check`
- `python3 -m py_compile GameChatTranslator/Distribution/easyocr_runner.py`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-easyocr`

## 확인 포인트
- EasyOCR 미설치 시 외부 OCR 상태 박스에 설치 안내가 명확히 표시되는지
- EasyOCR 설치 시 `EasyOCR-Color`, `EasyOCR-ColorThick`, `EasyOCR-Adaptive` 후보가 추가되는지
- publish 산출물에 `easyocr_runner.py`가 포함되는지
