### PR TITLE
개선: 설정창 제어와 영역 재지정 UX 보강

### DIFF
--- a/GameChatTranslator/Views/AreaSelector/AreaSelector.xaml
+++ b/GameChatTranslator/Views/AreaSelector/AreaSelector.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="AreaSelector" WindowStyle="None" AllowsTransparency="True" Background="#55000000" Topmost="True"
-        WindowState="Maximized" MouseDown="Window_MouseDown" MouseMove="Window_MouseMove" MouseUp="Window_MouseUp">
+        WindowState="Maximized" MouseDown="Window_MouseDown" MouseMove="Window_MouseMove" MouseUp="Window_MouseUp" MouseRightButtonDown="Window_MouseRightButtonDown">
     <!--
         영역 선택 전용 투명 오버레이입니다.
         전체 화면을 덮고, 사용자가 드래그하는 동안 SelectionBorder를 움직여 선택 영역을 시각적으로 보여줍니다.

--- a/GameChatTranslator/Views/AreaSelector/AreaSelector.xaml.cs
+++ b/GameChatTranslator/Views/AreaSelector/AreaSelector.xaml.cs
@@ -56,6 +56,11 @@ namespace GameTranslator
         /// </summary>
         private void Window_MouseDown(object sender, MouseButtonEventArgs e)
         {
+            if (e.ChangedButton != MouseButton.Left)
+            {
+                return;
+            }
+
             // 클릭한 순간의 마우스 좌표를 시작점으로 기록
             startPoint = e.GetPosition(this);
 
@@ -116,6 +121,11 @@ namespace GameTranslator
         /// </summary>
         private void Window_MouseUp(object sender, MouseButtonEventArgs e)
         {
+            if (e.ChangedButton != MouseButton.Left)
+            {
+                return;
+            }
+
             // 드래그를 해서 정상적인 영역이 만들어졌다면
             if (selectionArea != Rectangle.Empty)
             {
@@ -149,6 +159,18 @@ namespace GameTranslator
                 // 그냥 클릭만 하고 드래그를 하지 않았다면 테두리만 다시 숨김
                 SelectionBorder.Visibility = Visibility.Collapsed;
             }
+        }
+
+        /// <summary>
+        /// 영역 재지정 중 마우스 우클릭 시 현재 선택을 취소하고 오버레이를 닫습니다.
+        /// 기존 캡처 영역은 변경하지 않습니다.
+        /// </summary>
+        private void Window_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            e.Handled = true;
+            selectionArea = Rectangle.Empty;
+            SelectionBorder.Visibility = Visibility.Collapsed;
+            Close();
         }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Capture.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Capture.cs
@@ -39,6 +39,7 @@ namespace GameTranslator
             if (areaSelector != null) { areaSelector.Close(); }
             areaSelector = new AreaSelector();
             areaSelector.Owner = this;
+            areaSelector.Closed += (_, __) => areaSelector = null;
             areaSelector.Show();
         }
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
@@ -67,7 +67,7 @@ namespace GameTranslator
                 return;
             }
 
-            OptionSelector selector = CreateSettingsDialog();
+            OptionSelector selector = CreateSettingsDialog(isDialogMode: true);
             bool? dialogResult = selector.ShowDialog();
 
             if (dialogResult != true)
@@ -122,6 +122,7 @@ namespace GameTranslator
 
             WindowUtils.SetClickThrough(this);
             UpdateYellowHotkeyGuideText();
+            UpdateMoveLockToggleButton();
 
             string cx = ini.Read("CaptureX");
             string cy = ini.Read("CaptureY");
@@ -190,6 +191,12 @@ namespace GameTranslator
             autoModeStatusTimer?.Stop();
             translationResultAutoClearTimer?.Stop();
             captureBorderWindow?.Close();
+            if (settingsWindow != null)
+            {
+                settingsWindow.Closed -= SettingsWindow_Closed;
+                settingsWindow.Close();
+                settingsWindow = null;
+            }
             logViewerWindow?.CloseForShutdown();
             ocrDiagnosticWindow?.Close();
             UnregisterHotKey(_windowHandle, ID_HOTKEY_MOVE_LOCK);
@@ -214,26 +221,49 @@ namespace GameTranslator
         /// </summary>
         public void ShowSettingsWindow()
         {
-            OptionSelector selector = CreateSettingsDialog();
-            bool? dialogResult = selector.ShowDialog();
-            if (dialogResult == true)
+            if (settingsWindow != null)
             {
-                ExecuteSettingsDialogPostAction(selector.RequestedActionAfterClose);
+                if (settingsWindow.WindowState == WindowState.Minimized)
+                {
+                    settingsWindow.WindowState = WindowState.Normal;
+                }
+
+                settingsWindow.Activate();
+                return;
             }
+
+            settingsWindow = CreateSettingsDialog(isDialogMode: false);
+            settingsWindow.Closed += SettingsWindow_Closed;
+            settingsWindow.Show();
+            settingsWindow.Activate();
         }
 
         /// <summary>
         /// 환경설정창에서 이동 잠금 전환을 요청할 때 사용하는 래퍼입니다.
         /// </summary>
-        public void ToggleMoveLockFromSettings()
+        public bool ToggleMoveLockFromSettings()
         {
             ToggleMoveLock();
-            UpdateYellowHotkeyGuideText();
+            return !isLocked;
         }
 
-        private OptionSelector CreateSettingsDialog()
+        private void SettingsWindow_Closed(object sender, EventArgs e)
         {
-            return new OptionSelector(this, ini)
+            if (sender is OptionSelector selector)
+            {
+                ExecuteSettingsDialogPostAction(selector.RequestedActionAfterClose);
+                selector.Closed -= SettingsWindow_Closed;
+            }
+
+            if (ReferenceEquals(settingsWindow, sender))
+            {
+                settingsWindow = null;
+            }
+        }
+
+        private OptionSelector CreateSettingsDialog(bool isDialogMode)
+        {
+            return new OptionSelector(this, ini, isDialogMode)
             {
                 Owner = this,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner
@@ -254,6 +284,22 @@ namespace GameTranslator
         /// <paramref name="e"/>는 마우스 왼쪽 버튼 이벤트 정보입니다.
         /// </summary>
         private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e) { if (!isLocked) this.DragMove(); }
+
+        private void BtnMoveLockToggle_Click(object sender, RoutedEventArgs e)
+        {
+            ToggleMoveLock();
+        }
+
+        private void UpdateMoveLockToggleButton()
+        {
+            if (BtnMoveLockToggle == null)
+            {
+                return;
+            }
+
+            BtnMoveLockToggle.Visibility = isLocked ? Visibility.Collapsed : Visibility.Visible;
+            BtnMoveLockToggle.Content = "위치 고정";
+        }
 
         /// <summary>
         /// Ctrl+7 단축키로 번역창 이동 가능 상태와 클릭 관통 잠금 상태를 전환합니다.
@@ -276,6 +322,9 @@ namespace GameTranslator
                 MainBorder.BorderBrush = Brushes.LimeGreen;
                 UpdateCaptureBorder(true);
             }
+
+            UpdateYellowHotkeyGuideText();
+            UpdateMoveLockToggleButton();
         }
     }
 }

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml
@@ -12,17 +12,38 @@
     -->
     <Border x:Name="MainBorder" Background="#CC1E1E1E" CornerRadius="10" BorderThickness="2" BorderBrush="#55FFFFFF">
         <StackPanel Margin="15">
-            <!-- 단축키와 현재 자동 번역 모드를 표시하는 상단 안내 영역입니다. MainWindow.Hotkeys.cs에서 동적으로 갱신합니다. -->
-            <TextBlock x:Name="TxtHotkeyGuide"
-                       Text="[Ctrl+8] 설정  [Ctrl+9] 번역  [Ctrl+0] 자동"
-                       TextWrapping="Wrap"
-                       Foreground="#FFCC00"
-                       FontSize="11"
-                       FontWeight="Bold"
-                       LineHeight="16"
-                       TextAlignment="Left"
-                       HorizontalAlignment="Stretch"
-                       Margin="0,0,0,6"/>
+            <Grid Margin="0,0,0,6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- 단축키와 현재 자동 번역 모드를 표시하는 상단 안내 영역입니다. MainWindow.Hotkeys.cs에서 동적으로 갱신합니다. -->
+                <TextBlock x:Name="TxtHotkeyGuide"
+                           Grid.Column="0"
+                           Text="[Ctrl+8] 설정  [Ctrl+9] 번역  [Ctrl+0] 자동"
+                           TextWrapping="Wrap"
+                           Foreground="#FFCC00"
+                           FontSize="11"
+                           FontWeight="Bold"
+                           LineHeight="16"
+                           TextAlignment="Left"
+                           HorizontalAlignment="Stretch"
+                           Margin="0,0,8,0"/>
+
+                <Button x:Name="BtnMoveLockToggle"
+                        Grid.Column="1"
+                        Content="위치 고정"
+                        Padding="10,2"
+                        MinWidth="74"
+                        Height="24"
+                        Background="#2F6B2F"
+                        Foreground="White"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        Visibility="Collapsed"
+                        Click="BtnMoveLockToggle_Click"/>
+            </Grid>
 
             <!-- 자동 번역 모드 전환 시 현재 상태를 잠깐 강조 표시합니다. 단축키 안내가 길어져도 전환 상태를 놓치지 않게 분리했습니다. -->
             <TextBlock x:Name="TxtAutoModeStatus"

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -78,6 +78,7 @@ namespace GameTranslator
         private AppDataPaths appDataPaths;
         private Dictionary<string, OcrEngine> ocrEngines = new Dictionary<string, OcrEngine>();
         private IntPtr _windowHandle;
+        private OptionSelector settingsWindow;
         private LogViewerWindow logViewerWindow;
         private OcrDiagnosticWindow ocrDiagnosticWindow;
 

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="GameChatTranslator 환경 설정" Width="1420" Height="920"
-        WindowStartupLocation="CenterScreen" Topmost="True" Background="#1E1E1E" Foreground="White" ResizeMode="NoResize">
+        WindowStartupLocation="CenterScreen" Background="#1E1E1E" Foreground="White" ResizeMode="NoResize">
 
     <Window.Resources>
         <Style x:Key="SectionTitleStyle" TargetType="TextBlock">

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -27,6 +28,7 @@ namespace GameTranslator
         private readonly SettingsService _settingsService = new SettingsService();
         private readonly OcrLanguageStatusFormatter _ocrLanguageStatusFormatter = new OcrLanguageStatusFormatter();
         private readonly DispatcherTimer _updateStatusResetTimer;
+        private readonly bool _isDialogMode;
         internal OptionSelectorPostAction RequestedActionAfterClose { get; private set; } = OptionSelectorPostAction.None;
 
         private static readonly (string Label, string Tag)[] OcrLanguageStatusTargets =
@@ -43,23 +45,30 @@ namespace GameTranslator
         /// <paramref name="mainWindow"/>는 투명도 미리보기와 업데이트 확인을 호출할 메인 창 인스턴스이고,
         /// <paramref name="ini"/>는 config.ini 읽기/쓰기를 담당하는 설정 파일 객체입니다.
         /// </summary>
-        public OptionSelector(MainWindow mainWindow, IniFile ini)
+        public OptionSelector(MainWindow mainWindow, IniFile ini, bool isDialogMode)
         {
             InitializeComponent(); // XAML 디자인 UI 요소들을 메모리에 로드
             _mainWindow = mainWindow;
             _ini = ini;
+            _isDialogMode = isDialogMode;
             _updateStatusResetTimer = new DispatcherTimer
             {
                 Interval = TimeSpan.FromSeconds(3)
             };
             _updateStatusResetTimer.Tick += UpdateStatusResetTimer_Tick;
+            Loaded += OptionSelector_Loaded;
 
             RegisterNumericSettingInputGuards();
             LoadCurrentSettings(); // 창이 켜지자마자 INI 파일에서 기존 설정값을 불러옴
             LoadPresetList();
             RefreshInstallLocationStatus();
-            RefreshOcrLanguageStatus();
             RefreshAdvancedSettingValidationStatus();
+        }
+
+        private void OptionSelector_Loaded(object sender, RoutedEventArgs e)
+        {
+            Loaded -= OptionSelector_Loaded;
+            RefreshOcrLanguageStatus();
         }
 
         /// <summary>
@@ -259,11 +268,27 @@ namespace GameTranslator
         /// 설정창에는 OCR 엔진 사용 가능 여부 중심으로 간결하게 표시합니다.
         /// capability는 설치됐는데 엔진이 안 만들어지면 재부팅 필요 가능성만 보조 문구로 안내합니다.
         /// </summary>
-        private void RefreshOcrLanguageStatus()
+        private async void RefreshOcrLanguageStatus()
         {
             if (TxtOcrLanguageStatus == null) return;
 
-            Dictionary<string, string> capabilityStates = GetOcrCapabilityStates();
+            TxtOcrLanguageStatus.Text = "OCR 언어팩 상태 확인 중...";
+
+            Dictionary<string, string> capabilityStates;
+            try
+            {
+                capabilityStates = await Task.Run(GetOcrCapabilityStates);
+            }
+            catch
+            {
+                capabilityStates = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            if (!IsLoaded)
+            {
+                return;
+            }
+
             var entries = new List<OcrLanguageStatusEntry>();
             foreach ((string label, string tag) in OcrLanguageStatusTargets)
             {
@@ -531,8 +556,7 @@ namespace GameTranslator
             if (!SaveSettingsToIni()) return;
             _mainWindow?.ApplyRuntimeSettingsFromIni();
             RequestedActionAfterClose = OptionSelectorPostAction.StartAreaSelection;
-            DialogResult = true;
-            Close();
+            CloseWithSuccess();
         }
 
         /// <summary>
@@ -540,7 +564,12 @@ namespace GameTranslator
         /// </summary>
         private void BtnToggleMoveLock_Click(object sender, RoutedEventArgs e)
         {
-            _mainWindow?.ToggleMoveLockFromSettings();
+            bool overlayUnlocked = _mainWindow?.ToggleMoveLockFromSettings() == true;
+            if (!_isDialogMode && overlayUnlocked)
+            {
+                WindowState = WindowState.Minimized;
+                _mainWindow?.Activate();
+            }
         }
 
         /// <summary>
@@ -552,8 +581,19 @@ namespace GameTranslator
         {
             if (!SaveSettingsToIni()) return;
             _mainWindow?.ApplyRuntimeSettingsFromIni();
-            this.DialogResult = true;
-            this.Close();
+            CloseWithSuccess();
+        }
+
+        private void CloseWithSuccess()
+        {
+            if (_isDialogMode)
+            {
+                DialogResult = true;
+            }
+            else
+            {
+                Close();
+            }
         }
 
         private bool SaveSettingsToIni()


### PR DESCRIPTION
## 변경 내용
- 런타임 설정창을 modeless로 전환하고 Topmost를 제거했습니다.
- 설정창 OCR 언어 상태 조회를 창 표시 후 비동기 갱신으로 미뤄 열기 지연을 줄였습니다.
- 메인 번역창에 이동 후 바로 다시 고정할 수 있는 버튼을 추가했습니다.
- 영역 다시 지정 중 마우스 우클릭으로 취소할 수 있게 했습니다.
- AreaSelector 닫힘 후 참조를 정리해 재진입 경로를 안정화했습니다.

## 확인 사항
- 설정창 저장 후 즉시 반영 유지
- 영역 다시 지정 -> 우클릭 취소 시 기존 캡처 영역 유지
- 설정창에서 이동 잠금 해제 시 창이 최소화되어 바로 위치 조정 가능

## 검증
- git diff --check
- dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true
- dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true
- dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-settings-window-and-move-toggle
