### PR TITLE
개선: OCR 진단에 빌드 커밋 정보 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrDiagnosticExporterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrDiagnosticExporterTests.cs
@@ -24,6 +24,8 @@ namespace GameChatTranslator.Tests
             Assert.Contains("- Color: 123", summary);
             Assert.Contains("외부 OCR 상태: Tesseract 후보 추가 (jpn+eng+kor+chi_sim)", summary);
             Assert.Contains("앱 버전: v.test", summary);
+            Assert.Contains("빌드 정보: 1.0.31-alpha+abcdef1234567890", summary);
+            Assert.Contains("빌드 커밋: abcdef1234567890", summary);
             Assert.Contains("게임 언어: ko", summary);
             Assert.Contains("현재 자동 OCR 모드: 자동", summary);
             Assert.Contains("표시 좌표 CaptureX/Y/W/H: X=1, Y=2, W=30, H=40", summary);
@@ -129,6 +131,8 @@ namespace GameChatTranslator.Tests
                 Metadata = new OcrDiagnosticMetadata
                 {
                     AppVersion = "v.test",
+                    BuildInformationalVersion = "1.0.31-alpha+abcdef1234567890",
+                    BuildCommit = "abcdef1234567890",
                     GameLanguage = "ko",
                     TargetLanguage = "en-US",
                     AutoTranslateMode = "자동",

--- a/GameChatTranslator/Core/OcrDiagnosticExporter.cs
+++ b/GameChatTranslator/Core/OcrDiagnosticExporter.cs
@@ -118,6 +118,8 @@ namespace GameTranslator
             builder.AppendLine();
             builder.AppendLine("[환경 설정]");
             builder.AppendLine($"앱 버전: {EmptyToDash(metadata.AppVersion)}");
+            builder.AppendLine($"빌드 정보: {EmptyToDash(metadata.BuildInformationalVersion)}");
+            builder.AppendLine($"빌드 커밋: {EmptyToDash(metadata.BuildCommit)}");
             builder.AppendLine($"게임 언어: {EmptyToDash(metadata.GameLanguage)}");
             builder.AppendLine($"번역 언어: {EmptyToDash(metadata.TargetLanguage)}");
             builder.AppendLine($"현재 자동 OCR 모드: {EmptyToDash(metadata.AutoTranslateMode)}");

--- a/GameChatTranslator/Models/OcrDiagnosticModels.cs
+++ b/GameChatTranslator/Models/OcrDiagnosticModels.cs
@@ -37,6 +37,8 @@ namespace GameTranslator
     public class OcrDiagnosticMetadata
     {
         public string AppVersion { get; set; } = "";
+        public string BuildInformationalVersion { get; set; } = "";
+        public string BuildCommit { get; set; } = "";
         public string GameLanguage { get; set; } = "";
         public string TargetLanguage { get; set; } = "";
         public string AutoTranslateMode { get; set; } = "";

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Windows.Media.Ocr;
 
@@ -643,6 +644,8 @@ namespace GameTranslator
             var metadata = new OcrDiagnosticMetadata
             {
                 AppVersion = CurrentAppVersion,
+                BuildInformationalVersion = CurrentBuildInformationalVersion,
+                BuildCommit = CurrentBuildCommit,
                 GameLanguage = gameLang,
                 TargetLanguage = targetLang,
                 AutoTranslateMode = GetAutoTranslateModeLabel(),
@@ -660,6 +663,32 @@ namespace GameTranslator
             }
 
             return metadata;
+        }
+
+        private static string CurrentBuildInformationalVersion
+        {
+            get
+            {
+                return Assembly
+                    .GetExecutingAssembly()
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                    .InformationalVersion ?? "";
+            }
+        }
+
+        private static string CurrentBuildCommit
+        {
+            get
+            {
+                string informationalVersion = CurrentBuildInformationalVersion;
+                int plusIndex = informationalVersion.IndexOf('+');
+                if (plusIndex < 0 || plusIndex >= informationalVersion.Length - 1)
+                {
+                    return "";
+                }
+
+                return informationalVersion.Substring(plusIndex + 1).Trim();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## 요약
- OCR 진단 ZIP `summary.txt`의 `[환경 설정]`에 빌드 정보를 추가했습니다.
- 기존 `앱 버전`은 유지하고, 아래 두 줄을 추가합니다.
  - `빌드 정보: 1.0.31-alpha+<commit>`
  - `빌드 커밋: <commit>`
- 앞으로 ZIP만 받아도 어떤 커밋으로 게시한 빌드인지 바로 확인할 수 있습니다.

## #158 확인 결과
- #158 ZIP도 `PaddleOCR ... timeout 120000ms`로 표시되어 PR #155 미반영 게시본입니다.
- 이 PR이 머지된 뒤에는 summary에서 커밋을 직접 확인할 수 있어 같은 혼선을 줄일 수 있습니다.

## 검증
- `git diff --check`
- `/home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `/home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-build-info`
