### PR TITLE
수정: EasyOCR Python 런처 탐색에 py 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
@@ -52,6 +52,16 @@ namespace GameChatTranslator.Tests
                 values);
         }
 
+        [Fact]
+        public void BuildPythonCandidates_IncludesPyLauncherFallback()
+        {
+            var values = _adapter.GetPythonCandidatesForTesting("");
+
+            Assert.Contains("python", values);
+            Assert.Contains("py", values);
+            Assert.Contains("python3", values);
+        }
+
         [Theory]
         [InlineData("ko", "ko")]
         [InlineData("en-US", "en")]
@@ -70,6 +80,7 @@ namespace GameChatTranslator.Tests
 
             Assert.Contains("easyocr", message, System.StringComparison.OrdinalIgnoreCase);
             Assert.Contains("torch", message, System.StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("py -m pip", message, System.StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/GameChatTranslator/Core/EasyOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/EasyOcrCliAdapter.cs
@@ -174,7 +174,7 @@ namespace GameTranslator
                 return EasyOcrCliBatchResult.CreateFailure(
                     SettingsService.DefaultEasyOcrPythonPath,
                     languageCombinations,
-                    "python 실행 파일을 찾지 못했습니다. PATH 또는 config.ini의 EasyOcrPythonPath를 확인해 주세요.",
+                    "python 또는 py 실행 파일을 찾지 못했습니다. PATH 또는 config.ini의 EasyOcrPythonPath를 확인해 주세요.",
                     isPythonMissing: true);
             }
             finally
@@ -228,10 +228,15 @@ namespace GameTranslator
             string stderr = EmptyToFallback(standardError, "");
             return exitCode switch
             {
-                3 => "EasyOCR 모듈을 찾지 못했습니다. python -m pip install torch torchvision easyocr 후 다시 실행해 주세요.",
+                3 => "EasyOCR 모듈을 찾지 못했습니다. py -m pip install torch torchvision easyocr 또는 python -m pip install torch torchvision easyocr 후 다시 실행해 주세요.",
                 4 => EmptyToFallback(stderr, "EasyOCR 실행 중 오류가 발생했습니다."),
                 _ => EmptyToFallback(stderr, $"EasyOCR 종료 코드: {exitCode}")
             };
+        }
+
+        internal IReadOnlyList<string> GetPythonCandidatesForTesting(string configuredPythonPath)
+        {
+            return GetPythonCandidates(configuredPythonPath).ToList();
         }
 
         private IEnumerable<string> GetPythonCandidates(string configuredPythonPath)
@@ -250,6 +255,7 @@ namespace GameTranslator
             }
 
             candidates.Add(SettingsService.DefaultEasyOcrPythonPath);
+            candidates.Add("py");
             candidates.Add("python3");
 
             return candidates
@@ -344,7 +350,7 @@ namespace GameTranslator
                 return EasyOcrCliBatchResult.CreateFailure(
                     pythonExecutablePath,
                     languageCombinations,
-                    "python 실행 파일을 찾지 못했습니다.",
+                    "python 또는 py 실행 파일을 찾지 못했습니다.",
                     isPythonMissing: true);
             }
             catch (Exception ex)


### PR DESCRIPTION
요약
- EasyOCR Python 실행 파일 탐색에 `py` 런처 fallback 추가
- 미설치/실행 실패 안내 문구를 `python 또는 py` 기준으로 정정
- `py -m pip install ...` 방식으로 설치한 Windows 환경에서 EasyOCR 후보가 안 뜨는 문제 수정

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`

## 원인
- 기존 코드는 `python`, `python3`만 탐색하고 `py` 런처는 보지 않음
- #144 환경처럼 `py -m pip install torch torchvision easyocr`로 설치한 경우 EasyOCR가 실제 설치돼 있어도 진단 경로에서 실행 파일을 못 찾아 후보가 생성되지 않음
