### PR TITLE
개선: OCR 진단 엔진 선택을 다중 체크박스로 변경

### DIFF
--- a/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
@@ -209,6 +209,38 @@ namespace GameChatTranslator.Tests
             Assert.Equal(expected, _service.GetConfiguredOcrEngineDisplayName(engine));
         }
 
+        [Theory]
+        [InlineData(null, new[] { ConfiguredOcrEngine.WindowsOcr, ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.EasyOcr, ConfiguredOcrEngine.PaddleOcr })]
+        [InlineData("", new[] { ConfiguredOcrEngine.WindowsOcr, ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.EasyOcr, ConfiguredOcrEngine.PaddleOcr })]
+        [InlineData("All", new[] { ConfiguredOcrEngine.WindowsOcr, ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.EasyOcr, ConfiguredOcrEngine.PaddleOcr })]
+        [InlineData("WindowsOcr", new[] { ConfiguredOcrEngine.WindowsOcr })]
+        [InlineData("Tesseract,EasyOcr", new[] { ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.EasyOcr })]
+        [InlineData("PaddleOCR|WindowsOcr", new[] { ConfiguredOcrEngine.WindowsOcr, ConfiguredOcrEngine.PaddleOcr })]
+        [InlineData("unknown", new[] { ConfiguredOcrEngine.WindowsOcr, ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.EasyOcr, ConfiguredOcrEngine.PaddleOcr })]
+        public void NormalizeConfiguredOcrEngineSelection_MapsLegacyAndMultiSelectValues(string rawValue, ConfiguredOcrEngine[] expected)
+        {
+            Assert.Equal(expected, _service.NormalizeConfiguredOcrEngineSelection(rawValue).ToArray());
+        }
+
+        [Theory]
+        [InlineData(new[] { ConfiguredOcrEngine.WindowsOcr, ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.EasyOcr, ConfiguredOcrEngine.PaddleOcr }, "All")]
+        [InlineData(new[] { ConfiguredOcrEngine.WindowsOcr }, "WindowsOcr")]
+        [InlineData(new[] { ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.PaddleOcr }, "Tesseract,PaddleOcr")]
+        [InlineData(new ConfiguredOcrEngine[0], "All")]
+        public void GetConfiguredOcrEngineSelectionTag_ReturnsNormalizedConfigValue(ConfiguredOcrEngine[] engines, string expected)
+        {
+            Assert.Equal(expected, _service.GetConfiguredOcrEngineSelectionTag(engines));
+        }
+
+        [Theory]
+        [InlineData(new[] { ConfiguredOcrEngine.WindowsOcr, ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.EasyOcr, ConfiguredOcrEngine.PaddleOcr }, "전체 비교")]
+        [InlineData(new[] { ConfiguredOcrEngine.WindowsOcr }, "Windows OCR")]
+        [InlineData(new[] { ConfiguredOcrEngine.Tesseract, ConfiguredOcrEngine.EasyOcr }, "Tesseract + EasyOCR")]
+        public void GetConfiguredOcrEngineSelectionDisplayName_ReturnsUserFacingLabel(ConfiguredOcrEngine[] engines, string expected)
+        {
+            Assert.Equal(expected, _service.GetConfiguredOcrEngineSelectionDisplayName(engines));
+        }
+
 
         [Theory]
         [InlineData("true")]

--- a/GameChatTranslator/Core/SettingsService.cs
+++ b/GameChatTranslator/Core/SettingsService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GameTranslator
 {
@@ -8,6 +10,14 @@ namespace GameTranslator
     /// </summary>
     public sealed class SettingsService
     {
+        private static readonly ConfiguredOcrEngine[] ConfiguredOcrEngineSelectionOrder =
+        {
+            ConfiguredOcrEngine.WindowsOcr,
+            ConfiguredOcrEngine.Tesseract,
+            ConfiguredOcrEngine.EasyOcr,
+            ConfiguredOcrEngine.PaddleOcr
+        };
+
         public const string DefaultGeminiModel = "gemini-2.5-flash";
         public const string DefaultLocalLlmEndpoint = "http://localhost:1234/v1/chat/completions";
         public const string DefaultLocalLlmModel = "qwen/qwen3.5-9b";
@@ -259,6 +269,89 @@ namespace GameTranslator
         }
 
         /// <summary>
+        /// OCR 진단 기본 선택 목록을 반환합니다.
+        /// 현재 기본값은 모든 OCR 엔진 전체 비교입니다.
+        /// </summary>
+        public IReadOnlyList<ConfiguredOcrEngine> GetDefaultConfiguredOcrEngineSelection()
+        {
+            return ConfiguredOcrEngineSelectionOrder;
+        }
+
+        /// <summary>
+        /// 저장된 OCR 엔진 선택 문자열을 다중 선택 목록으로 변환합니다.
+        /// 구버전 단일 값과 All 값도 함께 읽고, 알 수 없는 값이면 전체 비교로 되돌립니다.
+        /// </summary>
+        public IReadOnlyList<ConfiguredOcrEngine> NormalizeConfiguredOcrEngineSelection(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return ConfiguredOcrEngineSelectionOrder;
+            }
+
+            string normalized = value.Trim();
+            if (normalized.Equals("All", StringComparison.OrdinalIgnoreCase))
+            {
+                return ConfiguredOcrEngineSelectionOrder;
+            }
+
+            var requested = new HashSet<ConfiguredOcrEngine>();
+            string[] tokens = normalized.Split(new[] { ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string token in tokens)
+            {
+                if (TryParseConfiguredOcrEngine(token, out ConfiguredOcrEngine engine))
+                {
+                    requested.Add(engine);
+                }
+            }
+
+            if (requested.Count == 0)
+            {
+                if (TryParseConfiguredOcrEngine(normalized, out ConfiguredOcrEngine singleEngine))
+                {
+                    requested.Add(singleEngine);
+                }
+                else
+                {
+                    return ConfiguredOcrEngineSelectionOrder;
+                }
+            }
+
+            return ConfiguredOcrEngineSelectionOrder
+                .Where(requested.Contains)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// OCR 진단 다중 선택 목록을 config.ini에 저장할 문자열로 변환합니다.
+        /// 전체 선택이면 All, 일부 선택이면 쉼표 구분 태그 목록을 저장합니다.
+        /// </summary>
+        public string GetConfiguredOcrEngineSelectionTag(IEnumerable<ConfiguredOcrEngine> engines)
+        {
+            ConfiguredOcrEngine[] normalizedSelection = NormalizeConfiguredOcrEngineSelectionInternal(engines);
+            if (normalizedSelection.Length == ConfiguredOcrEngineSelectionOrder.Length)
+            {
+                return DefaultOcrEngineSelection;
+            }
+
+            return string.Join(",", normalizedSelection.Select(GetConfiguredOcrEngineTag));
+        }
+
+        /// <summary>
+        /// OCR 진단 다중 선택 목록을 설정창과 진단 요약에 표시할 사용자용 문자열로 변환합니다.
+        /// 전체 선택이면 전체 비교, 일부 선택이면 엔진 이름을 + 로 연결합니다.
+        /// </summary>
+        public string GetConfiguredOcrEngineSelectionDisplayName(IEnumerable<ConfiguredOcrEngine> engines)
+        {
+            ConfiguredOcrEngine[] normalizedSelection = NormalizeConfiguredOcrEngineSelectionInternal(engines);
+            if (normalizedSelection.Length == ConfiguredOcrEngineSelectionOrder.Length)
+            {
+                return "전체 비교";
+            }
+
+            return string.Join(" + ", normalizedSelection.Select(GetConfiguredOcrEngineDisplayName));
+        }
+
+        /// <summary>
         /// OCR 엔진 enum을 설정창과 진단 요약에 표시할 사용자용 이름으로 변환합니다.
         /// </summary>
         public string GetConfiguredOcrEngineDisplayName(ConfiguredOcrEngine engine)
@@ -348,6 +441,57 @@ namespace GameTranslator
                 DefaultKeyOcrDiagnostic,
                 DefaultKeyHotkeyGuideToggle,
                 DefaultKeyOpenSettings);
+        }
+
+        private ConfiguredOcrEngine[] NormalizeConfiguredOcrEngineSelectionInternal(IEnumerable<ConfiguredOcrEngine> engines)
+        {
+            var selected = new HashSet<ConfiguredOcrEngine>((engines ?? Enumerable.Empty<ConfiguredOcrEngine>())
+                .Where(engine => engine != ConfiguredOcrEngine.All));
+
+            if (selected.Count == 0)
+            {
+                return ConfiguredOcrEngineSelectionOrder;
+            }
+
+            return ConfiguredOcrEngineSelectionOrder
+                .Where(selected.Contains)
+                .ToArray();
+        }
+
+        private bool TryParseConfiguredOcrEngine(string value, out ConfiguredOcrEngine engine)
+        {
+            engine = ConfiguredOcrEngine.All;
+            string normalized = (value ?? "").Trim();
+
+            if (normalized.Equals("WindowsOcr", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("Windows", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("WinOcr", StringComparison.OrdinalIgnoreCase))
+            {
+                engine = ConfiguredOcrEngine.WindowsOcr;
+                return true;
+            }
+
+            if (normalized.Equals("Tesseract", StringComparison.OrdinalIgnoreCase))
+            {
+                engine = ConfiguredOcrEngine.Tesseract;
+                return true;
+            }
+
+            if (normalized.Equals("EasyOcr", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("EasyOCR", StringComparison.OrdinalIgnoreCase))
+            {
+                engine = ConfiguredOcrEngine.EasyOcr;
+                return true;
+            }
+
+            if (normalized.Equals("PaddleOcr", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("PaddleOCR", StringComparison.OrdinalIgnoreCase))
+            {
+                engine = ConfiguredOcrEngine.PaddleOcr;
+                return true;
+            }
+
+            return false;
         }
     }
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.OcrDiagnostics.cs
@@ -57,7 +57,7 @@ namespace GameTranslator
 
             int threshold = SettingsValueNormalizer.NormalizeThreshold(ini.Read("Threshold"));
             int scaleFactor = SettingsValueNormalizer.NormalizeScaleFactor(ini.Read("ScaleFactor"));
-            ConfiguredOcrEngine configuredOcrEngine = ReadConfiguredOcrEngineSelection();
+            IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines = ReadConfiguredOcrEngineSelection();
 
             var result = new OcrDiagnosticResult
             {
@@ -65,7 +65,7 @@ namespace GameTranslator
                 Threshold = threshold,
                 ScaleFactor = scaleFactor,
                 CaptureArea = GetCapturePixelArea(),
-                Metadata = BuildOcrDiagnosticMetadata(configuredOcrEngine)
+                Metadata = BuildOcrDiagnosticMetadata(configuredOcrEngines)
             };
 
             Stopwatch totalStopwatch = Stopwatch.StartNew();
@@ -102,7 +102,7 @@ namespace GameTranslator
             {
                 OcrDiagnosticCandidate bestCandidate = null;
 
-                if (ShouldIncludeWindowsOcrCandidates(configuredOcrEngine))
+                if (ShouldIncludeWindowsOcrCandidates(configuredOcrEngines))
                 {
                     foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
                     {
@@ -149,17 +149,17 @@ namespace GameTranslator
                 }
 
                 var externalSummaries = new List<ExternalOcrDiagnosticSummary>();
-                if (ShouldIncludeTesseractCandidates(configuredOcrEngine))
+                if (ShouldIncludeTesseractCandidates(configuredOcrEngines))
                 {
                     externalSummaries.Add(await TryBuildTesseractDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()));
                 }
 
-                if (ShouldIncludeEasyOcrCandidates(configuredOcrEngine))
+                if (ShouldIncludeEasyOcrCandidates(configuredOcrEngines))
                 {
                     externalSummaries.Add(await TryBuildEasyOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()));
                 }
 
-                if (ShouldIncludePaddleOcrCandidates(configuredOcrEngine))
+                if (ShouldIncludePaddleOcrCandidates(configuredOcrEngines))
                 {
                     externalSummaries.Add(await TryBuildPaddleOcrDiagnosticCandidatesAsync(preprocessedImages, ReadTranslationContentMode()));
                 }
@@ -676,7 +676,7 @@ namespace GameTranslator
         /// OCR 진단 ZIP에 포함할 앱 버전, 언어 설정, OCR 모드, 언어팩 상태를 문자열 모델로 만듭니다.
         /// Exporter가 WinRT/Assembly/IniFile에 의존하지 않도록 MainWindow에서 현재 런타임 값을 채워 전달합니다.
         /// </summary>
-        private OcrDiagnosticMetadata BuildOcrDiagnosticMetadata(ConfiguredOcrEngine configuredOcrEngine)
+        private OcrDiagnosticMetadata BuildOcrDiagnosticMetadata(IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines)
         {
             var metadata = new OcrDiagnosticMetadata
             {
@@ -685,7 +685,7 @@ namespace GameTranslator
                 BuildCommit = CurrentBuildCommit,
                 GameLanguage = gameLang,
                 TargetLanguage = targetLang,
-                ConfiguredOcrEngine = settingsService.GetConfiguredOcrEngineDisplayName(configuredOcrEngine),
+                ConfiguredOcrEngine = settingsService.GetConfiguredOcrEngineSelectionDisplayName(configuredOcrEngines),
                 AutoTranslateMode = GetAutoTranslateModeLabel(),
                 DiagnosticProcessingMode = GetOcrProcessingModeLabel(OcrProcessingMode.Accurate),
                 SaveDebugImages = settingsService.IsEnabled(ini.Read("SaveDebugImages")) ? "true" : "false",
@@ -751,24 +751,24 @@ namespace GameTranslator
             }
         }
 
-        private static bool ShouldIncludeWindowsOcrCandidates(ConfiguredOcrEngine configuredOcrEngine)
+        private static bool ShouldIncludeWindowsOcrCandidates(IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines)
         {
-            return configuredOcrEngine == ConfiguredOcrEngine.All || configuredOcrEngine == ConfiguredOcrEngine.WindowsOcr;
+            return configuredOcrEngines.Contains(ConfiguredOcrEngine.WindowsOcr);
         }
 
-        private static bool ShouldIncludeTesseractCandidates(ConfiguredOcrEngine configuredOcrEngine)
+        private static bool ShouldIncludeTesseractCandidates(IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines)
         {
-            return configuredOcrEngine == ConfiguredOcrEngine.All || configuredOcrEngine == ConfiguredOcrEngine.Tesseract;
+            return configuredOcrEngines.Contains(ConfiguredOcrEngine.Tesseract);
         }
 
-        private static bool ShouldIncludeEasyOcrCandidates(ConfiguredOcrEngine configuredOcrEngine)
+        private static bool ShouldIncludeEasyOcrCandidates(IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines)
         {
-            return configuredOcrEngine == ConfiguredOcrEngine.All || configuredOcrEngine == ConfiguredOcrEngine.EasyOcr;
+            return configuredOcrEngines.Contains(ConfiguredOcrEngine.EasyOcr);
         }
 
-        private static bool ShouldIncludePaddleOcrCandidates(ConfiguredOcrEngine configuredOcrEngine)
+        private static bool ShouldIncludePaddleOcrCandidates(IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines)
         {
-            return configuredOcrEngine == ConfiguredOcrEngine.All || configuredOcrEngine == ConfiguredOcrEngine.PaddleOcr;
+            return configuredOcrEngines.Contains(ConfiguredOcrEngine.PaddleOcr);
         }
 
         private string FormatRectangle(Rectangle rectangle)

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
@@ -160,7 +160,7 @@ namespace GameTranslator
 
             EnsureNormalizedSetting("ResultHistoryLimit", SettingsValueNormalizer.NormalizeResultHistoryLimit(ini.Read("ResultHistoryLimit")).ToString());
             EnsureNormalizedSetting("TranslationResultAutoClearSeconds", SettingsValueNormalizer.NormalizeTranslationResultAutoClearSeconds(ini.Read("TranslationResultAutoClearSeconds")).ToString());
-            EnsureNormalizedSetting("OcrEngineSelection", settingsService.GetConfiguredOcrEngineTag(settingsService.NormalizeConfiguredOcrEngine(ini.Read("OcrEngineSelection"))));
+            EnsureNormalizedSetting("OcrEngineSelection", settingsService.GetConfiguredOcrEngineSelectionTag(settingsService.NormalizeConfiguredOcrEngineSelection(ini.Read("OcrEngineSelection"))));
             EnsureNormalizedSetting("AutoCopyTranslationResult", settingsService.IsEnabled(ini.Read("AutoCopyTranslationResult"))
                 ? "true"
                 : SettingsService.DefaultAutoCopyTranslationResult);
@@ -228,11 +228,11 @@ namespace GameTranslator
 
         /// <summary>
         /// OCR 진단에서 어떤 엔진 후보를 점수 계산 대상으로 사용할지 읽습니다.
-        /// All은 전체 비교 모드이고, 나머지는 선택한 엔진만 평가합니다.
+        /// 구버전 단일 값과 All도 함께 읽고, 현재는 다중 선택 목록으로 반환합니다.
         /// </summary>
-        private ConfiguredOcrEngine ReadConfiguredOcrEngineSelection()
+        private IReadOnlyList<ConfiguredOcrEngine> ReadConfiguredOcrEngineSelection()
         {
-            return settingsService.NormalizeConfiguredOcrEngine(ini.Read("OcrEngineSelection"));
+            return settingsService.NormalizeConfiguredOcrEngineSelection(ini.Read("OcrEngineSelection"));
         }
 
         /// <summary>
@@ -254,7 +254,6 @@ namespace GameTranslator
         {
             gameLang = ini.Read("GameLanguage") ?? "ko";
             targetLang = ini.Read("TargetLanguage") ?? "ko";
-            currentConfiguredOcrEngine = ReadConfiguredOcrEngineSelection();
 
             TranslationEngineMode configuredEngine = ReadTranslationEngineMode();
             string geminiKey = ReadGeminiKey();

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -49,7 +49,6 @@ namespace GameTranslator
         private uint keyTrans, keyAuto, keySettings;
 
         private TranslationEngineMode currentTranslationEngineMode = TranslationEngineMode.Google;
-        private ConfiguredOcrEngine currentConfiguredOcrEngine = ConfiguredOcrEngine.All;
 
         private DispatcherTimer autoTranslateTimer;
         // 🌟 [추가] 최상단 강제 유지 타이머

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
@@ -142,6 +142,12 @@ namespace GameTranslator
         /// </summary>
         private void BtnSavePreset_Click(object sender, RoutedEventArgs e)
         {
+            if (!TryGetSelectedConfiguredOcrEngines(out IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines))
+            {
+                MessageBox.Show("프리셋에 저장할 OCR 엔진을 최소 1개 선택해 주세요.", "프리셋 저장", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
             string presetName = GetSelectedPresetName();
             if (string.IsNullOrWhiteSpace(presetName))
             {
@@ -149,7 +155,7 @@ namespace GameTranslator
                 return;
             }
 
-            SavePreset(presetName);
+            SavePreset(presetName, configuredOcrEngines);
 
             List<string> names = ReadPresetNames();
             if (!names.Contains(presetName, StringComparer.OrdinalIgnoreCase))
@@ -274,7 +280,7 @@ namespace GameTranslator
         /// <paramref name="presetName"/>은 저장할 프리셋 이름입니다.
         /// Gemini API Key는 보안상 프리셋에 포함하지 않습니다.
         /// </summary>
-        private void SavePreset(string presetName)
+        private void SavePreset(string presetName, IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines)
         {
             string section = GetPresetSectionName(presetName);
 
@@ -291,7 +297,7 @@ namespace GameTranslator
             _ini.Write("AutoCopyTranslationResult", CheckAutoCopyTranslationResult?.IsChecked == true ? "true" : "false", section);
             _ini.Write("TranslationContentMode", GetSelectedTranslationContentModeTag(), section);
             _ini.Write("TranslationEngine", GetSelectedTag(ComboTranslationEngine, SettingsService.DefaultTranslationEngine), section);
-            _ini.Write("OcrEngineSelection", GetSelectedTag(ComboConfiguredOcrEngine, SettingsService.DefaultOcrEngineSelection), section);
+            _ini.Write("OcrEngineSelection", _settingsService.GetConfiguredOcrEngineSelectionTag(configuredOcrEngines), section);
             _ini.Write("GeminiModel", _settingsService.NormalizeGeminiModel(TxtGeminiModel?.Text), section);
             _ini.Write("LocalLlmEndpoint", _settingsService.NormalizeLocalLlmEndpoint(TxtLocalLlmEndpoint?.Text), section);
             _ini.Write("LocalLlmModel", _settingsService.NormalizeLocalLlmModel(TxtLocalLlmModel?.Text), section);
@@ -335,7 +341,7 @@ namespace GameTranslator
                 _settingsService.IsEnabled(SettingsService.DefaultAutoCopyTranslationResult));
             ApplyTranslationContentMode(_settingsService.NormalizeTranslationContentMode(ReadPresetValue(section, "TranslationContentMode", SettingsService.DefaultTranslationContentMode)));
             SetComboByTag(ComboTranslationEngine, _settingsService.GetTranslationEngineTag(_settingsService.NormalizeTranslationEngineMode(ReadPresetValue(section, "TranslationEngine", SettingsService.DefaultTranslationEngine))));
-            SetComboByTag(ComboConfiguredOcrEngine, _settingsService.GetConfiguredOcrEngineTag(_settingsService.NormalizeConfiguredOcrEngine(ReadPresetValue(section, "OcrEngineSelection", SettingsService.DefaultOcrEngineSelection))));
+            ApplyConfiguredOcrEngineSelection(_settingsService.NormalizeConfiguredOcrEngineSelection(ReadPresetValue(section, "OcrEngineSelection", SettingsService.DefaultOcrEngineSelection)));
             TxtGeminiModel.Text = _settingsService.NormalizeGeminiModel(ReadPresetValue(section, "GeminiModel", SettingsService.DefaultGeminiModel));
             TxtLocalLlmEndpoint.Text = _settingsService.NormalizeLocalLlmEndpoint(ReadPresetValue(section, "LocalLlmEndpoint", SettingsService.DefaultLocalLlmEndpoint));
             TxtLocalLlmModel.Text = _settingsService.NormalizeLocalLlmModel(ReadPresetValue(section, "LocalLlmModel", SettingsService.DefaultLocalLlmModel));

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -295,18 +295,13 @@
                             <TextBlock Text="진단 점수에 사용할 OCR 엔진:"
                                        Margin="0,0,0,5"
                                        Foreground="#CCC"/>
-                            <ComboBox x:Name="ComboConfiguredOcrEngine"
-                                      Height="24"
-                                      Margin="0,0,0,6"
-                                      Background="#333"
-                                      Foreground="Black">
-                                <ComboBoxItem Content="전체 비교" Tag="All"/>
-                                <ComboBoxItem Content="Windows OCR" Tag="WindowsOcr"/>
-                                <ComboBoxItem Content="Tesseract" Tag="Tesseract"/>
-                                <ComboBoxItem Content="EasyOCR" Tag="EasyOcr"/>
-                                <ComboBoxItem Content="PaddleOCR" Tag="PaddleOcr"/>
-                            </ComboBox>
-                            <TextBlock Text="전체 비교는 모든 후보를 함께 채점하고, 나머지는 선택한 OCR 엔진만 점수 계산합니다."
+                            <WrapPanel Margin="0,0,0,6">
+                                <CheckBox x:Name="CheckDiagnosticWindowsOcr" Content="Windows OCR" Foreground="#CCC" Margin="0,0,12,6"/>
+                                <CheckBox x:Name="CheckDiagnosticTesseract" Content="Tesseract" Foreground="#CCC" Margin="0,0,12,6"/>
+                                <CheckBox x:Name="CheckDiagnosticEasyOcr" Content="EasyOCR" Foreground="#CCC" Margin="0,0,12,6"/>
+                                <CheckBox x:Name="CheckDiagnosticPaddleOcr" Content="PaddleOCR" Foreground="#CCC" Margin="0,0,0,6"/>
+                            </WrapPanel>
+                            <TextBlock Text="선택한 OCR만 후보 생성과 점수 계산에 포함합니다. 모두 체크하면 기존 전체 비교와 같습니다."
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,8"
                                        Foreground="#AFAFAF"

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -132,11 +132,7 @@ namespace GameTranslator
                 TranslationEngineMode engineMode = _settingsService.NormalizeTranslationEngineMode(_ini.Read("TranslationEngine"));
                 SetComboByTag(ComboTranslationEngine, _settingsService.GetTranslationEngineTag(engineMode));
             }
-            if (ComboConfiguredOcrEngine != null)
-            {
-                ConfiguredOcrEngine configuredOcrEngine = _settingsService.NormalizeConfiguredOcrEngine(_ini.Read("OcrEngineSelection"));
-                SetComboByTag(ComboConfiguredOcrEngine, _settingsService.GetConfiguredOcrEngineTag(configuredOcrEngine));
-            }
+            ApplyConfiguredOcrEngineSelection(_settingsService.NormalizeConfiguredOcrEngineSelection(_ini.Read("OcrEngineSelection")));
             if (TxtResultHistoryLimit != null)
             {
                 TxtResultHistoryLimit.Text = SettingsValueNormalizer.NormalizeResultHistoryLimit(_ini.Read("ResultHistoryLimit")).ToString();
@@ -532,7 +528,7 @@ namespace GameTranslator
         /// </summary>
         private void BtnSelectArea_Click(object sender, RoutedEventArgs e)
         {
-            SaveSettingsToIni();
+            if (!SaveSettingsToIni()) return;
             _mainWindow?.ApplyRuntimeSettingsFromIni();
             RequestedActionAfterClose = OptionSelectorPostAction.StartAreaSelection;
             DialogResult = true;
@@ -554,15 +550,25 @@ namespace GameTranslator
         /// </summary>
         private void BtnSaveAndStart_Click(object sender, RoutedEventArgs e)
         {
-            SaveSettingsToIni();
+            if (!SaveSettingsToIni()) return;
             _mainWindow?.ApplyRuntimeSettingsFromIni();
             this.DialogResult = true;
             this.Close();
         }
 
-        private void SaveSettingsToIni()
+        private bool SaveSettingsToIni()
         {
             RequestedActionAfterClose = OptionSelectorPostAction.None;
+
+            if (!TryGetSelectedConfiguredOcrEngines(out IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines))
+            {
+                System.Windows.MessageBox.Show(
+                    "진단 점수에 사용할 OCR 엔진을 최소 1개 선택해 주세요.",
+                    "OCR 선택",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return false;
+            }
 
             _ini.Write("GameLanguage", GetSelectedTag(ComboGameLang, "ko"));
             _ini.Write("TargetLanguage", GetSelectedTag(ComboTargetLang, "ko"));
@@ -598,7 +604,7 @@ namespace GameTranslator
             _ini.Write("AutoCopyTranslationResult", CheckAutoCopyTranslationResult?.IsChecked == true ? "true" : "false");
             _ini.Write("TranslationContentMode", GetSelectedTranslationContentModeTag());
             _ini.Write("TranslationEngine", GetSelectedTag(ComboTranslationEngine, SettingsService.DefaultTranslationEngine));
-            _ini.Write("OcrEngineSelection", GetSelectedTag(ComboConfiguredOcrEngine, SettingsService.DefaultOcrEngineSelection));
+            _ini.Write("OcrEngineSelection", _settingsService.GetConfiguredOcrEngineSelectionTag(configuredOcrEngines));
             _ini.Write("GeminiKey", PasswordGeminiKey?.Password?.Trim() ?? "");
             _ini.Write("GeminiModel", _settingsService.NormalizeGeminiModel(TxtGeminiModel?.Text));
 
@@ -611,6 +617,29 @@ namespace GameTranslator
             int localLlmMaxTokens = _settingsService.NormalizeLocalLlmMaxTokens(TxtLocalLlmMaxTokens?.Text);
             _ini.Write("LocalLlmMaxTokens", localLlmMaxTokens.ToString());
             if (TxtLocalLlmMaxTokens != null) TxtLocalLlmMaxTokens.Text = localLlmMaxTokens.ToString();
+
+            return true;
+        }
+
+        private void ApplyConfiguredOcrEngineSelection(IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines)
+        {
+            HashSet<ConfiguredOcrEngine> selected = new HashSet<ConfiguredOcrEngine>(configuredOcrEngines ?? Array.Empty<ConfiguredOcrEngine>());
+            if (CheckDiagnosticWindowsOcr != null) CheckDiagnosticWindowsOcr.IsChecked = selected.Contains(ConfiguredOcrEngine.WindowsOcr);
+            if (CheckDiagnosticTesseract != null) CheckDiagnosticTesseract.IsChecked = selected.Contains(ConfiguredOcrEngine.Tesseract);
+            if (CheckDiagnosticEasyOcr != null) CheckDiagnosticEasyOcr.IsChecked = selected.Contains(ConfiguredOcrEngine.EasyOcr);
+            if (CheckDiagnosticPaddleOcr != null) CheckDiagnosticPaddleOcr.IsChecked = selected.Contains(ConfiguredOcrEngine.PaddleOcr);
+        }
+
+        private bool TryGetSelectedConfiguredOcrEngines(out IReadOnlyList<ConfiguredOcrEngine> configuredOcrEngines)
+        {
+            List<ConfiguredOcrEngine> selected = new List<ConfiguredOcrEngine>();
+            if (CheckDiagnosticWindowsOcr?.IsChecked == true) selected.Add(ConfiguredOcrEngine.WindowsOcr);
+            if (CheckDiagnosticTesseract?.IsChecked == true) selected.Add(ConfiguredOcrEngine.Tesseract);
+            if (CheckDiagnosticEasyOcr?.IsChecked == true) selected.Add(ConfiguredOcrEngine.EasyOcr);
+            if (CheckDiagnosticPaddleOcr?.IsChecked == true) selected.Add(ConfiguredOcrEngine.PaddleOcr);
+
+            configuredOcrEngines = selected;
+            return selected.Count > 0;
         }
 
         /// <summary>


### PR DESCRIPTION
## 변경 내용
- OCR 진단용 엔진 선택 UI를 단일 콤보박스에서 다중 체크박스 4개로 변경
- 최소 1개 선택 검증 추가
- config.ini와 프리셋에 다중 선택 값을 정규화해 저장
- 구버전 All/단일 값 설정도 그대로 읽어 하위 호환 유지
- 진단 요약의 "OCR 엔진 선택" 문구를 선택 조합 기준으로 출력

## 검증
- git diff --check
- /home/faust/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- /home/faust/.dotnet/dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-ocr-checkboxes