### PR TITLE
개선: PaddleOCR 진단 실패 시 빠르게 중단

### DIFF
--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -463,6 +463,7 @@ namespace GameTranslator
             int failureCount = 0;
             bool pythonMissing = false;
             bool moduleMissing = false;
+            bool paddleOcrUnavailable = false;
             string firstErrorMessage = "";
             var candidates = new List<OcrDiagnosticCandidate>();
 
@@ -505,7 +506,8 @@ namespace GameTranslator
                         break;
                     }
 
-                    continue;
+                    paddleOcrUnavailable = true;
+                    break;
                 }
 
                 successCount += batchResult.GroupResults.Count(group => group.Success);
@@ -553,6 +555,7 @@ namespace GameTranslator
                     candidate.Score = ocrService.ScoreMergedLinesForSelection(normalizedMergedLines, characterNames, contentMode);
                     candidates.Add(candidate);
                 }
+
             }
 
             if (pythonMissing || moduleMissing)
@@ -562,7 +565,7 @@ namespace GameTranslator
                 return new ExternalOcrDiagnosticSummary(candidates, failedStatus, totalElapsedMs, totalCallCount);
             }
 
-            if (successCount == 0)
+            if (successCount == 0 || paddleOcrUnavailable)
             {
                 string failedStatus = $"PaddleOCR 실패: {firstErrorMessage}";
                 AppendLog($"[OCR DIAG] {failedStatus}");


### PR DESCRIPTION
## 요약
- PaddleOCR 진단 batch가 런타임 오류로 실패하면 남은 전처리 후보 반복을 즉시 중단합니다.
- #151처럼 PaddleOCR 실패가 Color/ColorThick/Adaptive마다 반복되어 진단 시간이 190초까지 늘어나는 문제를 줄입니다.
- 메인 번역 경로는 변경하지 않고 OCR spike 진단 경로만 수정했습니다.

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-paddle-failfast`
