### PR TITLE
개선: PaddleOCR 진단 배치 재사용

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
@@ -43,8 +43,32 @@ namespace GameChatTranslator.Tests
                     "-X",
                     "utf8",
                     "paddleocr_runner.py",
-                    "--image",
+                    "--images",
                     "input.png",
+                    "--groups",
+                    "korean|japan|ch",
+                    "--gpu",
+                    "false"
+                },
+                values);
+        }
+
+        [Fact]
+        public void BuildBatchArguments_UsesImagesFlagAndPreservesOrder()
+        {
+            var values = _adapter.BuildBatchArguments(
+                "paddleocr_runner.py",
+                new[] { "input-1.png", "input-2.png", "input-3.png" },
+                new[] { "korean", "japan", "ch" });
+
+            Assert.Equal(
+                new[]
+                {
+                    "-X",
+                    "utf8",
+                    "paddleocr_runner.py",
+                    "--images",
+                    "input-1.png|input-2.png|input-3.png",
                     "--groups",
                     "korean|japan|ch",
                     "--gpu",

--- a/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
@@ -129,7 +129,22 @@ namespace GameTranslator
             string gameLanguage,
             int timeoutMs = 120000)
         {
-            if (bitmap == null)
+            return RecognizeBatch(
+                bitmap == null ? Array.Empty<Bitmap>() : new[] { bitmap },
+                configuredPythonPath,
+                configuredLanguageCodes,
+                gameLanguage,
+                timeoutMs);
+        }
+
+        public PaddleOcrCliBatchResult RecognizeBatch(
+            IReadOnlyList<Bitmap> bitmaps,
+            string configuredPythonPath,
+            string configuredLanguageCodes,
+            string gameLanguage,
+            int timeoutMs = 120000)
+        {
+            if (bitmaps == null || bitmaps.Count == 0 || bitmaps.Any(bitmap => bitmap == null))
             {
                 return PaddleOcrCliBatchResult.CreateFailure("", new List<string>(), "OCR 입력 이미지가 없습니다.");
             }
@@ -147,8 +162,13 @@ namespace GameTranslator
             string inputDirectory = Path.Combine(Path.GetTempPath(), "GameChatTranslator", "PaddleOCR");
             Directory.CreateDirectory(inputDirectory);
 
-            string inputFilePath = Path.Combine(inputDirectory, $"ocr_{Guid.NewGuid():N}.png");
-            bitmap.Save(inputFilePath, ImageFormat.Png);
+            var inputFilePaths = new List<string>();
+            for (int index = 0; index < bitmaps.Count; index++)
+            {
+                string inputFilePath = Path.Combine(inputDirectory, $"ocr_{Guid.NewGuid():N}_{index}.png");
+                bitmaps[index].Save(inputFilePath, ImageFormat.Png);
+                inputFilePaths.Add(inputFilePath);
+            }
 
             try
             {
@@ -157,7 +177,7 @@ namespace GameTranslator
                     PaddleOcrCliBatchResult runResult = TryRecognizeInternal(
                         pythonPath,
                         runnerScriptPath,
-                        inputFilePath,
+                        inputFilePaths,
                         languageCandidates,
                         timeoutMs);
                     if (runResult.Success || !runResult.IsPythonMissing)
@@ -176,9 +196,12 @@ namespace GameTranslator
             {
                 try
                 {
-                    if (File.Exists(inputFilePath))
+                    foreach (string inputFilePath in inputFilePaths)
                     {
-                        File.Delete(inputFilePath);
+                        if (File.Exists(inputFilePath))
+                        {
+                            File.Delete(inputFilePath);
+                        }
                     }
                 }
                 catch
@@ -197,13 +220,21 @@ namespace GameTranslator
             string inputFilePath,
             IReadOnlyList<string> languageCandidates)
         {
+            return BuildBatchArguments(runnerScriptPath, new[] { inputFilePath }, languageCandidates);
+        }
+
+        internal IReadOnlyList<string> BuildBatchArguments(
+            string runnerScriptPath,
+            IReadOnlyList<string> inputFilePaths,
+            IReadOnlyList<string> languageCandidates)
+        {
             return new[]
             {
                 "-X",
                 "utf8",
                 runnerScriptPath,
-                "--image",
-                inputFilePath,
+                "--images",
+                string.Join("|", inputFilePaths ?? Array.Empty<string>()),
                 "--groups",
                 string.Join("|", languageCandidates ?? Array.Empty<string>()),
                 "--gpu",
@@ -254,7 +285,7 @@ namespace GameTranslator
         private PaddleOcrCliBatchResult TryRecognizeInternal(
             string pythonExecutablePath,
             string runnerScriptPath,
-            string inputFilePath,
+            IReadOnlyList<string> inputFilePaths,
             IReadOnlyList<string> languageCandidates,
             int timeoutMs)
         {
@@ -269,7 +300,7 @@ namespace GameTranslator
                 StandardErrorEncoding = Encoding.UTF8
             };
 
-            foreach (string argument in BuildArguments(runnerScriptPath, inputFilePath, languageCandidates))
+            foreach (string argument in BuildBatchArguments(runnerScriptPath, inputFilePaths, languageCandidates))
             {
                 processStartInfo.ArgumentList.Add(argument);
             }
@@ -310,8 +341,8 @@ namespace GameTranslator
                         isModuleMissing: process.ExitCode == 3);
                 }
 
-                List<PaddleOcrCliGroupResult> groupResults = ParseGroupResults(standardOutput);
-                if (groupResults.Count == 0)
+                List<PaddleOcrCliImageResult> imageResults = ParseImageResults(standardOutput);
+                if (imageResults.Count == 0)
                 {
                     return PaddleOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
@@ -319,10 +350,11 @@ namespace GameTranslator
                         EmptyToFallback(standardError, "PaddleOCR 결과를 읽지 못했습니다."));
                 }
 
-                int successCount = groupResults.Count(group => group.Success);
+                int successCount = imageResults.Sum(image => image.GroupResults.Count(group => group.Success));
                 if (successCount == 0)
                 {
-                    string firstErrorMessage = groupResults
+                    string firstErrorMessage = imageResults
+                        .SelectMany(image => image.GroupResults)
                         .Select(group => group.ErrorMessage)
                         .FirstOrDefault(message => !string.IsNullOrWhiteSpace(message));
                     return PaddleOcrCliBatchResult.CreateFailure(
@@ -331,7 +363,7 @@ namespace GameTranslator
                         EmptyToFallback(firstErrorMessage, "PaddleOCR 결과가 모두 실패했습니다."));
                 }
 
-                return PaddleOcrCliBatchResult.CreateSuccess(pythonExecutablePath, languageCandidates, groupResults, standardError);
+                return PaddleOcrCliBatchResult.CreateSuccess(pythonExecutablePath, languageCandidates, imageResults, standardError);
             }
             catch (System.ComponentModel.Win32Exception)
             {
@@ -347,28 +379,62 @@ namespace GameTranslator
             }
         }
 
-        private static List<PaddleOcrCliGroupResult> ParseGroupResults(string json)
+        private static List<PaddleOcrCliImageResult> ParseImageResults(string json)
         {
             PaddleOcrRunnerResponse response = JsonSerializer.Deserialize<PaddleOcrRunnerResponse>(json ?? "", new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             });
 
-            return (response?.Groups ?? new List<PaddleOcrRunnerGroup>())
-                .Select(group => new PaddleOcrCliGroupResult(
-                    group?.LanguageCodes ?? "",
-                    group?.Success ?? false,
-                    (group?.Lines ?? new List<PaddleOcrRunnerLine>())
-                        .Where(line => !string.IsNullOrWhiteSpace(line?.Text))
-                        .Select(line => new OcrLine
-                        {
-                            Top = line.Top,
-                            Bottom = line.Bottom,
-                            Text = line.Text.Trim()
-                        })
-                        .ToList(),
-                    group?.Error ?? ""))
-                .ToList();
+            if (response?.Images?.Count > 0)
+            {
+                return response.Images
+                    .OrderBy(image => image?.Index ?? int.MaxValue)
+                    .Select(image => new PaddleOcrCliImageResult(
+                        image?.Index ?? -1,
+                        (image?.Groups ?? new List<PaddleOcrRunnerGroup>())
+                            .Select(group => new PaddleOcrCliGroupResult(
+                                group?.LanguageCodes ?? "",
+                                group?.Success ?? false,
+                                (group?.Lines ?? new List<PaddleOcrRunnerLine>())
+                                    .Where(line => !string.IsNullOrWhiteSpace(line?.Text))
+                                    .Select(line => new OcrLine
+                                    {
+                                        Top = line.Top,
+                                        Bottom = line.Bottom,
+                                        Text = line.Text.Trim()
+                                    })
+                                    .ToList(),
+                                group?.Error ?? ""))
+                            .ToList()))
+                    .ToList();
+            }
+
+            if (response?.Groups?.Count > 0)
+            {
+                return new List<PaddleOcrCliImageResult>
+                {
+                    new PaddleOcrCliImageResult(
+                        0,
+                        response.Groups
+                            .Select(group => new PaddleOcrCliGroupResult(
+                                group?.LanguageCodes ?? "",
+                                group?.Success ?? false,
+                                (group?.Lines ?? new List<PaddleOcrRunnerLine>())
+                                    .Where(line => !string.IsNullOrWhiteSpace(line?.Text))
+                                    .Select(line => new OcrLine
+                                    {
+                                        Top = line.Top,
+                                        Bottom = line.Bottom,
+                                        Text = line.Text.Trim()
+                                    })
+                                    .ToList(),
+                                group?.Error ?? ""))
+                            .ToList())
+                };
+            }
+
+            return new List<PaddleOcrCliImageResult>();
         }
 
         private static string EmptyToFallback(string value, string fallback)
@@ -378,6 +444,13 @@ namespace GameTranslator
 
         private sealed class PaddleOcrRunnerResponse
         {
+            public List<PaddleOcrRunnerImage> Images { get; set; } = new List<PaddleOcrRunnerImage>();
+            public List<PaddleOcrRunnerGroup> Groups { get; set; } = new List<PaddleOcrRunnerGroup>();
+        }
+
+        private sealed class PaddleOcrRunnerImage
+        {
+            public int Index { get; set; }
             public List<PaddleOcrRunnerGroup> Groups { get; set; } = new List<PaddleOcrRunnerGroup>();
         }
 
@@ -403,7 +476,7 @@ namespace GameTranslator
             bool success,
             string pythonExecutablePath,
             IReadOnlyList<string> languageCandidates,
-            IReadOnlyList<PaddleOcrCliGroupResult> groupResults,
+            IReadOnlyList<PaddleOcrCliImageResult> imageResults,
             string errorMessage,
             bool isPythonMissing,
             bool isModuleMissing)
@@ -411,7 +484,7 @@ namespace GameTranslator
             Success = success;
             PythonExecutablePath = pythonExecutablePath ?? "";
             LanguageCandidates = languageCandidates ?? Array.Empty<string>();
-            GroupResults = groupResults ?? Array.Empty<PaddleOcrCliGroupResult>();
+            ImageResults = imageResults ?? Array.Empty<PaddleOcrCliImageResult>();
             ErrorMessage = errorMessage ?? "";
             IsPythonMissing = isPythonMissing;
             IsModuleMissing = isModuleMissing;
@@ -420,7 +493,8 @@ namespace GameTranslator
         public bool Success { get; }
         public string PythonExecutablePath { get; }
         public IReadOnlyList<string> LanguageCandidates { get; }
-        public IReadOnlyList<PaddleOcrCliGroupResult> GroupResults { get; }
+        public IReadOnlyList<PaddleOcrCliImageResult> ImageResults { get; }
+        public IReadOnlyList<PaddleOcrCliGroupResult> GroupResults => ImageResults.FirstOrDefault()?.GroupResults ?? Array.Empty<PaddleOcrCliGroupResult>();
         public string ErrorMessage { get; }
         public bool IsPythonMissing { get; }
         public bool IsModuleMissing { get; }
@@ -428,10 +502,10 @@ namespace GameTranslator
         public static PaddleOcrCliBatchResult CreateSuccess(
             string pythonExecutablePath,
             IReadOnlyList<string> languageCandidates,
-            IReadOnlyList<PaddleOcrCliGroupResult> groupResults,
+            IReadOnlyList<PaddleOcrCliImageResult> imageResults,
             string errorMessage = "")
         {
-            return new PaddleOcrCliBatchResult(true, pythonExecutablePath, languageCandidates, groupResults, errorMessage, false, false);
+            return new PaddleOcrCliBatchResult(true, pythonExecutablePath, languageCandidates, imageResults, errorMessage, false, false);
         }
 
         public static PaddleOcrCliBatchResult CreateFailure(
@@ -441,8 +515,20 @@ namespace GameTranslator
             bool isPythonMissing = false,
             bool isModuleMissing = false)
         {
-            return new PaddleOcrCliBatchResult(false, pythonExecutablePath, languageCandidates, Array.Empty<PaddleOcrCliGroupResult>(), errorMessage, isPythonMissing, isModuleMissing);
+            return new PaddleOcrCliBatchResult(false, pythonExecutablePath, languageCandidates, Array.Empty<PaddleOcrCliImageResult>(), errorMessage, isPythonMissing, isModuleMissing);
         }
+    }
+
+    public sealed class PaddleOcrCliImageResult
+    {
+        public PaddleOcrCliImageResult(int index, IReadOnlyList<PaddleOcrCliGroupResult> groupResults)
+        {
+            Index = index;
+            GroupResults = groupResults ?? Array.Empty<PaddleOcrCliGroupResult>();
+        }
+
+        public int Index { get; }
+        public IReadOnlyList<PaddleOcrCliGroupResult> GroupResults { get; }
     }
 
     public sealed class PaddleOcrCliGroupResult

--- a/GameChatTranslator/Distribution/paddleocr_runner.py
+++ b/GameChatTranslator/Distribution/paddleocr_runner.py
@@ -7,10 +7,21 @@ import warnings
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--image", required=True)
+    parser.add_argument("--image")
+    parser.add_argument("--images")
     parser.add_argument("--groups", required=True)
     parser.add_argument("--gpu", default="false")
     return parser.parse_args()
+
+
+def parse_image_paths(args):
+    if getattr(args, "images", None):
+        return [value.strip() for value in args.images.split("|") if value.strip()]
+
+    if getattr(args, "image", None):
+        return [args.image.strip()] if str(args.image).strip() else []
+
+    return []
 
 
 def parse_language_groups(raw_value):
@@ -228,7 +239,7 @@ def recognize_with_legacy_ocr(ocr, image_path):
     return build_lines_from_words(build_words_from_legacy_payload(results))
 
 
-def recognize_image(language_code, image_path, use_gpu):
+def create_ocr(language_code, use_gpu):
     # PaddlePaddle 3.3.x CPU inference can fail in PIR/oneDNN conversion.
     # Set this before importing paddleocr so the diagnostic runner stays usable.
     os.environ.setdefault("FLAGS_enable_pir_api", "0")
@@ -251,6 +262,10 @@ def recognize_image(language_code, image_path, use_gpu):
             show_log=False,
         )
 
+    return ocr
+
+
+def recognize_image(ocr, image_path):
     if hasattr(ocr, "predict"):
         return recognize_with_predict(ocr, image_path)
 
@@ -259,7 +274,12 @@ def recognize_image(language_code, image_path, use_gpu):
 
 def main():
     args = parse_args()
+    image_paths = parse_image_paths(args)
     language_groups = parse_language_groups(args.groups)
+    if not image_paths:
+        print("PaddleOCR image paths are empty.", file=sys.stderr)
+        return 2
+
     if not language_groups:
         print("PaddleOCR language groups are empty.", file=sys.stderr)
         return 2
@@ -274,28 +294,40 @@ def main():
 
     warnings.filterwarnings("ignore")
 
-    response = {"groups": []}
+    response = {
+        "images": [
+            {
+                "index": index,
+                "groups": [],
+            }
+            for index in range(len(image_paths))
+        ]
+    }
 
     for language_code in language_groups:
         try:
-            lines = recognize_image(language_code, args.image, use_gpu)
-            response["groups"].append(
-                {
-                    "languageCodes": language_code,
-                    "success": True,
-                    "error": "",
-                    "lines": lines,
-                }
-            )
+            ocr = create_ocr(language_code, use_gpu)
+            for index, image_path in enumerate(image_paths):
+                lines = recognize_image(ocr, image_path)
+                response["images"][index]["groups"].append(
+                    {
+                        "languageCodes": language_code,
+                        "success": True,
+                        "error": "",
+                        "lines": lines,
+                    }
+                )
         except Exception as exc:
-            response["groups"].append(
-                {
-                    "languageCodes": language_code,
-                    "success": False,
-                    "error": str(exc),
-                    "lines": [],
-                }
-            )
+            error_text = str(exc)
+            for image in response["images"]:
+                image["groups"].append(
+                    {
+                        "languageCodes": language_code,
+                        "success": False,
+                        "error": error_text,
+                        "lines": [],
+                    }
+                )
 
     print(json.dumps(response, ensure_ascii=False))
     return 0

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -467,29 +467,37 @@ namespace GameTranslator
             bool paddleOcrUnavailable = false;
             string firstErrorMessage = "";
             var candidates = new List<OcrDiagnosticCandidate>();
+            var preparedInputs = new List<PaddleOcrPreparedInput>();
 
-            foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
+            try
             {
-                using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
-                byte[] croppedPng = BitmapToPngBytes(croppedBitmap);
-                byte[] preprocessedPng = BitmapToPngBytes(preprocessedImage.Bitmap);
+                foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
+                {
+                    using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
+                    preparedInputs.Add(new PaddleOcrPreparedInput
+                    {
+                        Name = preprocessedImage.Name,
+                        CroppedPng = BitmapToPngBytes(croppedBitmap),
+                        PreprocessedPng = BitmapToPngBytes(preprocessedImage.Bitmap),
+                        InputBitmap = (Bitmap)croppedBitmap.Clone()
+                    });
+                }
 
                 Stopwatch stopwatch = Stopwatch.StartNew();
-                using Bitmap paddleOcrInputBitmap = (Bitmap)croppedBitmap.Clone();
                 PaddleOcrCliBatchResult batchResult = await Task.Run(() =>
-                    paddleOcrCliAdapter.Recognize(
-                        paddleOcrInputBitmap,
+                    paddleOcrCliAdapter.RecognizeBatch(
+                        preparedInputs.Select(input => input.InputBitmap).ToList(),
                         configuredPythonPath,
                         configuredLanguageCodes,
                         gameLang,
                         PaddleOcrDiagnosticTimeoutMs));
                 stopwatch.Stop();
                 totalElapsedMs += stopwatch.ElapsedMilliseconds;
-                totalCallCount += batchResult.LanguageCandidates.Count;
+                totalCallCount += batchResult.ImageResults.Sum(image => image.GroupResults.Count);
 
                 if (!batchResult.Success)
                 {
-                    failureCount += Math.Max(1, batchResult.LanguageCandidates.Count);
+                    failureCount += Math.Max(1, batchResult.LanguageCandidates.Count * Math.Max(1, preparedInputs.Count));
                     if (string.IsNullOrWhiteSpace(firstErrorMessage))
                     {
                         firstErrorMessage = batchResult.ErrorMessage;
@@ -498,65 +506,81 @@ namespace GameTranslator
                     if (batchResult.IsPythonMissing)
                     {
                         pythonMissing = true;
-                        break;
                     }
-
-                    if (batchResult.IsModuleMissing)
+                    else if (batchResult.IsModuleMissing)
                     {
                         moduleMissing = true;
-                        break;
                     }
-
-                    paddleOcrUnavailable = true;
-                    break;
+                    else
+                    {
+                        paddleOcrUnavailable = true;
+                    }
                 }
-
-                successCount += batchResult.GroupResults.Count(group => group.Success);
-                failureCount += batchResult.GroupResults.Count(group => !group.Success);
-
-                var candidate = new OcrDiagnosticCandidate
+                else
                 {
-                    Name = $"PaddleOCR-{preprocessedImage.Name}",
-                    PreprocessedPng = preprocessedPng,
-                    CroppedPng = croppedPng
-                };
-                var languageCandidates = new List<OcrLanguageCandidate>();
+                    successCount += batchResult.ImageResults.Sum(image => image.GroupResults.Count(group => group.Success));
+                    failureCount += batchResult.ImageResults.Sum(image => image.GroupResults.Count(group => !group.Success));
 
-                foreach (PaddleOcrCliGroupResult groupResult in batchResult.GroupResults.Where(group => group.Success))
-                {
-                    var languageResult = new OcrDiagnosticLanguageResult
+                    for (int index = 0; index < preparedInputs.Count; index++)
                     {
-                        LanguageTag = $"paddleocr:{groupResult.LanguageCodes}"
-                    };
-                    languageResult.Lines.AddRange(groupResult.Lines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                    candidate.Languages.Add(languageResult);
+                        PaddleOcrPreparedInput preparedInput = preparedInputs[index];
+                        PaddleOcrCliImageResult imageResult = batchResult.ImageResults.FirstOrDefault(image => image.Index == index);
+                        if (imageResult == null)
+                        {
+                            continue;
+                        }
 
-                    languageCandidates.Add(new OcrLanguageCandidate
-                    {
-                        LanguageCode = groupResult.LanguageCodes,
-                        Lines = groupResult.Lines
-                            .Select(line => new OcrLine
+                        var candidate = new OcrDiagnosticCandidate
+                        {
+                            Name = $"PaddleOCR-{preparedInput.Name}",
+                            PreprocessedPng = preparedInput.PreprocessedPng,
+                            CroppedPng = preparedInput.CroppedPng
+                        };
+                        var languageCandidates = new List<OcrLanguageCandidate>();
+
+                        foreach (PaddleOcrCliGroupResult groupResult in imageResult.GroupResults.Where(group => group.Success))
+                        {
+                            var languageResult = new OcrDiagnosticLanguageResult
                             {
-                                Top = line.Top,
-                                Bottom = line.Bottom,
-                                Text = line.Text
-                            })
-                            .ToList()
-                    });
-                }
+                                LanguageTag = $"paddleocr:{groupResult.LanguageCodes}"
+                            };
+                            languageResult.Lines.AddRange(groupResult.Lines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                            candidate.Languages.Add(languageResult);
 
-                List<OcrLine> mergedLines = contentMode == TranslationContentMode.Strinova
-                    ? ocrService.MergeBestChatLinesByComponents(languageCandidates, characterNames)
-                    : ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
-                List<OcrLine> filteredMergedLines = ocrTranslationHarnessService.FilterMergedLinesForDiagnostics(mergedLines, characterNames);
-                List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(filteredMergedLines, characterNames, contentMode);
-                if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
+                            languageCandidates.Add(new OcrLanguageCandidate
+                            {
+                                LanguageCode = groupResult.LanguageCodes,
+                                Lines = groupResult.Lines
+                                    .Select(line => new OcrLine
+                                    {
+                                        Top = line.Top,
+                                        Bottom = line.Bottom,
+                                        Text = line.Text
+                                    })
+                                    .ToList()
+                            });
+                        }
+
+                        List<OcrLine> mergedLines = contentMode == TranslationContentMode.Strinova
+                            ? ocrService.MergeBestChatLinesByComponents(languageCandidates, characterNames)
+                            : ocrService.MergeBestLinesByIndex(languageCandidates, characterNames, contentMode);
+                        List<OcrLine> filteredMergedLines = ocrTranslationHarnessService.FilterMergedLinesForDiagnostics(mergedLines, characterNames);
+                        List<OcrLine> normalizedMergedLines = ocrService.NormalizeMergedLinesForSelection(filteredMergedLines, characterNames, contentMode);
+                        if (normalizedMergedLines.Count > 0 && candidate.Languages.Count > 0)
+                        {
+                            candidate.MergedLines.AddRange(normalizedMergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                            candidate.Score = ocrService.ScoreMergedLinesForSelection(normalizedMergedLines, characterNames, contentMode);
+                            candidates.Add(candidate);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                foreach (PaddleOcrPreparedInput preparedInput in preparedInputs)
                 {
-                    candidate.MergedLines.AddRange(normalizedMergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                    candidate.Score = ocrService.ScoreMergedLinesForSelection(normalizedMergedLines, characterNames, contentMode);
-                    candidates.Add(candidate);
+                    preparedInput.Dispose();
                 }
-
             }
 
             if (pythonMissing || moduleMissing)
@@ -789,6 +813,19 @@ namespace GameTranslator
             public string Status { get; }
             public long ElapsedMs { get; }
             public int CallCount { get; }
+        }
+
+        private sealed class PaddleOcrPreparedInput : IDisposable
+        {
+            public string Name { get; set; } = "";
+            public byte[] PreprocessedPng { get; set; }
+            public byte[] CroppedPng { get; set; }
+            public Bitmap InputBitmap { get; set; }
+
+            public void Dispose()
+            {
+                InputBitmap?.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
## 요약
- PaddleOCR 진단에서 전처리 이미지별로 Python 프로세스를 새로 띄우지 않고 배치로 재사용합니다.
- 언어 그룹별 OCR 모델을 한 번만 초기화하고 여러 이미지에 재사용합니다.
- 메인 번역 경로는 건드리지 않고 `codex/ocr-spike` 진단 경로에만 적용합니다.

## 변경 사항
- `paddleocr_runner.py`에 `--images` 배치 입력 추가
- `PaddleOcrCliAdapter`에 `RecognizeBatch(...)` 추가
- 진단 경로에서 PaddleOCR 3개 전처리 후보를 단일 배치 호출로 처리
- 배치 인자 테스트 추가

## 검증
- `git diff --check`
- `dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-paddle-batch`