### PR TITLE
개선: PaddleOCR PIR 우회 및 timeout 단축

### DIFF
--- a/GameChatTranslator/Distribution/paddleocr_runner.py
+++ b/GameChatTranslator/Distribution/paddleocr_runner.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import sys
 import warnings
 
@@ -228,6 +229,10 @@ def recognize_with_legacy_ocr(ocr, image_path):
 
 
 def recognize_image(language_code, image_path, use_gpu):
+    # PaddlePaddle 3.3.x CPU inference can fail in PIR/oneDNN conversion.
+    # Set this before importing paddleocr so the diagnostic runner stays usable.
+    os.environ.setdefault("FLAGS_enable_pir_api", "0")
+
     from paddleocr import PaddleOCR
 
     try:

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -14,7 +14,7 @@ namespace GameTranslator
     {
         private const int TesseractDiagnosticTimeoutMs = 2500;
         private const int EasyOcrDiagnosticTimeoutMs = 120000;
-        private const int PaddleOcrDiagnosticTimeoutMs = 120000;
+        private const int PaddleOcrDiagnosticTimeoutMs = 30000;
 
         /// <summary>
         /// OCR 테스트/진단 창을 열거나 이미 열린 창을 앞으로 가져옵니다.


### PR DESCRIPTION
## 요약
- PaddleOCR runner에서 `paddleocr` import 전에 `FLAGS_enable_pir_api=0`을 기본 설정해 PaddlePaddle 3.3.x PIR/oneDNN 런타임 오류를 우회합니다.
- 사용자가 이미 `FLAGS_enable_pir_api`를 지정한 경우에는 덮어쓰지 않습니다.
- PaddleOCR 진단 timeout을 120000ms에서 30000ms로 낮춰, 우회가 실패해도 #154처럼 진단이 90초 이상 지연되는 문제를 줄입니다.

## 배경
- #154의 PaddleOCR 오류는 `ConvertPirAttribute2RuntimeAttribute not support ... onednn_instruction.cc` 계열입니다.
- PaddlePaddle 3.3.x CPU inference의 PIR/oneDNN 경로에서 보고된 런타임 문제와 동일 계열이라, timeout만 낮추는 대신 PIR 비활성화 우회를 같이 적용했습니다.

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-paddle-pir`

## 주의
- 이 PR은 `codex/ocr-spike` 진단 경로 전용입니다.
- PaddlePaddle/PaddleOCR 버전 조합 문제 자체가 완전히 해결됐는지는 Windows 재진단으로 확인해야 합니다.
