### PR TITLE
기능: OCR 진단에 PaddleOCR 비교 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
@@ -82,5 +82,30 @@ namespace GameChatTranslator.Tests
             Assert.Contains("torch", message, System.StringComparison.OrdinalIgnoreCase);
             Assert.Contains("py -m pip", message, System.StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public void ParseGroupResults_ReadsSnakeCaseLanguageCodes()
+        {
+            var groups = EasyOcrCliAdapter.ParseGroupResults(
+                """
+                {
+                  "groups": [
+                    {
+                      "language_codes": "ja+en",
+                      "success": true,
+                      "error": "",
+                      "lines": [
+                        { "top": 1, "bottom": 2, "text": "猫は可愛い" }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+            EasyOcrCliGroupResult group = Assert.Single(groups);
+            Assert.Equal("ja+en", group.LanguageCodes);
+            Assert.True(group.Success);
+            Assert.Equal("猫は可愛い", Assert.Single(group.Lines).Text);
+        }
     }
 }

--- a/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
@@ -1,0 +1,87 @@
+using GameTranslator;
+using System.Runtime.Versioning;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    [SupportedOSPlatform("windows")]
+    public class PaddleOcrCliAdapterTests
+    {
+        private readonly PaddleOcrCliAdapter _adapter = new PaddleOcrCliAdapter();
+
+        [Fact]
+        public void BuildLanguageCodes_UsesGameLanguageFirstAndDeduplicatesDefaults()
+        {
+            string value = _adapter.BuildLanguageCodes(SettingsService.DefaultPaddleOcrLanguageCodes, "ja");
+
+            Assert.Equal("japan+en+korean+ch", value);
+        }
+
+        [Fact]
+        public void BuildLanguageCandidates_DefaultValue_ReturnsFourComparisonGroups()
+        {
+            var values = _adapter.BuildLanguageCandidates(SettingsService.DefaultPaddleOcrLanguageCodes, "ko");
+
+            Assert.Equal(4, values.Count);
+            Assert.Equal("korean", values[0]);
+            Assert.Contains("en", values);
+            Assert.Contains("japan", values);
+            Assert.Contains("ch", values);
+        }
+
+        [Fact]
+        public void BuildArguments_IncludesRunnerImageAndGroups()
+        {
+            var values = _adapter.BuildArguments(
+                "paddleocr_runner.py",
+                "input.png",
+                new[] { "korean", "japan", "ch" });
+
+            Assert.Equal(
+                new[]
+                {
+                    "-X",
+                    "utf8",
+                    "paddleocr_runner.py",
+                    "--image",
+                    "input.png",
+                    "--groups",
+                    "korean|japan|ch",
+                    "--gpu",
+                    "false"
+                },
+                values);
+        }
+
+        [Fact]
+        public void BuildPythonCandidates_IncludesPyLauncherFallback()
+        {
+            var values = _adapter.GetPythonCandidatesForTesting("");
+
+            Assert.Contains("python", values);
+            Assert.Contains("py", values);
+            Assert.Contains("python3", values);
+        }
+
+        [Theory]
+        [InlineData("ko", "korean")]
+        [InlineData("en-US", "en")]
+        [InlineData("zh-Hans-CN", "ch")]
+        [InlineData("ru", "ru")]
+        [InlineData("ja", "japan")]
+        public void MapAppLanguageTagToPaddleOcr_MapsKnownTags(string input, string expected)
+        {
+            Assert.Equal(expected, _adapter.MapAppLanguageTagToPaddleOcr(input));
+        }
+
+        [Fact]
+        public void GetFailureMessageForExitCode_ModuleMissing_ReturnsInstallGuidance()
+        {
+            string message = _adapter.GetFailureMessageForExitCode(3, "");
+
+            Assert.Contains("paddleocr", message, System.StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("paddlepaddle", message, System.StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("py -m pip", message, System.StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
@@ -113,6 +113,24 @@ namespace GameChatTranslator.Tests
         }
 
         [Theory]
+        [InlineData(null, SettingsService.DefaultPaddleOcrPythonPath)]
+        [InlineData("", SettingsService.DefaultPaddleOcrPythonPath)]
+        [InlineData("  C:\\Python311\\python.exe  ", "C:\\Python311\\python.exe")]
+        public void NormalizePaddleOcrPythonPath_UsesDefaultForBlankValues(string rawValue, string expected)
+        {
+            Assert.Equal(expected, _service.NormalizePaddleOcrPythonPath(rawValue));
+        }
+
+        [Theory]
+        [InlineData(null, SettingsService.DefaultPaddleOcrLanguageCodes)]
+        [InlineData("", SettingsService.DefaultPaddleOcrLanguageCodes)]
+        [InlineData("  korean|japan|ch  ", "korean|japan|ch")]
+        public void NormalizePaddleOcrLanguageCodes_UsesDefaultForBlankValues(string rawValue, string expected)
+        {
+            Assert.Equal(expected, _service.NormalizePaddleOcrLanguageCodes(rawValue));
+        }
+
+        [Theory]
         [InlineData(null, TranslationEngineMode.Google)]
         [InlineData("", TranslationEngineMode.Google)]
         [InlineData("Google", TranslationEngineMode.Google)]

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
     <Compile Include="../GameChatTranslator/Core/EasyOcrCliAdapter.cs" Link="Core/EasyOcrCliAdapter.cs" />
+    <Compile Include="../GameChatTranslator/Core/PaddleOcrCliAdapter.cs" Link="Core/PaddleOcrCliAdapter.cs" />
     <Compile Include="../GameChatTranslator/Core/TesseractCliOcrAdapter.cs" Link="Core/TesseractCliOcrAdapter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrTranslationHarnessService.cs" Link="Core/OcrTranslationHarnessService.cs" />
     <Compile Include="../GameChatTranslator/Models/OcrDiagnosticModels.cs" Link="Models/OcrDiagnosticModels.cs" />

--- a/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
@@ -8,84 +8,75 @@ using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace GameTranslator
 {
     /// <summary>
-    /// 실험 브랜치에서 EasyOCR를 외부 Python 프로세스로 호출합니다.
-    /// 메인 번역 경로는 건드리지 않고, OCR 진단 화면에서 Win OCR/Tesseract와 비교하기 위한 배치 실행만 담당합니다.
+    /// 실험 브랜치에서 PaddleOCR를 외부 Python 프로세스로 호출합니다.
+    /// 메인 번역 경로는 건드리지 않고, OCR 진단 화면에서 Win OCR/Tesseract/EasyOCR와 비교하기 위한 배치 실행만 담당합니다.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public sealed class EasyOcrCliAdapter
+    public sealed class PaddleOcrCliAdapter
     {
-        private const string RunnerFileName = "easyocr_runner.py";
+        private const string RunnerFileName = "paddleocr_runner.py";
 
-        private static readonly Dictionary<string, string> AppLanguageToEasyOcrMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, string> AppLanguageToPaddleOcrMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["ko"] = "ko",
-            ["ko-KR"] = "ko",
+            ["ko"] = "korean",
+            ["ko-KR"] = "korean",
             ["en"] = "en",
             ["en-US"] = "en",
-            ["ja"] = "ja",
-            ["ja-JP"] = "ja",
-            ["zh-Hans-CN"] = "ch_sim",
-            ["zh-CN"] = "ch_sim",
+            ["ja"] = "japan",
+            ["ja-JP"] = "japan",
+            ["zh-Hans-CN"] = "ch",
+            ["zh-CN"] = "ch",
             ["ru"] = "ru",
             ["ru-RU"] = "ru"
         };
 
         private static readonly string[] DefaultLanguagePriority =
         {
-            "ja",
-            "ko",
-            "ch_sim"
+            "en",
+            "korean",
+            "japan",
+            "ch"
         };
 
         public string BuildLanguageCodes(string configuredValue, string gameLanguage)
         {
             if (!string.IsNullOrWhiteSpace(configuredValue) &&
-                !string.Equals(configuredValue.Trim(), SettingsService.DefaultEasyOcrLanguageCodes, StringComparison.OrdinalIgnoreCase))
+                !string.Equals(configuredValue.Trim(), SettingsService.DefaultPaddleOcrLanguageCodes, StringComparison.OrdinalIgnoreCase))
             {
                 return NormalizeLanguageCodes(configuredValue);
             }
 
             var codes = new List<string>();
-            string mappedGameLanguage = MapAppLanguageTagToEasyOcr(gameLanguage);
+            string mappedGameLanguage = MapAppLanguageTagToPaddleOcr(gameLanguage);
             if (!string.IsNullOrWhiteSpace(mappedGameLanguage))
             {
                 codes.Add(mappedGameLanguage);
             }
 
-            codes.Add("en");
-            codes.Add("ko");
-            codes.Add("ja");
-            codes.Add("ch_sim");
-
+            codes.AddRange(DefaultLanguagePriority);
             return string.Join("+", codes.Distinct(StringComparer.OrdinalIgnoreCase));
         }
 
-        public IReadOnlyList<string> BuildLanguageCombinations(string configuredValue, string gameLanguage)
+        public IReadOnlyList<string> BuildLanguageCandidates(string configuredValue, string gameLanguage)
         {
             string normalizedConfiguredValue = (configuredValue ?? "").Trim();
 
             if (string.IsNullOrWhiteSpace(normalizedConfiguredValue) ||
-                string.Equals(normalizedConfiguredValue, SettingsService.DefaultEasyOcrLanguageCodes, StringComparison.OrdinalIgnoreCase))
+                string.Equals(normalizedConfiguredValue, SettingsService.DefaultPaddleOcrLanguageCodes, StringComparison.OrdinalIgnoreCase))
             {
-                var combinations = new List<string>();
-                string mappedGameLanguage = MapAppLanguageTagToEasyOcr(gameLanguage);
-                if (!string.IsNullOrWhiteSpace(mappedGameLanguage) &&
-                    !string.Equals(mappedGameLanguage, "en", StringComparison.OrdinalIgnoreCase))
+                var candidates = new List<string>();
+                string mappedGameLanguage = MapAppLanguageTagToPaddleOcr(gameLanguage);
+                if (!string.IsNullOrWhiteSpace(mappedGameLanguage))
                 {
-                    combinations.Add(BuildPair(mappedGameLanguage));
+                    candidates.Add(mappedGameLanguage);
                 }
 
-                foreach (string languageCode in DefaultLanguagePriority)
-                {
-                    combinations.Add(BuildPair(languageCode));
-                }
-
-                return combinations
+                candidates.AddRange(DefaultLanguagePriority);
+                return candidates
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
             }
@@ -100,22 +91,25 @@ namespace GameTranslator
                     .ToList();
             }
 
-            return new[] { NormalizeLanguageCodes(normalizedConfiguredValue) };
+            return NormalizeLanguageCodes(normalizedConfiguredValue)
+                .Split(new[] { '+' }, StringSplitOptions.RemoveEmptyEntries)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
 
         public string NormalizeLanguageCodes(string rawValue)
         {
             IEnumerable<string> tokens = (rawValue ?? "")
                 .Split(new[] { '+', ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(token => MapAppLanguageTagToEasyOcr(token.Trim()))
+                .Select(token => MapAppLanguageTagToPaddleOcr(token.Trim()))
                 .Where(token => !string.IsNullOrWhiteSpace(token))
                 .Distinct(StringComparer.OrdinalIgnoreCase);
 
             string normalized = string.Join("+", tokens);
-            return string.IsNullOrWhiteSpace(normalized) ? SettingsService.DefaultEasyOcrLanguageCodes : normalized;
+            return string.IsNullOrWhiteSpace(normalized) ? SettingsService.DefaultPaddleOcrLanguageCodes : normalized;
         }
 
-        public string MapAppLanguageTagToEasyOcr(string languageTag)
+        public string MapAppLanguageTagToPaddleOcr(string languageTag)
         {
             if (string.IsNullOrWhiteSpace(languageTag))
             {
@@ -123,12 +117,12 @@ namespace GameTranslator
             }
 
             string normalized = languageTag.Trim();
-            return AppLanguageToEasyOcrMap.TryGetValue(normalized, out string mapped)
+            return AppLanguageToPaddleOcrMap.TryGetValue(normalized, out string mapped)
                 ? mapped
                 : normalized;
         }
 
-        public EasyOcrCliBatchResult Recognize(
+        public PaddleOcrCliBatchResult Recognize(
             Bitmap bitmap,
             string configuredPythonPath,
             string configuredLanguageCodes,
@@ -137,20 +131,20 @@ namespace GameTranslator
         {
             if (bitmap == null)
             {
-                return EasyOcrCliBatchResult.CreateFailure("", new List<string>(), "OCR 입력 이미지가 없습니다.");
+                return PaddleOcrCliBatchResult.CreateFailure("", new List<string>(), "OCR 입력 이미지가 없습니다.");
             }
 
-            IReadOnlyList<string> languageCombinations = BuildLanguageCombinations(configuredLanguageCodes, gameLanguage);
+            IReadOnlyList<string> languageCandidates = BuildLanguageCandidates(configuredLanguageCodes, gameLanguage);
             string runnerScriptPath = GetRunnerScriptPath();
             if (!File.Exists(runnerScriptPath))
             {
-                return EasyOcrCliBatchResult.CreateFailure(
+                return PaddleOcrCliBatchResult.CreateFailure(
                     "",
-                    languageCombinations,
-                    "easyocr_runner.py를 찾지 못했습니다. 게시 산출물에 EasyOCR 러너가 포함됐는지 확인해 주세요.");
+                    languageCandidates,
+                    "paddleocr_runner.py를 찾지 못했습니다. 게시 산출물에 PaddleOCR 러너가 포함됐는지 확인해 주세요.");
             }
 
-            string inputDirectory = Path.Combine(Path.GetTempPath(), "GameChatTranslator", "EasyOCR");
+            string inputDirectory = Path.Combine(Path.GetTempPath(), "GameChatTranslator", "PaddleOCR");
             Directory.CreateDirectory(inputDirectory);
 
             string inputFilePath = Path.Combine(inputDirectory, $"ocr_{Guid.NewGuid():N}.png");
@@ -160,11 +154,11 @@ namespace GameTranslator
             {
                 foreach (string pythonPath in GetPythonCandidates(configuredPythonPath))
                 {
-                    EasyOcrCliBatchResult runResult = TryRecognizeInternal(
+                    PaddleOcrCliBatchResult runResult = TryRecognizeInternal(
                         pythonPath,
                         runnerScriptPath,
                         inputFilePath,
-                        languageCombinations,
+                        languageCandidates,
                         timeoutMs);
                     if (runResult.Success || !runResult.IsPythonMissing)
                     {
@@ -172,10 +166,10 @@ namespace GameTranslator
                     }
                 }
 
-                return EasyOcrCliBatchResult.CreateFailure(
-                    SettingsService.DefaultEasyOcrPythonPath,
-                    languageCombinations,
-                    "python 또는 py 실행 파일을 찾지 못했습니다. PATH 또는 config.ini의 EasyOcrPythonPath를 확인해 주세요.",
+                return PaddleOcrCliBatchResult.CreateFailure(
+                    SettingsService.DefaultPaddleOcrPythonPath,
+                    languageCandidates,
+                    "python 또는 py 실행 파일을 찾지 못했습니다. PATH 또는 config.ini의 PaddleOcrPythonPath를 확인해 주세요.",
                     isPythonMissing: true);
             }
             finally
@@ -201,7 +195,7 @@ namespace GameTranslator
         internal IReadOnlyList<string> BuildArguments(
             string runnerScriptPath,
             string inputFilePath,
-            IReadOnlyList<string> languageCombinations)
+            IReadOnlyList<string> languageCandidates)
         {
             return new[]
             {
@@ -211,17 +205,10 @@ namespace GameTranslator
                 "--image",
                 inputFilePath,
                 "--groups",
-                string.Join("|", languageCombinations ?? Array.Empty<string>()),
+                string.Join("|", languageCandidates ?? Array.Empty<string>()),
                 "--gpu",
                 "false"
             };
-        }
-
-        internal string BuildPair(string languageCode)
-        {
-            return string.Equals(languageCode, "en", StringComparison.OrdinalIgnoreCase)
-                ? "en"
-                : $"{languageCode}+en";
         }
 
         internal string GetFailureMessageForExitCode(int exitCode, string standardError)
@@ -229,9 +216,9 @@ namespace GameTranslator
             string stderr = EmptyToFallback(standardError, "");
             return exitCode switch
             {
-                3 => "EasyOCR 모듈을 찾지 못했습니다. py -m pip install torch torchvision easyocr 또는 python -m pip install torch torchvision easyocr 후 다시 실행해 주세요.",
-                4 => EmptyToFallback(stderr, "EasyOCR 실행 중 오류가 발생했습니다."),
-                _ => EmptyToFallback(stderr, $"EasyOCR 종료 코드: {exitCode}")
+                3 => "PaddleOCR 모듈을 찾지 못했습니다. py -m pip install paddlepaddle 및 py -m pip install \"paddleocr[all]\" 후 다시 실행해 주세요.",
+                4 => EmptyToFallback(stderr, "PaddleOCR 실행 중 오류가 발생했습니다."),
+                _ => EmptyToFallback(stderr, $"PaddleOCR 종료 코드: {exitCode}")
             };
         }
 
@@ -249,13 +236,13 @@ namespace GameTranslator
                 candidates.Add(configuredPythonPath.Trim());
             }
 
-            string environmentPath = Environment.GetEnvironmentVariable("EASYOCR_PYTHON_PATH");
+            string environmentPath = Environment.GetEnvironmentVariable("PADDLEOCR_PYTHON_PATH");
             if (!string.IsNullOrWhiteSpace(environmentPath))
             {
                 candidates.Add(environmentPath.Trim());
             }
 
-            candidates.Add(SettingsService.DefaultEasyOcrPythonPath);
+            candidates.Add(SettingsService.DefaultPaddleOcrPythonPath);
             candidates.Add("py");
             candidates.Add("python3");
 
@@ -264,11 +251,11 @@ namespace GameTranslator
                 .Distinct(StringComparer.OrdinalIgnoreCase);
         }
 
-        private EasyOcrCliBatchResult TryRecognizeInternal(
+        private PaddleOcrCliBatchResult TryRecognizeInternal(
             string pythonExecutablePath,
             string runnerScriptPath,
             string inputFilePath,
-            IReadOnlyList<string> languageCombinations,
+            IReadOnlyList<string> languageCandidates,
             int timeoutMs)
         {
             var processStartInfo = new ProcessStartInfo
@@ -282,7 +269,7 @@ namespace GameTranslator
                 StandardErrorEncoding = Encoding.UTF8
             };
 
-            foreach (string argument in BuildArguments(runnerScriptPath, inputFilePath, languageCombinations))
+            foreach (string argument in BuildArguments(runnerScriptPath, inputFilePath, languageCandidates))
             {
                 processStartInfo.ArgumentList.Add(argument);
             }
@@ -292,7 +279,7 @@ namespace GameTranslator
                 using Process process = Process.Start(processStartInfo);
                 if (process == null)
                 {
-                    return EasyOcrCliBatchResult.CreateFailure(pythonExecutablePath, languageCombinations, "EasyOCR Python 프로세스를 시작하지 못했습니다.");
+                    return PaddleOcrCliBatchResult.CreateFailure(pythonExecutablePath, languageCandidates, "PaddleOCR Python 프로세스를 시작하지 못했습니다.");
                 }
 
                 string standardOutput = process.StandardOutput.ReadToEnd();
@@ -308,28 +295,28 @@ namespace GameTranslator
                     {
                     }
 
-                    return EasyOcrCliBatchResult.CreateFailure(
+                    return PaddleOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
-                        languageCombinations,
-                        $"EasyOCR 실행이 {timeoutMs}ms 안에 끝나지 않았습니다.");
+                        languageCandidates,
+                        $"PaddleOCR 실행이 {timeoutMs}ms 안에 끝나지 않았습니다.");
                 }
 
                 if (process.ExitCode != 0)
                 {
-                    return EasyOcrCliBatchResult.CreateFailure(
+                    return PaddleOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
-                        languageCombinations,
+                        languageCandidates,
                         GetFailureMessageForExitCode(process.ExitCode, standardError),
                         isModuleMissing: process.ExitCode == 3);
                 }
 
-                List<EasyOcrCliGroupResult> groupResults = ParseGroupResults(standardOutput);
+                List<PaddleOcrCliGroupResult> groupResults = ParseGroupResults(standardOutput);
                 if (groupResults.Count == 0)
                 {
-                    return EasyOcrCliBatchResult.CreateFailure(
+                    return PaddleOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
-                        languageCombinations,
-                        EmptyToFallback(standardError, "EasyOCR 결과를 읽지 못했습니다."));
+                        languageCandidates,
+                        EmptyToFallback(standardError, "PaddleOCR 결과를 읽지 못했습니다."));
                 }
 
                 int successCount = groupResults.Count(group => group.Success);
@@ -338,40 +325,40 @@ namespace GameTranslator
                     string firstErrorMessage = groupResults
                         .Select(group => group.ErrorMessage)
                         .FirstOrDefault(message => !string.IsNullOrWhiteSpace(message));
-                    return EasyOcrCliBatchResult.CreateFailure(
+                    return PaddleOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
-                        languageCombinations,
-                        EmptyToFallback(firstErrorMessage, "EasyOCR 결과가 모두 실패했습니다."));
+                        languageCandidates,
+                        EmptyToFallback(firstErrorMessage, "PaddleOCR 결과가 모두 실패했습니다."));
                 }
 
-                return EasyOcrCliBatchResult.CreateSuccess(pythonExecutablePath, languageCombinations, groupResults, standardError);
+                return PaddleOcrCliBatchResult.CreateSuccess(pythonExecutablePath, languageCandidates, groupResults, standardError);
             }
             catch (System.ComponentModel.Win32Exception)
             {
-                return EasyOcrCliBatchResult.CreateFailure(
+                return PaddleOcrCliBatchResult.CreateFailure(
                     pythonExecutablePath,
-                    languageCombinations,
+                    languageCandidates,
                     "python 또는 py 실행 파일을 찾지 못했습니다.",
                     isPythonMissing: true);
             }
             catch (Exception ex)
             {
-                return EasyOcrCliBatchResult.CreateFailure(pythonExecutablePath, languageCombinations, ex.Message);
+                return PaddleOcrCliBatchResult.CreateFailure(pythonExecutablePath, languageCandidates, ex.Message);
             }
         }
 
-        internal static List<EasyOcrCliGroupResult> ParseGroupResults(string json)
+        private static List<PaddleOcrCliGroupResult> ParseGroupResults(string json)
         {
-            EasyOcrRunnerResponse response = JsonSerializer.Deserialize<EasyOcrRunnerResponse>(json ?? "", new JsonSerializerOptions
+            PaddleOcrRunnerResponse response = JsonSerializer.Deserialize<PaddleOcrRunnerResponse>(json ?? "", new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             });
 
-            return (response?.Groups ?? new List<EasyOcrRunnerGroup>())
-                .Select(group => new EasyOcrCliGroupResult(
+            return (response?.Groups ?? new List<PaddleOcrRunnerGroup>())
+                .Select(group => new PaddleOcrCliGroupResult(
                     group?.LanguageCodes ?? "",
                     group?.Success ?? false,
-                    (group?.Lines ?? new List<EasyOcrRunnerLine>())
+                    (group?.Lines ?? new List<PaddleOcrRunnerLine>())
                         .Where(line => !string.IsNullOrWhiteSpace(line?.Text))
                         .Select(line => new OcrLine
                         {
@@ -389,21 +376,20 @@ namespace GameTranslator
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
         }
 
-        private sealed class EasyOcrRunnerResponse
+        private sealed class PaddleOcrRunnerResponse
         {
-            public List<EasyOcrRunnerGroup> Groups { get; set; } = new List<EasyOcrRunnerGroup>();
+            public List<PaddleOcrRunnerGroup> Groups { get; set; } = new List<PaddleOcrRunnerGroup>();
         }
 
-        private sealed class EasyOcrRunnerGroup
+        private sealed class PaddleOcrRunnerGroup
         {
-            [JsonPropertyName("language_codes")]
             public string LanguageCodes { get; set; } = "";
             public bool Success { get; set; }
             public string Error { get; set; } = "";
-            public List<EasyOcrRunnerLine> Lines { get; set; } = new List<EasyOcrRunnerLine>();
+            public List<PaddleOcrRunnerLine> Lines { get; set; } = new List<PaddleOcrRunnerLine>();
         }
 
-        private sealed class EasyOcrRunnerLine
+        private sealed class PaddleOcrRunnerLine
         {
             public double Top { get; set; }
             public double Bottom { get; set; }
@@ -411,21 +397,21 @@ namespace GameTranslator
         }
     }
 
-    public sealed class EasyOcrCliBatchResult
+    public sealed class PaddleOcrCliBatchResult
     {
-        private EasyOcrCliBatchResult(
+        private PaddleOcrCliBatchResult(
             bool success,
             string pythonExecutablePath,
-            IReadOnlyList<string> languageCombinations,
-            IReadOnlyList<EasyOcrCliGroupResult> groupResults,
+            IReadOnlyList<string> languageCandidates,
+            IReadOnlyList<PaddleOcrCliGroupResult> groupResults,
             string errorMessage,
             bool isPythonMissing,
             bool isModuleMissing)
         {
             Success = success;
             PythonExecutablePath = pythonExecutablePath ?? "";
-            LanguageCombinations = languageCombinations ?? Array.Empty<string>();
-            GroupResults = groupResults ?? Array.Empty<EasyOcrCliGroupResult>();
+            LanguageCandidates = languageCandidates ?? Array.Empty<string>();
+            GroupResults = groupResults ?? Array.Empty<PaddleOcrCliGroupResult>();
             ErrorMessage = errorMessage ?? "";
             IsPythonMissing = isPythonMissing;
             IsModuleMissing = isModuleMissing;
@@ -433,35 +419,35 @@ namespace GameTranslator
 
         public bool Success { get; }
         public string PythonExecutablePath { get; }
-        public IReadOnlyList<string> LanguageCombinations { get; }
-        public IReadOnlyList<EasyOcrCliGroupResult> GroupResults { get; }
+        public IReadOnlyList<string> LanguageCandidates { get; }
+        public IReadOnlyList<PaddleOcrCliGroupResult> GroupResults { get; }
         public string ErrorMessage { get; }
         public bool IsPythonMissing { get; }
         public bool IsModuleMissing { get; }
 
-        public static EasyOcrCliBatchResult CreateSuccess(
+        public static PaddleOcrCliBatchResult CreateSuccess(
             string pythonExecutablePath,
-            IReadOnlyList<string> languageCombinations,
-            IReadOnlyList<EasyOcrCliGroupResult> groupResults,
+            IReadOnlyList<string> languageCandidates,
+            IReadOnlyList<PaddleOcrCliGroupResult> groupResults,
             string errorMessage = "")
         {
-            return new EasyOcrCliBatchResult(true, pythonExecutablePath, languageCombinations, groupResults, errorMessage, false, false);
+            return new PaddleOcrCliBatchResult(true, pythonExecutablePath, languageCandidates, groupResults, errorMessage, false, false);
         }
 
-        public static EasyOcrCliBatchResult CreateFailure(
+        public static PaddleOcrCliBatchResult CreateFailure(
             string pythonExecutablePath,
-            IReadOnlyList<string> languageCombinations,
+            IReadOnlyList<string> languageCandidates,
             string errorMessage,
             bool isPythonMissing = false,
             bool isModuleMissing = false)
         {
-            return new EasyOcrCliBatchResult(false, pythonExecutablePath, languageCombinations, Array.Empty<EasyOcrCliGroupResult>(), errorMessage, isPythonMissing, isModuleMissing);
+            return new PaddleOcrCliBatchResult(false, pythonExecutablePath, languageCandidates, Array.Empty<PaddleOcrCliGroupResult>(), errorMessage, isPythonMissing, isModuleMissing);
         }
     }
 
-    public sealed class EasyOcrCliGroupResult
+    public sealed class PaddleOcrCliGroupResult
     {
-        public EasyOcrCliGroupResult(string languageCodes, bool success, IReadOnlyList<OcrLine> lines, string errorMessage)
+        public PaddleOcrCliGroupResult(string languageCodes, bool success, IReadOnlyList<OcrLine> lines, string errorMessage)
         {
             LanguageCodes = languageCodes ?? "";
             Success = success;

--- a/GameChatTranslator/Core/SettingsService.cs
+++ b/GameChatTranslator/Core/SettingsService.cs
@@ -21,6 +21,8 @@ namespace GameTranslator
         public const string DefaultTesseractLanguageCodes = "eng+kor+jpn+chi_sim";
         public const string DefaultEasyOcrPythonPath = "python";
         public const string DefaultEasyOcrLanguageCodes = "en+ko+ja+ch_sim";
+        public const string DefaultPaddleOcrPythonPath = "python";
+        public const string DefaultPaddleOcrLanguageCodes = "en+korean+japan+ch";
         public const string DefaultTranslationEngine = "Google";
         public const string DefaultTranslationContentMode = "Strinova";
         public const string DefaultResultDisplayMode = "Latest";
@@ -125,6 +127,22 @@ namespace GameTranslator
         public string NormalizeEasyOcrLanguageCodes(string value)
         {
             return string.IsNullOrWhiteSpace(value) ? DefaultEasyOcrLanguageCodes : value.Trim();
+        }
+
+        /// <summary>
+        /// PaddleOCR Python 실행 경로가 비어 있으면 기본 python 명령을 반환합니다.
+        /// </summary>
+        public string NormalizePaddleOcrPythonPath(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? DefaultPaddleOcrPythonPath : value.Trim();
+        }
+
+        /// <summary>
+        /// PaddleOCR 언어 코드 문자열이 비어 있으면 기본 다국어 조합을 반환합니다.
+        /// </summary>
+        public string NormalizePaddleOcrLanguageCodes(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? DefaultPaddleOcrLanguageCodes : value.Trim();
         }
 
         /// <summary>

--- a/GameChatTranslator/Distribution/paddleocr_runner.py
+++ b/GameChatTranslator/Distribution/paddleocr_runner.py
@@ -1,0 +1,300 @@
+import argparse
+import json
+import sys
+import warnings
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--groups", required=True)
+    parser.add_argument("--gpu", default="false")
+    return parser.parse_args()
+
+
+def parse_language_groups(raw_value):
+    groups = []
+    seen = set()
+
+    for chunk in (raw_value or "").split("|"):
+        for token in chunk.replace(",", "+").split("+"):
+            value = token.strip()
+            if value and value not in seen:
+                groups.append(value)
+                seen.add(value)
+
+    return groups
+
+
+def is_cjk(char):
+    if not char:
+        return False
+
+    code = ord(char)
+    return (
+        0x4E00 <= code <= 0x9FFF
+        or 0x3400 <= code <= 0x4DBF
+        or 0x3040 <= code <= 0x30FF
+        or 0xAC00 <= code <= 0xD7AF
+    )
+
+
+def append_token(current_text, token_text):
+    token_text = (token_text or "").strip()
+    if not token_text:
+        return current_text
+
+    if not current_text:
+        return token_text
+
+    previous_char = current_text[-1]
+    next_char = token_text[0]
+
+    no_space_before = ")]}:;!?.,%>/"
+    no_space_after = "([<{"
+
+    if previous_char in no_space_after or next_char in no_space_before:
+        return current_text + token_text
+
+    if is_cjk(previous_char) and is_cjk(next_char):
+        return current_text + token_text
+
+    return current_text + " " + token_text
+
+
+def same_line(word, line):
+    word_top = word["top"]
+    word_bottom = word["bottom"]
+    line_top = line["top"]
+    line_bottom = line["bottom"]
+
+    word_height = max(1.0, word_bottom - word_top)
+    line_height = max(1.0, line_bottom - line_top)
+    overlap = min(word_bottom, line_bottom) - max(word_top, line_top)
+    center_delta = abs(((word_top + word_bottom) / 2.0) - ((line_top + line_bottom) / 2.0))
+
+    return overlap >= max(2.0, min(word_height, line_height) * 0.3) or center_delta <= max(word_height, line_height) * 0.6
+
+
+def build_lines_from_words(words):
+    words.sort(key=lambda item: (item["top"], item["left"]))
+    line_groups = []
+
+    for word in words:
+        target_line = None
+        for line in line_groups:
+            if same_line(word, line):
+                target_line = line
+                break
+
+        if target_line is None:
+            target_line = {
+                "top": word["top"],
+                "bottom": word["bottom"],
+                "words": [],
+            }
+            line_groups.append(target_line)
+
+        target_line["top"] = min(target_line["top"], word["top"])
+        target_line["bottom"] = max(target_line["bottom"], word["bottom"])
+        target_line["words"].append(word)
+
+    line_groups.sort(key=lambda item: item["top"])
+
+    lines = []
+    for line in line_groups:
+        text = ""
+        for word in sorted(line["words"], key=lambda item: item["left"]):
+            text = append_token(text, word["text"])
+
+        text = text.strip()
+        if text:
+            lines.append(
+                {
+                    "top": float(line["top"]),
+                    "bottom": float(line["bottom"]),
+                    "text": text,
+                }
+            )
+
+    return lines
+
+
+def normalize_predict_payload(result_item):
+    payload = getattr(result_item, "json", result_item)
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+
+    if isinstance(payload, dict) and "res" in payload:
+        payload = payload["res"]
+
+    return payload if isinstance(payload, dict) else {}
+
+
+def build_words_from_predict_payload(payload):
+    texts = payload.get("rec_texts") or []
+    boxes = payload.get("rec_boxes") or []
+    polys = payload.get("rec_polys") or []
+    scores = payload.get("rec_scores") or []
+
+    words = []
+
+    for index, raw_text in enumerate(texts):
+        text = str(raw_text).strip()
+        if not text:
+            continue
+
+        score = scores[index] if index < len(scores) else None
+        if score is not None:
+            try:
+                if float(score) <= 0.0:
+                    continue
+            except Exception:
+                pass
+
+        if index < len(boxes) and isinstance(boxes[index], (list, tuple)) and len(boxes[index]) >= 4:
+            left = float(boxes[index][0])
+            top = float(boxes[index][1])
+            right = float(boxes[index][2])
+            bottom = float(boxes[index][3])
+        elif index < len(polys) and polys[index]:
+            xs = [float(point[0]) for point in polys[index]]
+            ys = [float(point[1]) for point in polys[index]]
+            left = min(xs)
+            right = max(xs)
+            top = min(ys)
+            bottom = max(ys)
+        else:
+            continue
+
+        words.append(
+            {
+                "left": left,
+                "right": right,
+                "top": top,
+                "bottom": bottom,
+                "text": text,
+            }
+        )
+
+    return words
+
+
+def build_words_from_legacy_payload(payload):
+    if not payload:
+        return []
+
+    rows = payload[0] if isinstance(payload, list) and payload and isinstance(payload[0], list) else payload
+    words = []
+
+    for row in rows or []:
+        if not isinstance(row, (list, tuple)) or len(row) < 2:
+            continue
+
+        bbox = row[0]
+        result = row[1]
+        if not isinstance(result, (list, tuple)) or not result:
+            continue
+
+        text = str(result[0]).strip()
+        if not text:
+            continue
+
+        xs = [float(point[0]) for point in bbox]
+        ys = [float(point[1]) for point in bbox]
+        words.append(
+            {
+                "left": min(xs),
+                "right": max(xs),
+                "top": min(ys),
+                "bottom": max(ys),
+                "text": text,
+            }
+        )
+
+    return words
+
+
+def recognize_with_predict(ocr, image_path):
+    words = []
+    for result_item in ocr.predict(image_path):
+        words.extend(build_words_from_predict_payload(normalize_predict_payload(result_item)))
+    return build_lines_from_words(words)
+
+
+def recognize_with_legacy_ocr(ocr, image_path):
+    results = ocr.ocr(image_path, cls=False)
+    return build_lines_from_words(build_words_from_legacy_payload(results))
+
+
+def recognize_image(language_code, image_path, use_gpu):
+    from paddleocr import PaddleOCR
+
+    try:
+        ocr = PaddleOCR(
+            lang=language_code,
+            device="gpu" if use_gpu else "cpu",
+            use_doc_orientation_classify=False,
+            use_doc_unwarping=False,
+            use_textline_orientation=False,
+        )
+    except TypeError:
+        ocr = PaddleOCR(
+            lang=language_code,
+            use_angle_cls=False,
+            use_gpu=use_gpu,
+            show_log=False,
+        )
+
+    if hasattr(ocr, "predict"):
+        return recognize_with_predict(ocr, image_path)
+
+    return recognize_with_legacy_ocr(ocr, image_path)
+
+
+def main():
+    args = parse_args()
+    language_groups = parse_language_groups(args.groups)
+    if not language_groups:
+        print("PaddleOCR language groups are empty.", file=sys.stderr)
+        return 2
+
+    use_gpu = str(args.gpu).strip().lower() in ("1", "true", "yes", "y", "on")
+
+    try:
+        import paddleocr  # noqa: F401
+    except Exception:
+        print("PaddleOCR module is not installed.", file=sys.stderr)
+        return 3
+
+    warnings.filterwarnings("ignore")
+
+    response = {"groups": []}
+
+    for language_code in language_groups:
+        try:
+            lines = recognize_image(language_code, args.image, use_gpu)
+            response["groups"].append(
+                {
+                    "languageCodes": language_code,
+                    "success": True,
+                    "error": "",
+                    "lines": lines,
+                }
+            )
+        except Exception as exc:
+            response["groups"].append(
+                {
+                    "languageCodes": language_code,
+                    "success": False,
+                    "error": str(exc),
+                    "lines": [],
+                }
+            )
+
+    print(json.dumps(response, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/GameChatTranslator/GameChatTranslator.csproj
+++ b/GameChatTranslator/GameChatTranslator.csproj
@@ -61,11 +61,17 @@
 	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	    <TargetPath>easyocr_runner.py</TargetPath>
 	  </None>
+	  <!-- PaddleOCR 비교 실험용 Python 러너입니다. 진단 경로에서만 사용합니다. -->
+	  <None Update="Distribution/paddleocr_runner.py">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>paddleocr_runner.py</TargetPath>
+	  </None>
 	</ItemGroup>
 
 	<ItemGroup>
 	  <!-- Visual Studio 게시 프로필에서도 배포 보조 파일이 누락되지 않도록 Publish 후 루트 출력 폴더에 한 번 더 복사합니다. -->
-	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/readme.txt;Distribution/easyocr_runner.py" />
+	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/readme.txt;Distribution/easyocr_runner.py;Distribution/paddleocr_runner.py" />
 	</ItemGroup>
 
 	<Target Name="CopyDistributionFilesToPublishDirectory" AfterTargets="Publish" Condition="'$(PublishDir)' != ''">

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -14,6 +14,7 @@ namespace GameTranslator
     {
         private const int TesseractDiagnosticTimeoutMs = 2500;
         private const int EasyOcrDiagnosticTimeoutMs = 120000;
+        private const int PaddleOcrDiagnosticTimeoutMs = 120000;
 
         /// <summary>
         /// OCR 테스트/진단 창을 열거나 이미 열린 창을 앞으로 가져옵니다.
@@ -145,7 +146,8 @@ namespace GameTranslator
                 var externalSummaries = new List<ExternalOcrDiagnosticSummary>
                 {
                     await TryBuildTesseractDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()),
-                    await TryBuildEasyOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode())
+                    await TryBuildEasyOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()),
+                    await TryBuildPaddleOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode())
                 };
                 result.ExternalOcrStatus = BuildExternalOcrStatusText(externalSummaries);
 
@@ -446,6 +448,129 @@ namespace GameTranslator
 
             string successStatus =
                 $"EasyOCR 후보 {candidates.Count}개 추가 / {successCount}개 그룹 성공 / {failureCount}개 그룹 실패 / timeout {EasyOcrDiagnosticTimeoutMs}ms";
+            AppendLog($"[OCR DIAG] {successStatus}");
+            return new ExternalOcrDiagnosticSummary(candidates, successStatus, totalElapsedMs, totalCallCount);
+        }
+
+        private async Task<ExternalOcrDiagnosticSummary> TryBuildPaddleOcrDiagnosticCandidatesAsync(IEnumerable<PreprocessedOcrImage> preprocessedImages, TranslationContentMode contentMode)
+        {
+            string configuredPythonPath = ReadPaddleOcrPythonPath();
+            string configuredLanguageCodes = ReadPaddleOcrLanguageCodes();
+
+            int totalCallCount = 0;
+            long totalElapsedMs = 0;
+            int successCount = 0;
+            int failureCount = 0;
+            bool pythonMissing = false;
+            bool moduleMissing = false;
+            string firstErrorMessage = "";
+            var candidates = new List<OcrDiagnosticCandidate>();
+
+            foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
+            {
+                using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
+                byte[] croppedPng = BitmapToPngBytes(croppedBitmap);
+                byte[] preprocessedPng = BitmapToPngBytes(preprocessedImage.Bitmap);
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                using Bitmap paddleOcrInputBitmap = (Bitmap)croppedBitmap.Clone();
+                PaddleOcrCliBatchResult batchResult = await Task.Run(() =>
+                    paddleOcrCliAdapter.Recognize(
+                        paddleOcrInputBitmap,
+                        configuredPythonPath,
+                        configuredLanguageCodes,
+                        gameLang,
+                        PaddleOcrDiagnosticTimeoutMs));
+                stopwatch.Stop();
+                totalElapsedMs += stopwatch.ElapsedMilliseconds;
+                totalCallCount += batchResult.LanguageCandidates.Count;
+
+                if (!batchResult.Success)
+                {
+                    failureCount += Math.Max(1, batchResult.LanguageCandidates.Count);
+                    if (string.IsNullOrWhiteSpace(firstErrorMessage))
+                    {
+                        firstErrorMessage = batchResult.ErrorMessage;
+                    }
+
+                    if (batchResult.IsPythonMissing)
+                    {
+                        pythonMissing = true;
+                        break;
+                    }
+
+                    if (batchResult.IsModuleMissing)
+                    {
+                        moduleMissing = true;
+                        break;
+                    }
+
+                    continue;
+                }
+
+                successCount += batchResult.GroupResults.Count(group => group.Success);
+                failureCount += batchResult.GroupResults.Count(group => !group.Success);
+
+                var candidate = new OcrDiagnosticCandidate
+                {
+                    Name = $"PaddleOCR-{preprocessedImage.Name}",
+                    PreprocessedPng = preprocessedPng,
+                    CroppedPng = croppedPng
+                };
+                var languageCandidates = new List<OcrLanguageCandidate>();
+
+                foreach (PaddleOcrCliGroupResult groupResult in batchResult.GroupResults.Where(group => group.Success))
+                {
+                    var languageResult = new OcrDiagnosticLanguageResult
+                    {
+                        LanguageTag = $"paddleocr:{groupResult.LanguageCodes}"
+                    };
+                    languageResult.Lines.AddRange(groupResult.Lines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                    candidate.Languages.Add(languageResult);
+
+                    languageCandidates.Add(new OcrLanguageCandidate
+                    {
+                        LanguageCode = groupResult.LanguageCodes,
+                        Lines = groupResult.Lines
+                            .Select(line => new OcrLine
+                            {
+                                Top = line.Top,
+                                Bottom = line.Bottom,
+                                Text = line.Text
+                            })
+                            .ToList()
+                    });
+                }
+
+                List<OcrLine> mergedLines = contentMode == TranslationContentMode.Strinova
+                    ? ocrService.MergeBestChatLinesByComponents(languageCandidates, characterNames)
+                    : ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
+                List<OcrLine> filteredMergedLines = ocrTranslationHarnessService.FilterMergedLinesForDiagnostics(mergedLines, characterNames);
+                List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(filteredMergedLines, characterNames, contentMode);
+                if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
+                {
+                    candidate.MergedLines.AddRange(normalizedMergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                    candidate.Score = ocrService.ScoreMergedLinesForSelection(normalizedMergedLines, characterNames, contentMode);
+                    candidates.Add(candidate);
+                }
+            }
+
+            if (pythonMissing || moduleMissing)
+            {
+                string failedStatus = $"PaddleOCR 미사용: {firstErrorMessage}";
+                AppendLog($"[OCR DIAG] {failedStatus}");
+                return new ExternalOcrDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
+            }
+
+            if (successCount == 0)
+            {
+                string failedStatus = $"PaddleOCR 실패: {firstErrorMessage}";
+                AppendLog($"[OCR DIAG] {failedStatus}");
+                return new ExternalOcrDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
+            }
+
+            string successStatus =
+                $"PaddleOCR 후보 {candidates.Count}개 추가 / {successCount}개 그룹 성공 / {failureCount}개 그룹 실패 / timeout {PaddleOcrDiagnosticTimeoutMs}ms";
             AppendLog($"[OCR DIAG] {successStatus}");
             return new ExternalOcrDiagnosticSummary(candidates, successStatus, totalElapsedMs, totalCallCount);
         }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
@@ -111,6 +111,8 @@ namespace GameTranslator
             EnsureNormalizedSetting("TesseractLanguageCodes", settingsService.NormalizeTesseractLanguageCodes(ini.Read("TesseractLanguageCodes")));
             EnsureNormalizedSetting("EasyOcrPythonPath", settingsService.NormalizeEasyOcrPythonPath(ini.Read("EasyOcrPythonPath")));
             EnsureNormalizedSetting("EasyOcrLanguageCodes", settingsService.NormalizeEasyOcrLanguageCodes(ini.Read("EasyOcrLanguageCodes")));
+            EnsureNormalizedSetting("PaddleOcrPythonPath", settingsService.NormalizePaddleOcrPythonPath(ini.Read("PaddleOcrPythonPath")));
+            EnsureNormalizedSetting("PaddleOcrLanguageCodes", settingsService.NormalizePaddleOcrLanguageCodes(ini.Read("PaddleOcrLanguageCodes")));
 
             if (string.IsNullOrWhiteSpace(ini.Read("SaveDebugImages")))
             {
@@ -291,6 +293,24 @@ namespace GameTranslator
         private string ReadEasyOcrLanguageCodes()
         {
             return settingsService.NormalizeEasyOcrLanguageCodes(ini.Read("EasyOcrLanguageCodes"));
+        }
+
+        /// <summary>
+        /// 외부 OCR 실험용 PaddleOCR Python 실행 경로를 읽습니다.
+        /// 비어 있으면 PATH의 python 명령을 기본값으로 사용합니다.
+        /// </summary>
+        private string ReadPaddleOcrPythonPath()
+        {
+            return settingsService.NormalizePaddleOcrPythonPath(ini.Read("PaddleOcrPythonPath"));
+        }
+
+        /// <summary>
+        /// 외부 OCR 실험용 PaddleOCR 언어 코드 조합을 읽습니다.
+        /// 비어 있으면 en+korean+japan+ch 기본 조합을 사용합니다.
+        /// </summary>
+        private string ReadPaddleOcrLanguageCodes()
+        {
+            return settingsService.NormalizePaddleOcrLanguageCodes(ini.Read("PaddleOcrLanguageCodes"));
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -73,6 +73,7 @@ namespace GameTranslator
         private readonly OcrTranslationHarnessService ocrTranslationHarnessService = new OcrTranslationHarnessService();
         private readonly TesseractCliOcrAdapter tesseractCliOcrAdapter = new TesseractCliOcrAdapter();
         private readonly EasyOcrCliAdapter easyOcrCliAdapter = new EasyOcrCliAdapter();
+        private readonly PaddleOcrCliAdapter paddleOcrCliAdapter = new PaddleOcrCliAdapter();
         private readonly TranslationApiErrorDescriber translationApiErrorDescriber = new TranslationApiErrorDescriber();
         private readonly TranslationApiClient translationApiClient;
         private AppDataPaths appDataPaths;


### PR DESCRIPTION
## 요약
- EasyOCR 진단 언어 태그가 `language_codes` JSON 키를 읽지 못하던 문제를 수정했습니다.
- OCR 진단 경로에 PaddleOCR 외부 어댑터와 Python runner를 추가했습니다.
- settings/config/publish 경로를 함께 연결해 Win OCR / Tesseract / EasyOCR / PaddleOCR 4자 비교가 가능해졌습니다.

## 검증
- `git diff --check`
- `python3 -m py_compile GameChatTranslator/Distribution/easyocr_runner.py GameChatTranslator/Distribution/paddleocr_runner.py`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-paddle`
