### PR TITLE
수정: EasyOCR 러너 JSON 직렬화 오류 보정

### DIFF
--- a/GameChatTranslator/Distribution/easyocr_runner.py
+++ b/GameChatTranslator/Distribution/easyocr_runner.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import sys
+import warnings
 
 
 def parse_args():
@@ -30,8 +31,8 @@ def make_word(result):
     if not text:
         return None
 
-    xs = [point[0] for point in bbox]
-    ys = [point[1] for point in bbox]
+    xs = [float(point[0]) for point in bbox]
+    ys = [float(point[1]) for point in bbox]
     return {
         "left": min(xs),
         "right": max(xs),
@@ -155,6 +156,12 @@ def main():
     except Exception:
         print("EasyOCR module is not installed.", file=sys.stderr)
         return 3
+
+    warnings.filterwarnings(
+        "ignore",
+        message=".*pin_memory.*",
+        category=UserWarning,
+    )
 
     response = {"groups": []}
 


### PR DESCRIPTION
요약
- EasyOCR runner에서 bbox 좌표를 Python 기본 숫자(float)로 강제 변환
- `json.dumps` 단계에서 numpy int32 직렬화 오류가 나지 않도록 보정
- torch `pin_memory` 경고는 stderr 노이즈를 줄이도록 무시

## 원인
- EasyOCR가 bbox 좌표를 numpy int32로 반환
- runner가 이를 그대로 response JSON에 넣음
- `json.dumps(...)`에서 `TypeError: Object of type int32 is not JSON serializable` 발생
- 결과적으로 EasyOCR 후보가 0개가 되어 비교가 불가능했음

## 검증
- `git diff --check`
- `python3 -m py_compile GameChatTranslator/Distribution/easyocr_runner.py`
- `python3` 스모크 테스트로 Decimal 좌표 입력 후 `json.dumps` 성공 확인
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
