### PR TITLE
개선: 설정창 중심 단축키와 OCR 선택 정리

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/OcrDiagnosticExporterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/OcrDiagnosticExporterTests.cs
@@ -27,6 +27,7 @@ namespace GameChatTranslator.Tests
             Assert.Contains("빌드 정보: 1.0.31-alpha+abcdef1234567890", summary);
             Assert.Contains("빌드 커밋: abcdef1234567890", summary);
             Assert.Contains("게임 언어: ko", summary);
+            Assert.Contains("OCR 엔진 선택: 전체 비교", summary);
             Assert.Contains("현재 자동 OCR 모드: 자동", summary);
             Assert.Contains("표시 좌표 CaptureX/Y/W/H: X=1, Y=2, W=30, H=40", summary);
             Assert.Contains("물리 픽셀 CapturePixelX/Y/W/H: X=10, Y=20, W=300, H=120", summary);
@@ -135,6 +136,7 @@ namespace GameChatTranslator.Tests
                     BuildCommit = "abcdef1234567890",
                     GameLanguage = "ko",
                     TargetLanguage = "en-US",
+                    ConfiguredOcrEngine = "전체 비교",
                     AutoTranslateMode = "자동",
                     DiagnosticProcessingMode = "정확",
                     SaveDebugImages = "false",

--- a/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
@@ -173,6 +173,42 @@ namespace GameChatTranslator.Tests
             Assert.Equal(expected, _service.GetTranslationContentModeTag(mode));
         }
 
+        [Theory]
+        [InlineData(null, ConfiguredOcrEngine.All)]
+        [InlineData("", ConfiguredOcrEngine.All)]
+        [InlineData("All", ConfiguredOcrEngine.All)]
+        [InlineData("WindowsOcr", ConfiguredOcrEngine.WindowsOcr)]
+        [InlineData("Tesseract", ConfiguredOcrEngine.Tesseract)]
+        [InlineData("EasyOCR", ConfiguredOcrEngine.EasyOcr)]
+        [InlineData("PaddleOCR", ConfiguredOcrEngine.PaddleOcr)]
+        [InlineData("unknown", ConfiguredOcrEngine.All)]
+        public void NormalizeConfiguredOcrEngine_MapsKnownValuesAndDefaultsToAll(string rawValue, ConfiguredOcrEngine expected)
+        {
+            Assert.Equal(expected, _service.NormalizeConfiguredOcrEngine(rawValue));
+        }
+
+        [Theory]
+        [InlineData(ConfiguredOcrEngine.All, "All")]
+        [InlineData(ConfiguredOcrEngine.WindowsOcr, "WindowsOcr")]
+        [InlineData(ConfiguredOcrEngine.Tesseract, "Tesseract")]
+        [InlineData(ConfiguredOcrEngine.EasyOcr, "EasyOcr")]
+        [InlineData(ConfiguredOcrEngine.PaddleOcr, "PaddleOcr")]
+        public void GetConfiguredOcrEngineTag_ReturnsConfigValue(ConfiguredOcrEngine engine, string expected)
+        {
+            Assert.Equal(expected, _service.GetConfiguredOcrEngineTag(engine));
+        }
+
+        [Theory]
+        [InlineData(ConfiguredOcrEngine.All, "전체 비교")]
+        [InlineData(ConfiguredOcrEngine.WindowsOcr, "Windows OCR")]
+        [InlineData(ConfiguredOcrEngine.Tesseract, "Tesseract")]
+        [InlineData(ConfiguredOcrEngine.EasyOcr, "EasyOCR")]
+        [InlineData(ConfiguredOcrEngine.PaddleOcr, "PaddleOCR")]
+        public void GetConfiguredOcrEngineDisplayName_ReturnsUserFacingLabel(ConfiguredOcrEngine engine, string expected)
+        {
+            Assert.Equal(expected, _service.GetConfiguredOcrEngineDisplayName(engine));
+        }
+
 
         [Theory]
         [InlineData("true")]
@@ -236,6 +272,7 @@ namespace GameChatTranslator.Tests
             Assert.Equal("Ctrl+=", hotkeys.LogViewer);
             Assert.Equal("Ctrl+5", hotkeys.OcrDiagnostic);
             Assert.Equal("Ctrl+F10", hotkeys.HotkeyGuideToggle);
+            Assert.Equal("Ctrl+8", hotkeys.OpenSettings);
         }
 
         [Fact]

--- a/GameChatTranslator/Core/OcrDiagnosticExporter.cs
+++ b/GameChatTranslator/Core/OcrDiagnosticExporter.cs
@@ -122,6 +122,7 @@ namespace GameTranslator
             builder.AppendLine($"빌드 커밋: {EmptyToDash(metadata.BuildCommit)}");
             builder.AppendLine($"게임 언어: {EmptyToDash(metadata.GameLanguage)}");
             builder.AppendLine($"번역 언어: {EmptyToDash(metadata.TargetLanguage)}");
+            builder.AppendLine($"OCR 엔진 선택: {EmptyToDash(metadata.ConfiguredOcrEngine)}");
             builder.AppendLine($"현재 자동 OCR 모드: {EmptyToDash(metadata.AutoTranslateMode)}");
             builder.AppendLine($"진단 OCR 모드: {EmptyToDash(metadata.DiagnosticProcessingMode)}");
             builder.AppendLine($"디버그 이미지 저장: {EmptyToDash(metadata.SaveDebugImages)}");

--- a/GameChatTranslator/Core/SettingsService.cs
+++ b/GameChatTranslator/Core/SettingsService.cs
@@ -36,6 +36,9 @@ namespace GameTranslator
         public const string DefaultKeyLogViewer = "Ctrl+=";
         public const string DefaultKeyOcrDiagnostic = "Ctrl+5";
         public const string DefaultKeyHotkeyGuideToggle = "Ctrl+F10";
+        public const string DefaultKeyOpenSettings = "Ctrl+8";
+        public const string DefaultOcrEngineSelection = "All";
+        public const string DefaultAutoCopyTranslationResult = "false";
 
         /// <summary>
         /// Gemini API 키를 선택합니다.
@@ -207,6 +210,70 @@ namespace GameTranslator
         }
 
         /// <summary>
+        /// OCR 엔진 선택값을 앱 내부 enum으로 변환합니다.
+        /// 알 수 없는 값은 전체 비교(All)로 되돌려 진단 흐름이 끊기지 않게 합니다.
+        /// </summary>
+        public ConfiguredOcrEngine NormalizeConfiguredOcrEngine(string value)
+        {
+            string normalized = (value ?? "").Trim();
+            if (normalized.Equals("WindowsOcr", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("Windows", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("WinOcr", StringComparison.OrdinalIgnoreCase))
+            {
+                return ConfiguredOcrEngine.WindowsOcr;
+            }
+
+            if (normalized.Equals("Tesseract", StringComparison.OrdinalIgnoreCase))
+            {
+                return ConfiguredOcrEngine.Tesseract;
+            }
+
+            if (normalized.Equals("EasyOcr", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("EasyOCR", StringComparison.OrdinalIgnoreCase))
+            {
+                return ConfiguredOcrEngine.EasyOcr;
+            }
+
+            if (normalized.Equals("PaddleOcr", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("PaddleOCR", StringComparison.OrdinalIgnoreCase))
+            {
+                return ConfiguredOcrEngine.PaddleOcr;
+            }
+
+            return ConfiguredOcrEngine.All;
+        }
+
+        /// <summary>
+        /// OCR 엔진 enum을 config.ini와 ComboBox.Tag에 저장할 문자열로 변환합니다.
+        /// </summary>
+        public string GetConfiguredOcrEngineTag(ConfiguredOcrEngine engine)
+        {
+            return engine switch
+            {
+                ConfiguredOcrEngine.WindowsOcr => "WindowsOcr",
+                ConfiguredOcrEngine.Tesseract => "Tesseract",
+                ConfiguredOcrEngine.EasyOcr => "EasyOcr",
+                ConfiguredOcrEngine.PaddleOcr => "PaddleOcr",
+                _ => DefaultOcrEngineSelection
+            };
+        }
+
+        /// <summary>
+        /// OCR 엔진 enum을 설정창과 진단 요약에 표시할 사용자용 이름으로 변환합니다.
+        /// </summary>
+        public string GetConfiguredOcrEngineDisplayName(ConfiguredOcrEngine engine)
+        {
+            return engine switch
+            {
+                ConfiguredOcrEngine.WindowsOcr => "Windows OCR",
+                ConfiguredOcrEngine.Tesseract => "Tesseract",
+                ConfiguredOcrEngine.EasyOcr => "EasyOCR",
+                ConfiguredOcrEngine.PaddleOcr => "PaddleOCR",
+                _ => "전체 비교"
+            };
+        }
+
+        /// <summary>
         /// true/1/yes/y/on 값을 true로 해석합니다.
         /// </summary>
         public bool IsEnabled(string value)
@@ -279,7 +346,8 @@ namespace GameTranslator
                 DefaultKeyCopyResult,
                 DefaultKeyLogViewer,
                 DefaultKeyOcrDiagnostic,
-                DefaultKeyHotkeyGuideToggle);
+                DefaultKeyHotkeyGuideToggle,
+                DefaultKeyOpenSettings);
         }
     }
 
@@ -313,7 +381,8 @@ namespace GameTranslator
             string copyResult,
             string logViewer,
             string ocrDiagnostic,
-            string hotkeyGuideToggle)
+            string hotkeyGuideToggle,
+            string openSettings)
         {
             MoveLock = moveLock;
             AreaSelect = areaSelect;
@@ -324,6 +393,7 @@ namespace GameTranslator
             LogViewer = logViewer;
             OcrDiagnostic = ocrDiagnostic;
             HotkeyGuideToggle = hotkeyGuideToggle;
+            OpenSettings = openSettings;
         }
 
         public string MoveLock { get; }
@@ -335,6 +405,20 @@ namespace GameTranslator
         public string LogViewer { get; }
         public string OcrDiagnostic { get; }
         public string HotkeyGuideToggle { get; }
+        public string OpenSettings { get; }
+    }
+
+    /// <summary>
+    /// 설정창에서 사용자가 선택한 OCR 엔진 범위입니다.
+    /// All은 비교 모드, 나머지는 선택한 엔진 후보만 점수 계산합니다.
+    /// </summary>
+    public enum ConfiguredOcrEngine
+    {
+        All,
+        WindowsOcr,
+        Tesseract,
+        EasyOcr,
+        PaddleOcr
     }
 
     /// <summary>

--- a/GameChatTranslator/Models/OcrDiagnosticModels.cs
+++ b/GameChatTranslator/Models/OcrDiagnosticModels.cs
@@ -41,6 +41,7 @@ namespace GameTranslator
         public string BuildCommit { get; set; } = "";
         public string GameLanguage { get; set; } = "";
         public string TargetLanguage { get; set; } = "";
+        public string ConfiguredOcrEngine { get; set; } = "";
         public string AutoTranslateMode { get; set; } = "";
         public string DiagnosticProcessingMode { get; set; } = "";
         public string SaveDebugImages { get; set; } = "";

--- a/GameChatTranslator/Views/MainWindow/MainWindow.ApiStatus.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.ApiStatus.cs
@@ -4,7 +4,7 @@ namespace GameTranslator
 {
     public partial class MainWindow
     {
-        private const string TranslationApiStatusDetailHint = "상세 원인: Ctrl+= 로그창";
+        private const string TranslationApiStatusDetailHint = "상세 원인: 환경설정 > 로그창";
 
         /// <summary>
         /// 번역 API 실패를 번역창 상단에 짧게 표시합니다.
@@ -15,7 +15,7 @@ namespace GameTranslator
             if (TxtApiStatus == null || string.IsNullOrWhiteSpace(message)) return;
 
             string displayMessage = message.Trim();
-            if (!displayMessage.Contains("Ctrl+="))
+            if (!displayMessage.Contains("로그창"))
             {
                 displayMessage += "\n" + TranslationApiStatusDetailHint;
             }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Clipboard.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Clipboard.cs
@@ -80,5 +80,34 @@ namespace GameTranslator
                 AppendLog($"클립보드 복사 실패: {ex.Message}");
             }
         }
+
+        /// <summary>
+        /// 환경설정창 버튼에서 최근 번역 결과 복사를 호출할 때 사용하는 래퍼입니다.
+        /// </summary>
+        public void CopyLastTranslationToClipboardFromSettings()
+        {
+            CopyLastTranslationToClipboard();
+        }
+
+        /// <summary>
+        /// 설정에서 자동 복사를 켠 경우 현재 번역 결과 버퍼를 클립보드에 반영합니다.
+        /// 자동 번역 중 로그가 과도하게 쌓이지 않도록 성공 로그는 남기지 않습니다.
+        /// </summary>
+        private void TryAutoCopyTranslationResult()
+        {
+            if (!ShouldAutoCopyTranslationResult() || string.IsNullOrWhiteSpace(lastClipboardTranslationText))
+            {
+                return;
+            }
+
+            try
+            {
+                System.Windows.Clipboard.SetText(lastClipboardTranslationText.Trim());
+            }
+            catch (Exception ex)
+            {
+                AppendLog($"자동 클립보드 복사 실패: {ex.Message}");
+            }
+        }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
@@ -45,40 +45,23 @@ namespace GameTranslator
             UnregisterHotKey(_windowHandle, ID_HOTKEY_LOG_VIEWER);
             UnregisterHotKey(_windowHandle, ID_HOTKEY_OCR_DIAGNOSTIC);
             UnregisterHotKey(_windowHandle, ID_HOTKEY_HOTKEY_GUIDE_TOGGLE);
+            UnregisterHotKey(_windowHandle, ID_HOTKEY_OPEN_SETTINGS);
 
             hotkeyWarningMessage = "";
             var failedHotkeys = new List<string>();
 
             DefaultHotkeys defaults = settingsService.GetDefaultHotkeys();
-            string moveHotkey = settingsService.NormalizeHotkey(ini.Read("Key_MoveLock"), defaults.MoveLock);
-            string areaHotkey = settingsService.NormalizeHotkey(ini.Read("Key_AreaSelect"), defaults.AreaSelect);
             string translateHotkey = settingsService.NormalizeHotkey(ini.Read("Key_Translate"), defaults.Translate);
             string autoHotkey = settingsService.NormalizeHotkey(ini.Read("Key_AutoTranslate"), defaults.AutoTranslate);
-            string toggleHotkey = settingsService.NormalizeHotkey(ini.Read("Key_ToggleEngine"), defaults.ToggleEngine);
-            string copyHotkey = settingsService.NormalizeHotkey(ini.Read("Key_CopyResult"), defaults.CopyResult);
-            string logHotkey = settingsService.NormalizeHotkey(ini.Read("Key_LogViewer"), defaults.LogViewer);
-            string ocrDiagnosticHotkey = settingsService.NormalizeHotkey(ini.Read("Key_OcrDiagnostic"), defaults.OcrDiagnostic);
-            string hotkeyGuideHotkey = settingsService.NormalizeHotkey(ini.Read("Key_HotkeyGuideToggle"), defaults.HotkeyGuideToggle);
+            string settingsHotkey = settingsService.NormalizeHotkey(ini.Read("Key_OpenSettings"), defaults.OpenSettings);
 
-            ParseHotkey(moveHotkey, out modMove, out keyMove);
-            ParseHotkey(areaHotkey, out modArea, out keyArea);
             ParseHotkey(translateHotkey, out modTrans, out keyTrans);
             ParseHotkey(autoHotkey, out modAuto, out keyAuto);
-            ParseHotkey(toggleHotkey, out modToggle, out keyToggle);
-            ParseHotkey(copyHotkey, out modCopy, out keyCopy);
-            ParseHotkey(logHotkey, out modLog, out keyLog);
-            ParseHotkey(ocrDiagnosticHotkey, out modOcrDiag, out keyOcrDiag);
-            ParseHotkey(hotkeyGuideHotkey, out modHotkeyGuide, out keyHotkeyGuide);
+            ParseHotkey(settingsHotkey, out modSettings, out keySettings);
 
-            RegisterHotKeyOrWarn(ID_HOTKEY_MOVE_LOCK, modMove, keyMove, "이동/잠금", moveHotkey, failedHotkeys);
-            RegisterHotKeyOrWarn(ID_HOTKEY_AREA_SELECT, modArea, keyArea, "영역 설정", areaHotkey, failedHotkeys);
             RegisterHotKeyOrWarn(ID_HOTKEY_TRANSLATE, modTrans, keyTrans, "수동 번역", translateHotkey, failedHotkeys);
             RegisterHotKeyOrWarn(ID_HOTKEY_AUTO, modAuto, keyAuto, "자동 번역", autoHotkey, failedHotkeys);
-            RegisterHotKeyOrWarn(ID_HOTKEY_TOGGLE_ENGINE, modToggle, keyToggle, "엔진 전환", toggleHotkey, failedHotkeys);
-            RegisterHotKeyOrWarn(ID_HOTKEY_COPY_RESULT, modCopy, keyCopy, "번역 복사", copyHotkey, failedHotkeys);
-            RegisterHotKeyOrWarn(ID_HOTKEY_LOG_VIEWER, modLog, keyLog, "로그창", logHotkey, failedHotkeys);
-            RegisterHotKeyOrWarn(ID_HOTKEY_OCR_DIAGNOSTIC, modOcrDiag, keyOcrDiag, "OCR 진단", ocrDiagnosticHotkey, failedHotkeys);
-            RegisterHotKeyOrWarn(ID_HOTKEY_HOTKEY_GUIDE_TOGGLE, modHotkeyGuide, keyHotkeyGuide, "단축키 안내", hotkeyGuideHotkey, failedHotkeys);
+            RegisterHotKeyOrWarn(ID_HOTKEY_OPEN_SETTINGS, modSettings, keySettings, "환경설정", settingsHotkey, failedHotkeys);
 
             if (failedHotkeys.Count > 0)
             {
@@ -133,17 +116,9 @@ namespace GameTranslator
         private void UpdateYellowHotkeyGuideText()
         {
             DefaultHotkeys defaults = settingsService.GetDefaultHotkeys();
-            string m = settingsService.NormalizeHotkey(ini.Read("Key_MoveLock"), defaults.MoveLock);
-            string a = settingsService.NormalizeHotkey(ini.Read("Key_AreaSelect"), defaults.AreaSelect);
+            string settingsHotkey = settingsService.NormalizeHotkey(ini.Read("Key_OpenSettings"), defaults.OpenSettings);
             string t = settingsService.NormalizeHotkey(ini.Read("Key_Translate"), defaults.Translate);
             string au = settingsService.NormalizeHotkey(ini.Read("Key_AutoTranslate"), defaults.AutoTranslate);
-            string tg = settingsService.NormalizeHotkey(ini.Read("Key_ToggleEngine"), defaults.ToggleEngine);
-            string copy = settingsService.NormalizeHotkey(ini.Read("Key_CopyResult"), defaults.CopyResult);
-            string log = settingsService.NormalizeHotkey(ini.Read("Key_LogViewer"), defaults.LogViewer);
-            string diag = settingsService.NormalizeHotkey(ini.Read("Key_OcrDiagnostic"), defaults.OcrDiagnostic);
-            string guide = settingsService.NormalizeHotkey(ini.Read("Key_HotkeyGuideToggle"), defaults.HotkeyGuideToggle);
-
-            // 🌟 안내 문구에 엔진 전환 추가
             string engineStr = GetCurrentTranslationEngineShortName();
             if (TxtHotkeyGuide == null)
             {
@@ -151,40 +126,13 @@ namespace GameTranslator
             }
 
             TxtHotkeyGuide.Inlines.Clear();
-
-            if (!isHotkeyGuideExpanded)
-            {
-                TxtHotkeyGuide.Inlines.Add(new Run($"[{guide}] 단축키 안내\t\t"));
-                TxtHotkeyGuide.Inlines.Add(new Run("자동: "));
-                TxtHotkeyGuide.Inlines.Add(new Run(GetAutoTranslateModeLabel())
-                {
-                    Foreground = isAutoTranslating ? Brushes.Lime : Brushes.Gray,
-                    FontWeight = FontWeights.Bold
-                });
-                TxtHotkeyGuide.Inlines.Add(new Run($"\t\t번역기: {engineStr}"));
-                return;
-            }
-
-            // 상세 안내 ON 상태에서는 기존 단축키 목록을 보여주고, Ctrl+F10으로 접을 수 있음을 함께 표시합니다.
-            TxtHotkeyGuide.Inlines.Add(new Run($"[{m}] 이동  [{a}] 영역  [{t}] 번역  [{au}] 자동: "));
+            TxtHotkeyGuide.Inlines.Add(new Run($"[{settingsHotkey}] 설정  [{t}] 번역  [{au}] 자동: "));
             TxtHotkeyGuide.Inlines.Add(new Run(GetAutoTranslateModeLabel())
             {
                 Foreground = isAutoTranslating ? Brushes.Lime : Brushes.Gray,
                 FontWeight = FontWeights.Bold
             });
-            TxtHotkeyGuide.Inlines.Add(new Run($"\n[{copy}] 복사  [{diag}] 진단  [{tg}] {engineStr}  [{log}] 로그"));
-            TxtHotkeyGuide.Inlines.Add(new Run($"\n[{guide}] 단축키 안내 숨김"));
-        }
-
-        /// <summary>
-        /// 번역창 상단 단축키 상세 목록 표시 여부를 전환합니다.
-        /// OFF 상태에서는 자동 번역 상태와 현재 번역 엔진만 표시해 게임 화면을 덜 가리게 합니다.
-        /// </summary>
-        private void ToggleHotkeyGuide()
-        {
-            isHotkeyGuideExpanded = !isHotkeyGuideExpanded;
-            UpdateYellowHotkeyGuideText();
-            AppendLog($"단축키 안내 표시: {(isHotkeyGuideExpanded ? "ON" : "OFF")}");
+            TxtHotkeyGuide.Inlines.Add(new Run($"  번역기: {engineStr}"));
         }
 
         /// <summary>
@@ -256,15 +204,9 @@ namespace GameTranslator
             {
                 switch (wParam.ToInt32())
                 {
-                    case ID_HOTKEY_MOVE_LOCK: ToggleMoveLock(); handled = true; break;
-                    case ID_HOTKEY_AREA_SELECT: startAreaSelection(); handled = true; break;
                     case ID_HOTKEY_TRANSLATE: runTranslation(); handled = true; break;
                     case ID_HOTKEY_AUTO: ToggleAutoTranslate(); handled = true; break;
-                    case ID_HOTKEY_TOGGLE_ENGINE: ToggleEngine(); handled = true; break;
-                    case ID_HOTKEY_COPY_RESULT: CopyLastTranslationToClipboard(); handled = true; break;
-                    case ID_HOTKEY_LOG_VIEWER: ToggleLogViewerWindow(); handled = true; break;
-                    case ID_HOTKEY_OCR_DIAGNOSTIC: ShowOcrDiagnosticWindow(); handled = true; break;
-                    case ID_HOTKEY_HOTKEY_GUIDE_TOGGLE: ToggleHotkeyGuide(); handled = true; break;
+                    case ID_HOTKEY_OPEN_SETTINGS: ShowSettingsWindow(); handled = true; break;
                 }
             }
             return IntPtr.Zero;

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
@@ -67,10 +67,7 @@ namespace GameTranslator
                 return;
             }
 
-            OptionSelector selector = new OptionSelector(this, ini);
-            selector.Owner = this;
-            selector.WindowStartupLocation = WindowStartupLocation.CenterOwner;
-
+            OptionSelector selector = CreateSettingsDialog();
             bool? dialogResult = selector.ShowDialog();
 
             if (dialogResult != true)
@@ -79,25 +76,16 @@ namespace GameTranslator
                 return;
             }
 
+            OptionSelectorPostAction requestedAction = selector.RequestedActionAfterClose;
+
             this.Topmost = false;
             this.Topmost = true;
 
-            gameLang = ini.Read("GameLanguage") ?? "ko";
-            targetLang = ini.Read("TargetLanguage") ?? "ko";
-
             _windowHandle = new WindowInteropHelper(this).Handle;
             HwndSource.FromHwnd(_windowHandle).AddHook(HwndHook);
-            RegisterAllHotkeys();
+            ApplyRuntimeSettingsFromIni();
 
             string geminiKey = ReadGeminiKey();
-
-            currentTranslationEngineMode = ReadTranslationEngineMode();
-            if (currentTranslationEngineMode == TranslationEngineMode.Gemini &&
-                (string.IsNullOrWhiteSpace(geminiKey) || geminiKey.Length < 30))
-            {
-                currentTranslationEngineMode = TranslationEngineMode.Google;
-                AppendLog("저장된 기본 번역 엔진이 Gemini이지만 API 키가 없어 Google로 시작합니다.");
-            }
 
             string currentEngine = GetCurrentTranslationEngineDisplayName();
 
@@ -186,6 +174,7 @@ namespace GameTranslator
 
             UpdateCaptureBorder(!isLocked);
             ShowHotkeyWarningIfAny();
+            ExecuteSettingsDialogPostAction(requestedAction);
         }
 
         /// <summary>
@@ -210,10 +199,53 @@ namespace GameTranslator
             UnregisterHotKey(_windowHandle, ID_HOTKEY_TOGGLE_ENGINE);
             UnregisterHotKey(_windowHandle, ID_HOTKEY_COPY_RESULT);
             UnregisterHotKey(_windowHandle, ID_HOTKEY_LOG_VIEWER);
+            UnregisterHotKey(_windowHandle, ID_HOTKEY_OCR_DIAGNOSTIC);
+            UnregisterHotKey(_windowHandle, ID_HOTKEY_HOTKEY_GUIDE_TOGGLE);
+            UnregisterHotKey(_windowHandle, ID_HOTKEY_OPEN_SETTINGS);
 
             AppendLog("프로그램이 정상적으로 종료되었습니다.");
             Application.Current.Shutdown();
             base.OnClosed(e);
+        }
+
+        /// <summary>
+        /// 런타임에서 환경설정창을 다시 열어 설정 변경을 적용합니다.
+        /// 저장 후 필요한 후처리(예: 캡처 영역 다시 지정)는 창이 닫힌 뒤 실행합니다.
+        /// </summary>
+        public void ShowSettingsWindow()
+        {
+            OptionSelector selector = CreateSettingsDialog();
+            bool? dialogResult = selector.ShowDialog();
+            if (dialogResult == true)
+            {
+                ExecuteSettingsDialogPostAction(selector.RequestedActionAfterClose);
+            }
+        }
+
+        /// <summary>
+        /// 환경설정창에서 이동 잠금 전환을 요청할 때 사용하는 래퍼입니다.
+        /// </summary>
+        public void ToggleMoveLockFromSettings()
+        {
+            ToggleMoveLock();
+            UpdateYellowHotkeyGuideText();
+        }
+
+        private OptionSelector CreateSettingsDialog()
+        {
+            return new OptionSelector(this, ini)
+            {
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+        }
+
+        private void ExecuteSettingsDialogPostAction(OptionSelectorPostAction action)
+        {
+            if (action == OptionSelectorPostAction.StartAreaSelection)
+            {
+                startAreaSelection();
+            }
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Native.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Native.cs
@@ -68,6 +68,7 @@ namespace GameTranslator
         private const int ID_HOTKEY_LOG_VIEWER = 9007;
         private const int ID_HOTKEY_OCR_DIAGNOSTIC = 9008;
         private const int ID_HOTKEY_HOTKEY_GUIDE_TOGGLE = 9009;
+        private const int ID_HOTKEY_OPEN_SETTINGS = 9010;
         internal const string DefaultGeminiModel = SettingsService.DefaultGeminiModel;
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -47,7 +47,7 @@ namespace GameTranslator
 
             if (gameChatArea == Rectangle.Empty)
             {
-                throw new InvalidOperationException("캡처 영역이 설정되어 있지 않습니다. Ctrl+8로 채팅 영역을 먼저 지정해 주세요.");
+                throw new InvalidOperationException("캡처 영역이 설정되어 있지 않습니다. 환경설정창에서 채팅 영역을 먼저 지정해 주세요.");
             }
 
             if (ocrEngines.Count == 0)
@@ -57,6 +57,7 @@ namespace GameTranslator
 
             int threshold = SettingsValueNormalizer.NormalizeThreshold(ini.Read("Threshold"));
             int scaleFactor = SettingsValueNormalizer.NormalizeScaleFactor(ini.Read("ScaleFactor"));
+            ConfiguredOcrEngine configuredOcrEngine = ReadConfiguredOcrEngineSelection();
 
             var result = new OcrDiagnosticResult
             {
@@ -64,7 +65,7 @@ namespace GameTranslator
                 Threshold = threshold,
                 ScaleFactor = scaleFactor,
                 CaptureArea = GetCapturePixelArea(),
-                Metadata = BuildOcrDiagnosticMetadata()
+                Metadata = BuildOcrDiagnosticMetadata(configuredOcrEngine)
             };
 
             Stopwatch totalStopwatch = Stopwatch.StartNew();
@@ -101,55 +102,67 @@ namespace GameTranslator
             {
                 OcrDiagnosticCandidate bestCandidate = null;
 
-                foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
+                if (ShouldIncludeWindowsOcrCandidates(configuredOcrEngine))
                 {
-                    var diagnosticCandidate = new OcrDiagnosticCandidate
+                    foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
                     {
-                        Name = preprocessedImage.Name,
-                        PreprocessedPng = BitmapToPngBytes(preprocessedImage.Bitmap)
-                    };
-
-                    Stopwatch cropStopwatch = Stopwatch.StartNew();
-                    using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
-                    cropStopwatch.Stop();
-                    stats.CropMs += cropStopwatch.ElapsedMilliseconds;
-                    diagnosticCandidate.CroppedPng = BitmapToPngBytes(croppedBitmap);
-
-                    Dictionary<string, OcrResult> ocrResults = await RecognizeLanguagesAsync(croppedBitmap, true, stats);
-                    foreach (var kvp in ocrResults.OrderBy(x => x.Key))
-                    {
-                        var languageResult = new OcrDiagnosticLanguageResult
+                        var diagnosticCandidate = new OcrDiagnosticCandidate
                         {
-                            LanguageTag = kvp.Key
+                            Name = preprocessedImage.Name,
+                            PreprocessedPng = BitmapToPngBytes(preprocessedImage.Bitmap)
                         };
-                        languageResult.Lines.AddRange(kvp.Value.Lines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                        diagnosticCandidate.Languages.Add(languageResult);
-                    }
 
-                    Stopwatch scoringStopwatch = Stopwatch.StartNew();
-                    OcrResult masterResult = SelectMasterOcrResult(ocrResults);
-                    if (masterResult != null)
-                    {
-                        List<OcrLine> mergedLines = MergeOcrLines(masterResult);
-                        diagnosticCandidate.MergedLines.AddRange(mergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
-                        diagnosticCandidate.Score = ScoreOcrCandidate(mergedLines, ReadTranslationContentMode());
-                    }
-                    scoringStopwatch.Stop();
-                    stats.ScoringMs += scoringStopwatch.ElapsedMilliseconds;
+                        Stopwatch cropStopwatch = Stopwatch.StartNew();
+                        using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
+                        cropStopwatch.Stop();
+                        stats.CropMs += cropStopwatch.ElapsedMilliseconds;
+                        diagnosticCandidate.CroppedPng = BitmapToPngBytes(croppedBitmap);
 
-                    result.Candidates.Add(diagnosticCandidate);
-                    if (bestCandidate == null || diagnosticCandidate.Score > bestCandidate.Score)
-                    {
-                        bestCandidate = diagnosticCandidate;
+                        Dictionary<string, OcrResult> ocrResults = await RecognizeLanguagesAsync(croppedBitmap, true, stats);
+                        foreach (var kvp in ocrResults.OrderBy(x => x.Key))
+                        {
+                            var languageResult = new OcrDiagnosticLanguageResult
+                            {
+                                LanguageTag = kvp.Key
+                            };
+                            languageResult.Lines.AddRange(kvp.Value.Lines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                            diagnosticCandidate.Languages.Add(languageResult);
+                        }
+
+                        Stopwatch scoringStopwatch = Stopwatch.StartNew();
+                        OcrResult masterResult = SelectMasterOcrResult(ocrResults);
+                        if (masterResult != null)
+                        {
+                            List<OcrLine> mergedLines = MergeOcrLines(masterResult);
+                            diagnosticCandidate.MergedLines.AddRange(mergedLines.Select(line => line.Text.Trim()).Where(text => !string.IsNullOrWhiteSpace(text)));
+                            diagnosticCandidate.Score = ScoreOcrCandidate(mergedLines, ReadTranslationContentMode());
+                        }
+                        scoringStopwatch.Stop();
+                        stats.ScoringMs += scoringStopwatch.ElapsedMilliseconds;
+
+                        result.Candidates.Add(diagnosticCandidate);
+                        if (bestCandidate == null || diagnosticCandidate.Score > bestCandidate.Score)
+                        {
+                            bestCandidate = diagnosticCandidate;
+                        }
                     }
                 }
 
-                var externalSummaries = new List<ExternalOcrDiagnosticSummary>
+                var externalSummaries = new List<ExternalOcrDiagnosticSummary>();
+                if (ShouldIncludeTesseractCandidates(configuredOcrEngine))
                 {
-                    await TryBuildTesseractDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()),
-                    await TryBuildEasyOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()),
-                    await TryBuildPaddleOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode())
-                };
+                    externalSummaries.Add(await TryBuildTesseractDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()));
+                }
+
+                if (ShouldIncludeEasyOcrCandidates(configuredOcrEngine))
+                {
+                    externalSummaries.Add(await TryBuildEasyOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()));
+                }
+
+                if (ShouldIncludePaddleOcrCandidates(configuredOcrEngine))
+                {
+                    externalSummaries.Add(await TryBuildPaddleOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()));
+                }
                 result.ExternalOcrStatus = BuildExternalOcrStatusText(externalSummaries);
 
                 foreach (ExternalOcrDiagnosticSummary externalSummary in externalSummaries)
@@ -663,7 +676,7 @@ namespace GameTranslator
         /// OCR 진단 ZIP에 포함할 앱 버전, 언어 설정, OCR 모드, 언어팩 상태를 문자열 모델로 만듭니다.
         /// Exporter가 WinRT/Assembly/IniFile에 의존하지 않도록 MainWindow에서 현재 런타임 값을 채워 전달합니다.
         /// </summary>
-        private OcrDiagnosticMetadata BuildOcrDiagnosticMetadata()
+        private OcrDiagnosticMetadata BuildOcrDiagnosticMetadata(ConfiguredOcrEngine configuredOcrEngine)
         {
             var metadata = new OcrDiagnosticMetadata
             {
@@ -672,6 +685,7 @@ namespace GameTranslator
                 BuildCommit = CurrentBuildCommit,
                 GameLanguage = gameLang,
                 TargetLanguage = targetLang,
+                ConfiguredOcrEngine = settingsService.GetConfiguredOcrEngineDisplayName(configuredOcrEngine),
                 AutoTranslateMode = GetAutoTranslateModeLabel(),
                 DiagnosticProcessingMode = GetOcrProcessingModeLabel(OcrProcessingMode.Accurate),
                 SaveDebugImages = settingsService.IsEnabled(ini.Read("SaveDebugImages")) ? "true" : "false",
@@ -735,6 +749,26 @@ namespace GameTranslator
                 string status = ocrEngines.ContainsKey(tag) ? "설치됨" : "미설치";
                 yield return $"{label} ({tag}) : {status}";
             }
+        }
+
+        private static bool ShouldIncludeWindowsOcrCandidates(ConfiguredOcrEngine configuredOcrEngine)
+        {
+            return configuredOcrEngine == ConfiguredOcrEngine.All || configuredOcrEngine == ConfiguredOcrEngine.WindowsOcr;
+        }
+
+        private static bool ShouldIncludeTesseractCandidates(ConfiguredOcrEngine configuredOcrEngine)
+        {
+            return configuredOcrEngine == ConfiguredOcrEngine.All || configuredOcrEngine == ConfiguredOcrEngine.Tesseract;
+        }
+
+        private static bool ShouldIncludeEasyOcrCandidates(ConfiguredOcrEngine configuredOcrEngine)
+        {
+            return configuredOcrEngine == ConfiguredOcrEngine.All || configuredOcrEngine == ConfiguredOcrEngine.EasyOcr;
+        }
+
+        private static bool ShouldIncludePaddleOcrCandidates(ConfiguredOcrEngine configuredOcrEngine)
+        {
+            return configuredOcrEngine == ConfiguredOcrEngine.All || configuredOcrEngine == ConfiguredOcrEngine.PaddleOcr;
         }
 
         private string FormatRectangle(Rectangle rectangle)

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
@@ -148,6 +148,11 @@ namespace GameTranslator
                 ini.Write("Key_HotkeyGuideToggle", SettingsService.DefaultKeyHotkeyGuideToggle);
             }
 
+            if (string.IsNullOrWhiteSpace(ini.Read("Key_OpenSettings")))
+            {
+                ini.Write("Key_OpenSettings", SettingsService.DefaultKeyOpenSettings);
+            }
+
             if (string.IsNullOrWhiteSpace(ini.Read("ResultDisplayMode")))
             {
                 ini.Write("ResultDisplayMode", SettingsService.DefaultResultDisplayMode);
@@ -155,6 +160,10 @@ namespace GameTranslator
 
             EnsureNormalizedSetting("ResultHistoryLimit", SettingsValueNormalizer.NormalizeResultHistoryLimit(ini.Read("ResultHistoryLimit")).ToString());
             EnsureNormalizedSetting("TranslationResultAutoClearSeconds", SettingsValueNormalizer.NormalizeTranslationResultAutoClearSeconds(ini.Read("TranslationResultAutoClearSeconds")).ToString());
+            EnsureNormalizedSetting("OcrEngineSelection", settingsService.GetConfiguredOcrEngineTag(settingsService.NormalizeConfiguredOcrEngine(ini.Read("OcrEngineSelection"))));
+            EnsureNormalizedSetting("AutoCopyTranslationResult", settingsService.IsEnabled(ini.Read("AutoCopyTranslationResult"))
+                ? "true"
+                : SettingsService.DefaultAutoCopyTranslationResult);
         }
 
         /// <summary>
@@ -215,6 +224,131 @@ namespace GameTranslator
         private TranslationContentMode ReadTranslationContentMode()
         {
             return settingsService.NormalizeTranslationContentMode(ini.Read("TranslationContentMode"));
+        }
+
+        /// <summary>
+        /// OCR 진단에서 어떤 엔진 후보를 점수 계산 대상으로 사용할지 읽습니다.
+        /// All은 전체 비교 모드이고, 나머지는 선택한 엔진만 평가합니다.
+        /// </summary>
+        private ConfiguredOcrEngine ReadConfiguredOcrEngineSelection()
+        {
+            return settingsService.NormalizeConfiguredOcrEngine(ini.Read("OcrEngineSelection"));
+        }
+
+        /// <summary>
+        /// 번역 결과를 매번 클립보드에 자동 복사할지 읽습니다.
+        /// 기본값은 OFF이며, 설정창에서 켠 경우에만 동작합니다.
+        /// </summary>
+        private bool ShouldAutoCopyTranslationResult()
+        {
+            return settingsService.IsEnabledOrDefault(
+                ini.Read("AutoCopyTranslationResult"),
+                settingsService.IsEnabled(SettingsService.DefaultAutoCopyTranslationResult));
+        }
+
+        /// <summary>
+        /// config.ini 값을 현재 런타임 상태와 UI에 다시 반영합니다.
+        /// 설정창 저장 후 단축키, 번역 엔진, 타이머, OCR 선택값이 재시작 없이 즉시 적용됩니다.
+        /// </summary>
+        public void ApplyRuntimeSettingsFromIni()
+        {
+            gameLang = ini.Read("GameLanguage") ?? "ko";
+            targetLang = ini.Read("TargetLanguage") ?? "ko";
+            currentConfiguredOcrEngine = ReadConfiguredOcrEngineSelection();
+
+            TranslationEngineMode configuredEngine = ReadTranslationEngineMode();
+            string geminiKey = ReadGeminiKey();
+            currentTranslationEngineMode =
+                configuredEngine == TranslationEngineMode.Gemini &&
+                (string.IsNullOrWhiteSpace(geminiKey) || geminiKey.Length < 30)
+                    ? TranslationEngineMode.Google
+                    : configuredEngine;
+
+            if (int.TryParse(ini.Read("Opacity"), out int opacityPercent))
+            {
+                Opacity = Math.Max(10, Math.Min(100, opacityPercent)) / 100.0;
+            }
+
+            if (autoTranslateTimer != null)
+            {
+                autoTranslateTimer.Interval = TimeSpan.FromSeconds(
+                    SettingsValueNormalizer.NormalizeAutoTranslateInterval(ini.Read("AutoTranslateInterval")));
+            }
+
+            if (translationResultAutoClearTimer != null)
+            {
+                if (ReadTranslationResultAutoClearSeconds() <= 0)
+                {
+                    translationResultAutoClearTimer.Stop();
+                }
+                else if (translationResultAutoClearTimer.IsEnabled)
+                {
+                    RestartTranslationResultAutoClearTimer();
+                }
+            }
+
+            if (TryReadSavedCaptureArea(out Rectangle displayArea, out Rectangle pixelArea))
+            {
+                gameChatArea = displayArea;
+                gameChatCaptureArea = pixelArea;
+                SizeToContent = SizeToContent.Manual;
+                Width = displayArea.Width;
+                MinWidth = displayArea.Width;
+                SizeToContent = SizeToContent.Height;
+                PositionTranslationWindowNearCaptureArea(displayArea, pixelArea);
+                UpdateCaptureBorder(!isLocked);
+            }
+            else
+            {
+                gameChatArea = Rectangle.Empty;
+                gameChatCaptureArea = Rectangle.Empty;
+                if (captureBorderWindow != null)
+                {
+                    captureBorderWindow.Visibility = Visibility.Hidden;
+                }
+            }
+
+            if (_windowHandle != IntPtr.Zero)
+            {
+                RegisterAllHotkeys();
+                ResetTranslationCache("환경설정 저장");
+            }
+
+            UpdateYellowHotkeyGuideText();
+        }
+
+        private bool TryReadSavedCaptureArea(out Rectangle displayArea, out Rectangle pixelArea)
+        {
+            displayArea = Rectangle.Empty;
+            pixelArea = Rectangle.Empty;
+
+            if (!int.TryParse(ini.Read("CaptureX"), out int x) ||
+                !int.TryParse(ini.Read("CaptureY"), out int y) ||
+                !int.TryParse(ini.Read("CaptureW"), out int w) ||
+                !int.TryParse(ini.Read("CaptureH"), out int h) ||
+                w <= 0 ||
+                h <= 0)
+            {
+                return false;
+            }
+
+            displayArea = new Rectangle(x, y, w, h);
+
+            if (int.TryParse(ini.Read("CapturePixelX"), out int px) &&
+                int.TryParse(ini.Read("CapturePixelY"), out int py) &&
+                int.TryParse(ini.Read("CapturePixelW"), out int pw) &&
+                int.TryParse(ini.Read("CapturePixelH"), out int ph) &&
+                pw > 0 &&
+                ph > 0)
+            {
+                pixelArea = new Rectangle(px, py, pw, ph);
+            }
+            else
+            {
+                pixelArea = ConvertDisplayAreaToPixels(displayArea);
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -470,6 +470,10 @@ namespace GameTranslator
                 }
 
                 performanceStats.Outcome = performanceStats.TranslatedLineCount > 0 ? "Translated" : "NoTranslatableLines";
+                if (performanceStats.TranslatedLineCount > 0)
+                {
+                    TryAutoCopyTranslationResult();
+                }
             }
             catch (Exception ex)
             {

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml
@@ -14,7 +14,7 @@
         <StackPanel Margin="15">
             <!-- 단축키와 현재 자동 번역 모드를 표시하는 상단 안내 영역입니다. MainWindow.Hotkeys.cs에서 동적으로 갱신합니다. -->
             <TextBlock x:Name="TxtHotkeyGuide"
-                       Text="[Ctrl+7] 이동  [Ctrl+8] 영역  [Ctrl+9] 번역  [Ctrl+0] 자동"
+                       Text="[Ctrl+8] 설정  [Ctrl+9] 번역  [Ctrl+0] 자동"
                        TextWrapping="Wrap"
                        Foreground="#FFCC00"
                        FontSize="11"

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -45,10 +45,11 @@ namespace GameTranslator
         private string gameLang = "ko";
         private string targetLang = "ko";
 
-        private uint modMove, modArea, modTrans, modAuto, modToggle, modCopy, modLog, modOcrDiag, modHotkeyGuide;
-        private uint keyMove, keyArea, keyTrans, keyAuto, keyToggle, keyCopy, keyLog, keyOcrDiag, keyHotkeyGuide;
+        private uint modTrans, modAuto, modSettings;
+        private uint keyTrans, keyAuto, keySettings;
 
         private TranslationEngineMode currentTranslationEngineMode = TranslationEngineMode.Google;
+        private ConfiguredOcrEngine currentConfiguredOcrEngine = ConfiguredOcrEngine.All;
 
         private DispatcherTimer autoTranslateTimer;
         // 🌟 [추가] 최상단 강제 유지 타이머
@@ -59,7 +60,6 @@ namespace GameTranslator
 
         private AutoTranslateMode autoTranslateMode = AutoTranslateMode.Off;
         private bool isAutoTranslating = false;
-        private bool isHotkeyGuideExpanded = false;
         private string lastRawTextCombined = "";
         private string hotkeyWarningMessage = "";
 

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
@@ -182,7 +182,7 @@ namespace GameTranslator
             string differenceSummary = BuildRecommendedPresetDifference(preset);
             ApplyRecommendedPreset(preset);
             MessageBox.Show(
-                $"'{preset.DisplayName}' 추천 프리셋 값을 입력칸에 반영했습니다.\n\n변경 예정값:\n{differenceSummary}\n\n저장하려면 [저장 및 게임 시작]을 눌러주세요. 사용자 프리셋으로 저장하려면 프리셋 이름을 직접 입력한 뒤 [프리셋 저장]을 눌러주세요.",
+                $"'{preset.DisplayName}' 추천 프리셋 값을 입력칸에 반영했습니다.\n\n변경 예정값:\n{differenceSummary}\n\n저장하려면 [저장]을 눌러주세요. 사용자 프리셋으로 저장하려면 프리셋 이름을 직접 입력한 뒤 [프리셋 저장]을 눌러주세요.",
                 "추천 프리셋 적용",
                 MessageBoxButton.OK,
                 MessageBoxImage.Information);
@@ -226,7 +226,7 @@ namespace GameTranslator
         /// 선택한 프리셋 값을 환경설정 UI에 불러옵니다.
         /// <paramref name="sender"/>는 불러오기 버튼이고,
         /// <paramref name="e"/>는 버튼 클릭 이벤트 정보입니다.
-        /// 저장 및 게임 시작을 눌러야 실제 실행 설정으로 확정됩니다.
+        /// 저장을 눌러야 실제 실행 설정으로 확정됩니다.
         /// </summary>
         private void BtnLoadPreset_Click(object sender, RoutedEventArgs e)
         {
@@ -238,7 +238,7 @@ namespace GameTranslator
             }
 
             LoadPreset(presetName);
-            MessageBox.Show($"프리셋 '{presetName}'을 불러왔습니다.\n저장 및 게임 시작을 누르면 적용됩니다.", "프리셋 불러오기", MessageBoxButton.OK, MessageBoxImage.Information);
+            MessageBox.Show($"프리셋 '{presetName}'을 불러왔습니다.\n저장을 누르면 적용됩니다.", "프리셋 불러오기", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
         /// <summary>
@@ -286,23 +286,20 @@ namespace GameTranslator
             _ini.Write("AutoTranslateInterval", SettingsValueNormalizer.NormalizeAutoTranslateInterval(TxtInterval?.Text).ToString(), section);
             _ini.Write("ResultDisplayMode", GetSelectedTag(ComboResultDisplayMode, SettingsService.DefaultResultDisplayMode), section);
             _ini.Write("ResultHistoryLimit", SettingsValueNormalizer.NormalizeResultHistoryLimit(TxtResultHistoryLimit?.Text).ToString(), section);
+            _ini.Write("TranslationResultAutoClearSeconds", SettingsValueNormalizer.NormalizeTranslationResultAutoClearSeconds(TxtTranslationResultAutoClearSeconds?.Text).ToString(), section);
             _ini.Write("SaveDebugImages", CheckSaveDebugImages?.IsChecked == true ? "true" : "false", section);
+            _ini.Write("AutoCopyTranslationResult", CheckAutoCopyTranslationResult?.IsChecked == true ? "true" : "false", section);
             _ini.Write("TranslationContentMode", GetSelectedTranslationContentModeTag(), section);
             _ini.Write("TranslationEngine", GetSelectedTag(ComboTranslationEngine, SettingsService.DefaultTranslationEngine), section);
+            _ini.Write("OcrEngineSelection", GetSelectedTag(ComboConfiguredOcrEngine, SettingsService.DefaultOcrEngineSelection), section);
             _ini.Write("GeminiModel", _settingsService.NormalizeGeminiModel(TxtGeminiModel?.Text), section);
             _ini.Write("LocalLlmEndpoint", _settingsService.NormalizeLocalLlmEndpoint(TxtLocalLlmEndpoint?.Text), section);
             _ini.Write("LocalLlmModel", _settingsService.NormalizeLocalLlmModel(TxtLocalLlmModel?.Text), section);
             _ini.Write("LocalLlmTimeoutSeconds", _settingsService.NormalizeLocalLlmTimeoutSeconds(TxtLocalLlmTimeout?.Text).ToString(), section);
             _ini.Write("LocalLlmMaxTokens", _settingsService.NormalizeLocalLlmMaxTokens(TxtLocalLlmMaxTokens?.Text).ToString(), section);
-            _ini.Write("Key_MoveLock", TxtKeyMove.Text, section);
-            _ini.Write("Key_AreaSelect", TxtKeyArea.Text, section);
+            _ini.Write("Key_OpenSettings", TxtKeySettings.Text, section);
             _ini.Write("Key_Translate", TxtKeyTrans.Text, section);
             _ini.Write("Key_AutoTranslate", TxtKeyAuto.Text, section);
-            _ini.Write("Key_ToggleEngine", TxtKeyToggle.Text, section);
-            _ini.Write("Key_CopyResult", TxtKeyCopy.Text, section);
-            _ini.Write("Key_LogViewer", TxtKeyLog.Text, section);
-            _ini.Write("Key_OcrDiagnostic", TxtKeyOcrDiagnostic.Text, section);
-            _ini.Write("Key_HotkeyGuideToggle", TxtKeyHotkeyGuide.Text, section);
 
             foreach (string key in PresetSettingKeys)
             {
@@ -331,24 +328,23 @@ namespace GameTranslator
             TxtInterval.Text = SettingsValueNormalizer.NormalizeAutoTranslateInterval(ReadPresetValue(section, "AutoTranslateInterval", "5")).ToString();
             SetComboByTag(ComboResultDisplayMode, ReadPresetValue(section, "ResultDisplayMode", SettingsService.DefaultResultDisplayMode));
             TxtResultHistoryLimit.Text = SettingsValueNormalizer.NormalizeResultHistoryLimit(ReadPresetValue(section, "ResultHistoryLimit", "5")).ToString();
+            TxtTranslationResultAutoClearSeconds.Text = SettingsValueNormalizer.NormalizeTranslationResultAutoClearSeconds(ReadPresetValue(section, "TranslationResultAutoClearSeconds", "0")).ToString();
             CheckSaveDebugImages.IsChecked = _settingsService.IsEnabled(ReadPresetValue(section, "SaveDebugImages", "false"));
+            CheckAutoCopyTranslationResult.IsChecked = _settingsService.IsEnabledOrDefault(
+                ReadPresetValue(section, "AutoCopyTranslationResult", SettingsService.DefaultAutoCopyTranslationResult),
+                _settingsService.IsEnabled(SettingsService.DefaultAutoCopyTranslationResult));
             ApplyTranslationContentMode(_settingsService.NormalizeTranslationContentMode(ReadPresetValue(section, "TranslationContentMode", SettingsService.DefaultTranslationContentMode)));
             SetComboByTag(ComboTranslationEngine, _settingsService.GetTranslationEngineTag(_settingsService.NormalizeTranslationEngineMode(ReadPresetValue(section, "TranslationEngine", SettingsService.DefaultTranslationEngine))));
+            SetComboByTag(ComboConfiguredOcrEngine, _settingsService.GetConfiguredOcrEngineTag(_settingsService.NormalizeConfiguredOcrEngine(ReadPresetValue(section, "OcrEngineSelection", SettingsService.DefaultOcrEngineSelection))));
             TxtGeminiModel.Text = _settingsService.NormalizeGeminiModel(ReadPresetValue(section, "GeminiModel", SettingsService.DefaultGeminiModel));
             TxtLocalLlmEndpoint.Text = _settingsService.NormalizeLocalLlmEndpoint(ReadPresetValue(section, "LocalLlmEndpoint", SettingsService.DefaultLocalLlmEndpoint));
             TxtLocalLlmModel.Text = _settingsService.NormalizeLocalLlmModel(ReadPresetValue(section, "LocalLlmModel", SettingsService.DefaultLocalLlmModel));
             TxtLocalLlmTimeout.Text = _settingsService.NormalizeLocalLlmTimeoutSeconds(ReadPresetValue(section, "LocalLlmTimeoutSeconds", SettingsService.DefaultLocalLlmTimeoutSeconds.ToString())).ToString();
             TxtLocalLlmMaxTokens.Text = _settingsService.NormalizeLocalLlmMaxTokens(ReadPresetValue(section, "LocalLlmMaxTokens", SettingsService.DefaultLocalLlmMaxTokens.ToString())).ToString();
             DefaultHotkeys defaults = _settingsService.GetDefaultHotkeys();
-            TxtKeyMove.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_MoveLock", defaults.MoveLock), defaults.MoveLock);
-            TxtKeyArea.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_AreaSelect", defaults.AreaSelect), defaults.AreaSelect);
+            TxtKeySettings.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_OpenSettings", defaults.OpenSettings), defaults.OpenSettings);
             TxtKeyTrans.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_Translate", defaults.Translate), defaults.Translate);
             TxtKeyAuto.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_AutoTranslate", defaults.AutoTranslate), defaults.AutoTranslate);
-            TxtKeyToggle.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_ToggleEngine", defaults.ToggleEngine), defaults.ToggleEngine);
-            TxtKeyCopy.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_CopyResult", defaults.CopyResult), defaults.CopyResult);
-            TxtKeyLog.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_LogViewer", defaults.LogViewer), defaults.LogViewer);
-            TxtKeyOcrDiagnostic.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_OcrDiagnostic", defaults.OcrDiagnostic), defaults.OcrDiagnostic);
-            TxtKeyHotkeyGuide.Text = _settingsService.NormalizeHotkey(ReadPresetValue(section, "Key_HotkeyGuideToggle", defaults.HotkeyGuideToggle), defaults.HotkeyGuideToggle);
 
             foreach (string key in PresetSettingKeys)
             {

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="GameTranslator.OptionSelector"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="GameChatTranslator 환경 설정" Width="1300" Height="900"
+        Title="GameChatTranslator 환경 설정" Width="1420" Height="920"
         WindowStartupLocation="CenterScreen" Topmost="True" Background="#1E1E1E" Foreground="White" ResizeMode="NoResize">
 
     <Window.Resources>
@@ -23,7 +23,7 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="20">
             <TextBlock Text="⚙️ 초기 환경 설정" FontSize="20" FontWeight="Bold" Foreground="LimeGreen" HorizontalAlignment="Center" Margin="0,0,0,6"/>
-            <TextBlock Text="자주 쓰는 설정부터 번역 엔진 설정까지 순서대로 정리했습니다. 변경한 값은 아래 저장 버튼을 눌러야 적용됩니다."
+            <TextBlock Text="자주 쓰는 설정부터 번역 엔진 설정까지 순서대로 정리했습니다. 저장 버튼을 누르면 현재 실행 중인 오버레이에도 즉시 반영됩니다."
                        TextWrapping="Wrap"
                        TextAlignment="Center"
                        Foreground="#CCC"
@@ -292,6 +292,25 @@
 
                     <GroupBox Header="OCR 테스트 / 진단" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
                         <StackPanel Margin="10">
+                            <TextBlock Text="진단 점수에 사용할 OCR 엔진:"
+                                       Margin="0,0,0,5"
+                                       Foreground="#CCC"/>
+                            <ComboBox x:Name="ComboConfiguredOcrEngine"
+                                      Height="24"
+                                      Margin="0,0,0,6"
+                                      Background="#333"
+                                      Foreground="Black">
+                                <ComboBoxItem Content="전체 비교" Tag="All"/>
+                                <ComboBoxItem Content="Windows OCR" Tag="WindowsOcr"/>
+                                <ComboBoxItem Content="Tesseract" Tag="Tesseract"/>
+                                <ComboBoxItem Content="EasyOCR" Tag="EasyOcr"/>
+                                <ComboBoxItem Content="PaddleOCR" Tag="PaddleOcr"/>
+                            </ComboBox>
+                            <TextBlock Text="전체 비교는 모든 후보를 함께 채점하고, 나머지는 선택한 OCR 엔진만 점수 계산합니다."
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"
+                                       Foreground="#AFAFAF"
+                                       FontSize="11"/>
                             <TextBlock Text="현재 저장된 캡처 영역을 분석해 원본, 전처리 후보, OCR 결과, 후보 점수를 별도 창에서 비교합니다."
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,8"
@@ -355,22 +374,27 @@
 
                             <TextBlock x:Name="TxtAdvancedValidationStatus" TextWrapping="Wrap" FontSize="11" Foreground="#8BE28B" Margin="0,0,0,10"/>
 
-                            <CheckBox x:Name="CheckSaveDebugImages" Content="디버그 캡처 이미지 저장" Foreground="#CCC"/>
+                            <CheckBox x:Name="CheckSaveDebugImages" Content="디버그 캡처 이미지 저장" Foreground="#CCC" Margin="0,0,0,6"/>
+                            <CheckBox x:Name="CheckAutoCopyTranslationResult" Content="번역 결과 자동 복사" Foreground="#CCC"/>
 
                         </StackPanel>
                     </GroupBox>
 
                     <GroupBox Header="캡처 영역 (Capture Area)" Foreground="White" BorderBrush="#555" Margin="0,0,0,10">
-                        <StackPanel Margin="10" Orientation="Horizontal">
-                            <TextBlock x:Name="TxtAreaInfo" Text="저장된 영역: 없음 (좌측 하단 기본값)" VerticalAlignment="Center" Foreground="#CCC" Width="280"/>
-                            <Button x:Name="BtnResetArea" Content="영역 초기화" MinWidth="150" Padding="12,0" Height="28" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
+                        <StackPanel Margin="10">
+                            <TextBlock x:Name="TxtAreaInfo" Text="저장된 영역: 없음 (좌측 하단 기본값)" VerticalAlignment="Center" Foreground="#CCC" Margin="0,0,0,8"/>
+                            <WrapPanel>
+                                <Button x:Name="BtnSelectArea" Content="영역 다시 지정" MinWidth="118" Padding="10,0" Height="28" Margin="0,0,8,8" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnSelectArea_Click"/>
+                                <Button x:Name="BtnResetArea" Content="영역 초기화" MinWidth="118" Padding="10,0" Height="28" Margin="0,0,8,8" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnResetArea_Click"/>
+                                <Button x:Name="BtnToggleMoveLock" Content="이동 잠금 전환" MinWidth="118" Padding="10,0" Height="28" Margin="0,0,0,8" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnToggleMoveLock_Click"/>
+                            </WrapPanel>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>
 
                 <StackPanel Grid.Column="4">
                     <TextBlock Text="3. 단축키 / 번역 엔진" Style="{StaticResource SectionTitleStyle}"/>
-                    <TextBlock Text="기본 키 순서대로 단축키를 정리하고 Gemini / Local LLM 연결 정보를 입력합니다." Style="{StaticResource SectionHintStyle}"/>
+                    <TextBlock Text="전역 단축키는 자주 쓰는 3개만 유지하고, 나머지 기능은 이 설정창 버튼으로 옮깁니다." Style="{StaticResource SectionHintStyle}"/>
 
                     <GroupBox Header="단축키 설정 (기본 키 순서)" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
                         <StackPanel Margin="10">
@@ -383,40 +407,16 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
 
-                                <TextBlock Text="Ctrl+5  OCR 진단 화면 :" Grid.Row="0" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyOcrDiagnostic" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+                                <TextBlock Text="Ctrl+8  환경설정 :" Grid.Row="0" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeySettings" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
 
-                                <TextBlock Text="Ctrl+6  번역 복사 :" Grid.Row="1" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyCopy" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+                                <TextBlock Text="Ctrl+9  수동 번역 :" Grid.Row="1" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyTrans" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
 
-                                <TextBlock Text="Ctrl+7  이동/잠금 :" Grid.Row="2" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyMove" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                                <TextBlock Text="Ctrl+8  영역 설정 :" Grid.Row="3" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyArea" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                                <TextBlock Text="Ctrl+9  수동 번역 :" Grid.Row="4" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyTrans" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                                <TextBlock Text="Ctrl+0  자동 번역 모드 :" Grid.Row="5" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyAuto" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                                <TextBlock Text="Ctrl+-  엔진 전환 :" Grid.Row="6" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyToggle" Grid.Row="6" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                                <TextBlock Text="Ctrl+=  로그창 ON/OFF :" Grid.Row="7" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyLog" Grid.Row="7" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
-
-                                <TextBlock Text="Ctrl+F10  단축키 안내 :" Grid.Row="8" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
-                                <TextBox x:Name="TxtKeyHotkeyGuide" Grid.Row="8" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
+                                <TextBlock Text="Ctrl+0  자동 번역 모드 :" Grid.Row="2" VerticalAlignment="Center" Margin="0,0,10,5" Foreground="#CCC"/>
+                                <TextBox x:Name="TxtKeyAuto" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" PreviewKeyDown="Hotkey_PreviewKeyDown" IsReadOnly="True" Cursor="Pen" Background="#333" Foreground="White"/>
                             </Grid>
 
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,0,0">
@@ -427,7 +427,7 @@
 
                     <GroupBox Header="기본 번역 엔진" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
                         <StackPanel Margin="10">
-                            <TextBlock Text="프로그램 시작 시 사용할 번역 엔진입니다. 실행 중에는 Ctrl+-로 순환 전환할 수 있습니다." TextWrapping="Wrap" Margin="0,0,0,8" Foreground="#CCC"/>
+                            <TextBlock Text="프로그램 시작 시 사용할 번역 엔진입니다. 저장을 누르면 현재 실행 중인 번역 엔진에도 즉시 반영됩니다." TextWrapping="Wrap" Margin="0,0,0,8" Foreground="#CCC"/>
                             <ComboBox x:Name="ComboTranslationEngine" Height="24" Background="#333" Foreground="Black">
                                 <ComboBoxItem Content="Google 무료 번역" Tag="Google"/>
                                 <ComboBoxItem Content="Gemini AI 번역" Tag="Gemini"/>
@@ -493,7 +493,7 @@
             </Grid>
 
             <!-- 저장 버튼: 모든 설정을 config.ini에 기록하고 설정창을 정상 종료해 MainWindow 로딩을 계속합니다. -->
-            <Button x:Name="BtnSaveAndStart" Content="💾 저장 및 게임 시작" Height="40" Background="LimeGreen" Foreground="Black" FontWeight="Bold" FontSize="16" Click="BtnSaveAndStart_Click" Cursor="Hand" Margin="0,8,0,10"/>
+            <Button x:Name="BtnSaveAndStart" Content="💾 저장" Height="40" Background="LimeGreen" Foreground="Black" FontWeight="Bold" FontSize="16" Click="BtnSaveAndStart_Click" Cursor="Hand" Margin="0,8,0,10"/>
         </StackPanel>
     </ScrollViewer>
 </Window>

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -27,6 +27,7 @@ namespace GameTranslator
         private readonly SettingsService _settingsService = new SettingsService();
         private readonly OcrLanguageStatusFormatter _ocrLanguageStatusFormatter = new OcrLanguageStatusFormatter();
         private readonly DispatcherTimer _updateStatusResetTimer;
+        internal OptionSelectorPostAction RequestedActionAfterClose { get; private set; } = OptionSelectorPostAction.None;
 
         private static readonly (string Label, string Tag)[] OcrLanguageStatusTargets =
         {
@@ -96,15 +97,9 @@ namespace GameTranslator
             // [단축키 세팅]
             // 각 텍스트박스에 기존에 저장된 단축키 문자열을 넣어줍니다. (없으면 기본값 적용)
             DefaultHotkeys defaults = _settingsService.GetDefaultHotkeys();
-            TxtKeyMove.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_MoveLock"), defaults.MoveLock);
-            TxtKeyArea.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_AreaSelect"), defaults.AreaSelect);
+            TxtKeySettings.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_OpenSettings"), defaults.OpenSettings);
             TxtKeyTrans.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_Translate"), defaults.Translate);
             TxtKeyAuto.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_AutoTranslate"), defaults.AutoTranslate);
-            TxtKeyToggle.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_ToggleEngine"), defaults.ToggleEngine);
-            TxtKeyCopy.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_CopyResult"), defaults.CopyResult);
-            TxtKeyLog.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_LogViewer"), defaults.LogViewer);
-            TxtKeyOcrDiagnostic.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_OcrDiagnostic"), defaults.OcrDiagnostic);
-            TxtKeyHotkeyGuide.Text = _settingsService.NormalizeHotkey(_ini.Read("Key_HotkeyGuideToggle"), defaults.HotkeyGuideToggle);
 
             // [캡처 영역 세팅]
             // 메인 폼에서 사용자가 드래그하여 저장했던 X, Y 좌표와 넓이, 높이를 읽어옵니다.
@@ -137,6 +132,11 @@ namespace GameTranslator
                 TranslationEngineMode engineMode = _settingsService.NormalizeTranslationEngineMode(_ini.Read("TranslationEngine"));
                 SetComboByTag(ComboTranslationEngine, _settingsService.GetTranslationEngineTag(engineMode));
             }
+            if (ComboConfiguredOcrEngine != null)
+            {
+                ConfiguredOcrEngine configuredOcrEngine = _settingsService.NormalizeConfiguredOcrEngine(_ini.Read("OcrEngineSelection"));
+                SetComboByTag(ComboConfiguredOcrEngine, _settingsService.GetConfiguredOcrEngineTag(configuredOcrEngine));
+            }
             if (TxtResultHistoryLimit != null)
             {
                 TxtResultHistoryLimit.Text = SettingsValueNormalizer.NormalizeResultHistoryLimit(_ini.Read("ResultHistoryLimit")).ToString();
@@ -144,6 +144,12 @@ namespace GameTranslator
             if (TxtTranslationResultAutoClearSeconds != null)
             {
                 TxtTranslationResultAutoClearSeconds.Text = SettingsValueNormalizer.NormalizeTranslationResultAutoClearSeconds(_ini.Read("TranslationResultAutoClearSeconds")).ToString();
+            }
+            if (CheckAutoCopyTranslationResult != null)
+            {
+                CheckAutoCopyTranslationResult.IsChecked = _settingsService.IsEnabledOrDefault(
+                    _ini.Read("AutoCopyTranslationResult"),
+                    _settingsService.IsEnabled(SettingsService.DefaultAutoCopyTranslationResult));
             }
 
             GeminiKeySelection geminiKey = _settingsService.SelectGeminiKey(
@@ -479,20 +485,14 @@ namespace GameTranslator
         /// <summary>
         /// 단축키 입력칸을 최초 기본 단축키 값으로 되돌립니다.
         /// 이 함수는 UI TextBox 값만 바꾸며 config.ini에는 쓰지 않습니다.
-        /// 실제 저장은 사용자가 [저장 및 게임 시작] 버튼을 눌렀을 때 BtnSaveAndStart_Click에서 처리됩니다.
+        /// 실제 저장은 사용자가 [저장] 버튼을 눌렀을 때 BtnSaveAndStart_Click에서 처리됩니다.
         /// </summary>
         private void ApplyDefaultHotkeyValues()
         {
             DefaultHotkeys defaults = _settingsService.GetDefaultHotkeys();
-            TxtKeyMove.Text = defaults.MoveLock;
-            TxtKeyArea.Text = defaults.AreaSelect;
+            TxtKeySettings.Text = defaults.OpenSettings;
             TxtKeyTrans.Text = defaults.Translate;
             TxtKeyAuto.Text = defaults.AutoTranslate;
-            TxtKeyToggle.Text = defaults.ToggleEngine;
-            TxtKeyCopy.Text = defaults.CopyResult;
-            TxtKeyLog.Text = defaults.LogViewer;
-            TxtKeyOcrDiagnostic.Text = defaults.OcrDiagnostic;
-            TxtKeyHotkeyGuide.Text = defaults.HotkeyGuideToggle;
         }
 
         /// <summary>
@@ -504,7 +504,7 @@ namespace GameTranslator
         {
             ApplyDefaultHotkeyValues();
             System.Windows.MessageBox.Show(
-                "단축키 입력칸을 기본값으로 되돌렸습니다.\n저장하려면 [저장 및 게임 시작] 버튼을 눌러주세요.",
+                "단축키 입력칸을 기본값으로 되돌렸습니다.\n저장하려면 [저장] 버튼을 눌러주세요.",
                 "단축키 초기화",
                 MessageBoxButton.OK,
                 MessageBoxImage.Information);
@@ -527,29 +527,51 @@ namespace GameTranslator
         }
 
         /// <summary>
-        /// 환경설정창의 현재 입력값을 config.ini에 저장하고 메인 번역창 실행을 허용합니다.
-        /// <paramref name="sender"/>는 저장 및 게임 시작 버튼이고,
+        /// 설정을 저장한 뒤 환경설정창을 닫고 캡처 영역 선택 오버레이를 엽니다.
+        /// 모달 설정창이 열린 상태에서는 영역 선택이 어려우므로 닫힌 뒤 MainWindow가 후처리합니다.
+        /// </summary>
+        private void BtnSelectArea_Click(object sender, RoutedEventArgs e)
+        {
+            SaveSettingsToIni();
+            _mainWindow?.ApplyRuntimeSettingsFromIni();
+            RequestedActionAfterClose = OptionSelectorPostAction.StartAreaSelection;
+            DialogResult = true;
+            Close();
+        }
+
+        /// <summary>
+        /// 설정창에서 번역 오버레이의 이동 잠금 상태를 즉시 토글합니다.
+        /// </summary>
+        private void BtnToggleMoveLock_Click(object sender, RoutedEventArgs e)
+        {
+            _mainWindow?.ToggleMoveLockFromSettings();
+        }
+
+        /// <summary>
+        /// 환경설정창의 현재 입력값을 config.ini에 저장하고 메인 번역창에 즉시 반영합니다.
+        /// <paramref name="sender"/>는 저장 버튼이고,
         /// <paramref name="e"/>는 버튼 클릭 이벤트 정보입니다.
         /// </summary>
         private void BtnSaveAndStart_Click(object sender, RoutedEventArgs e)
         {
-            // 콤보박스에서 선택된 항목의 Tag 값(언어 코드)을 저장
-            _ini.Write("GameLanguage", ((ComboBoxItem)ComboGameLang.SelectedItem).Tag.ToString());
-            _ini.Write("TargetLanguage", ((ComboBoxItem)ComboTargetLang.SelectedItem).Tag.ToString());
+            SaveSettingsToIni();
+            _mainWindow?.ApplyRuntimeSettingsFromIni();
+            this.DialogResult = true;
+            this.Close();
+        }
 
-            // 슬라이더의 투명도 값을 정수로 변환하여 저장
+        private void SaveSettingsToIni()
+        {
+            RequestedActionAfterClose = OptionSelectorPostAction.None;
+
+            _ini.Write("GameLanguage", GetSelectedTag(ComboGameLang, "ko"));
+            _ini.Write("TargetLanguage", GetSelectedTag(ComboTargetLang, "ko"));
             _ini.Write("Opacity", ((int)SliderOpacity.Value).ToString());
 
-            // 지정된 단축키 문자열 저장
-            _ini.Write("Key_MoveLock", TxtKeyMove.Text);
-            _ini.Write("Key_AreaSelect", TxtKeyArea.Text);
-            _ini.Write("Key_Translate", TxtKeyTrans.Text);
-            _ini.Write("Key_AutoTranslate", TxtKeyAuto.Text);
-            _ini.Write("Key_ToggleEngine", TxtKeyToggle.Text); // 🌟 추가
-            _ini.Write("Key_CopyResult", TxtKeyCopy.Text);
-            _ini.Write("Key_LogViewer", TxtKeyLog.Text);
-            _ini.Write("Key_OcrDiagnostic", TxtKeyOcrDiagnostic.Text);
-            _ini.Write("Key_HotkeyGuideToggle", TxtKeyHotkeyGuide.Text);
+            DefaultHotkeys defaults = _settingsService.GetDefaultHotkeys();
+            _ini.Write("Key_OpenSettings", _settingsService.NormalizeHotkey(TxtKeySettings?.Text, defaults.OpenSettings));
+            _ini.Write("Key_Translate", _settingsService.NormalizeHotkey(TxtKeyTrans?.Text, defaults.Translate));
+            _ini.Write("Key_AutoTranslate", _settingsService.NormalizeHotkey(TxtKeyAuto?.Text, defaults.AutoTranslate));
 
             int scaleFactor = SettingsValueNormalizer.NormalizeScaleFactor(GetSelectedTag(ComboScale, SettingsValueNormalizer.DefaultScaleFactor.ToString()));
             _ini.Write("ScaleFactor", scaleFactor.ToString());
@@ -573,10 +595,11 @@ namespace GameTranslator
 
             _ini.Write("SaveDebugImages", CheckSaveDebugImages?.IsChecked == true ? "true" : "false");
             _ini.Write("CheckUpdatesOnStartup", CheckUpdatesOnStartup?.IsChecked == true ? "true" : "false");
+            _ini.Write("AutoCopyTranslationResult", CheckAutoCopyTranslationResult?.IsChecked == true ? "true" : "false");
             _ini.Write("TranslationContentMode", GetSelectedTranslationContentModeTag());
             _ini.Write("TranslationEngine", GetSelectedTag(ComboTranslationEngine, SettingsService.DefaultTranslationEngine));
+            _ini.Write("OcrEngineSelection", GetSelectedTag(ComboConfiguredOcrEngine, SettingsService.DefaultOcrEngineSelection));
             _ini.Write("GeminiKey", PasswordGeminiKey?.Password?.Trim() ?? "");
-
             _ini.Write("GeminiModel", _settingsService.NormalizeGeminiModel(TxtGeminiModel?.Text));
 
             _ini.Write("LocalLlmEndpoint", _settingsService.NormalizeLocalLlmEndpoint(TxtLocalLlmEndpoint?.Text));
@@ -588,10 +611,6 @@ namespace GameTranslator
             int localLlmMaxTokens = _settingsService.NormalizeLocalLlmMaxTokens(TxtLocalLlmMaxTokens?.Text);
             _ini.Write("LocalLlmMaxTokens", localLlmMaxTokens.ToString());
             if (TxtLocalLlmMaxTokens != null) TxtLocalLlmMaxTokens.Text = localLlmMaxTokens.ToString();
-
-            // DialogResult를 true로 설정하여 메인 창(MainWindow)에 정상 종료되었음을 알리고 창을 닫습니다.
-            this.DialogResult = true;
-            this.Close();
         }
 
         /// <summary>
@@ -759,5 +778,11 @@ namespace GameTranslator
         {
             _mainWindow?.ShowOcrDiagnosticWindow();
         }
+    }
+
+    internal enum OptionSelectorPostAction
+    {
+        None,
+        StartAreaSelection
     }
 }


### PR DESCRIPTION
## 변경 내용
- 단축키를 수동 번역, 자동 번역 토글, 환경설정 열기 3개만 유지
- 환경설정 창 크기를 1420x920으로 확대하고 번역 결과 자동 복사 옵션 추가
- 캡처 영역 재지정/이동 잠금 전환을 환경설정 창에서 바로 실행 가능하게 정리
- OCR 선택값을 환경설정에 추가하고 진단 점수 판독 범위에만 우선 적용
- 저장 시 OCR 선택, 단축키, 표시/타이머 설정이 즉시 반영되도록 runtime 적용 경로 정리

## 검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-settings-hotkeys-ocr