### PR TITLE
수정: OCR 진단창 자동 실행 제거

### DIFF
--- a/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
+++ b/GameChatTranslator/Views/OcrDiagnostic/OcrDiagnosticWindow.xaml.cs
@@ -37,8 +37,6 @@ namespace GameTranslator
             this.mainWindow = mainWindow;
             this.defaultExportDirectory = defaultExportDirectory;
             UpdateSummaryHeader(null);
-
-            Loaded += async (s, e) => await RunDiagnosticAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
## 요약
- OCR 진단창을 열 때 자동으로 진단이 시작되던 Loaded 이벤트를 제거했습니다.
- 이제 창을 연 뒤 `현재 캡처 영역 진단` 버튼을 눌러야 진단이 시작됩니다.
- 기존 진단 버튼 실행, 결과 복사, ZIP 저장 흐름은 유지했습니다.

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-manual-diagnostic`
