### PR TITLE
기능: 메인 번역 OCR 엔진 선택 연결

### DIFF
--- a/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
+++ b/GameChatTranslator.Tests/Core/Settings/SettingsServiceTests.cs
@@ -153,6 +153,39 @@ namespace GameChatTranslator.Tests
         }
 
         [Theory]
+        [InlineData(null, MainOcrEngine.WindowsOcr)]
+        [InlineData("", MainOcrEngine.WindowsOcr)]
+        [InlineData("WindowsOcr", MainOcrEngine.WindowsOcr)]
+        [InlineData("Tesseract", MainOcrEngine.Tesseract)]
+        [InlineData("EasyOCR", MainOcrEngine.EasyOcr)]
+        [InlineData("PaddleOCR", MainOcrEngine.PaddleOcr)]
+        [InlineData("unknown", MainOcrEngine.WindowsOcr)]
+        public void NormalizeMainOcrEngine_MapsKnownValuesAndDefaultsToWindows(string rawValue, MainOcrEngine expected)
+        {
+            Assert.Equal(expected, _service.NormalizeMainOcrEngine(rawValue));
+        }
+
+        [Theory]
+        [InlineData(MainOcrEngine.WindowsOcr, "WindowsOcr")]
+        [InlineData(MainOcrEngine.Tesseract, "Tesseract")]
+        [InlineData(MainOcrEngine.EasyOcr, "EasyOcr")]
+        [InlineData(MainOcrEngine.PaddleOcr, "PaddleOcr")]
+        public void GetMainOcrEngineTag_ReturnsConfigValue(MainOcrEngine engine, string expected)
+        {
+            Assert.Equal(expected, _service.GetMainOcrEngineTag(engine));
+        }
+
+        [Theory]
+        [InlineData(MainOcrEngine.WindowsOcr, "Windows OCR")]
+        [InlineData(MainOcrEngine.Tesseract, "Tesseract")]
+        [InlineData(MainOcrEngine.EasyOcr, "EasyOCR")]
+        [InlineData(MainOcrEngine.PaddleOcr, "PaddleOCR")]
+        public void GetMainOcrEngineDisplayName_ReturnsUserFacingLabel(MainOcrEngine engine, string expected)
+        {
+            Assert.Equal(expected, _service.GetMainOcrEngineDisplayName(engine));
+        }
+
+        [Theory]
         [InlineData(null, TranslationContentMode.Strinova)]
         [InlineData("", TranslationContentMode.Strinova)]
         [InlineData("Strinova", TranslationContentMode.Strinova)]

--- a/GameChatTranslator/Core/SettingsService.cs
+++ b/GameChatTranslator/Core/SettingsService.cs
@@ -34,6 +34,7 @@ namespace GameTranslator
         public const string DefaultPaddleOcrPythonPath = "python";
         public const string DefaultPaddleOcrLanguageCodes = "en+korean+japan+ch";
         public const string DefaultTranslationEngine = "Google";
+        public const string DefaultMainOcrEngine = "WindowsOcr";
         public const string DefaultTranslationContentMode = "Strinova";
         public const string DefaultResultDisplayMode = "Latest";
 
@@ -190,6 +191,61 @@ namespace GameTranslator
                 TranslationEngineMode.Gemini => "Gemini",
                 TranslationEngineMode.LocalLlm => "LocalLlm",
                 _ => DefaultTranslationEngine
+            };
+        }
+
+        /// <summary>
+        /// 메인 번역 파이프라인에서 사용할 OCR 엔진 단일 선택값을 앱 내부 enum으로 변환합니다.
+        /// 현재 UI는 Windows OCR/Tesseract만 노출하지만, EasyOCR/PaddleOCR 추가를 고려해 enum은 미리 열어둡니다.
+        /// </summary>
+        public MainOcrEngine NormalizeMainOcrEngine(string value)
+        {
+            string normalized = (value ?? "").Trim();
+            if (normalized.Equals("Tesseract", StringComparison.OrdinalIgnoreCase))
+            {
+                return MainOcrEngine.Tesseract;
+            }
+
+            if (normalized.Equals("EasyOcr", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("EasyOCR", StringComparison.OrdinalIgnoreCase))
+            {
+                return MainOcrEngine.EasyOcr;
+            }
+
+            if (normalized.Equals("PaddleOcr", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("PaddleOCR", StringComparison.OrdinalIgnoreCase))
+            {
+                return MainOcrEngine.PaddleOcr;
+            }
+
+            return MainOcrEngine.WindowsOcr;
+        }
+
+        /// <summary>
+        /// 메인 번역용 OCR 엔진 enum을 config.ini에 저장할 문자열로 변환합니다.
+        /// </summary>
+        public string GetMainOcrEngineTag(MainOcrEngine engine)
+        {
+            return engine switch
+            {
+                MainOcrEngine.Tesseract => "Tesseract",
+                MainOcrEngine.EasyOcr => "EasyOcr",
+                MainOcrEngine.PaddleOcr => "PaddleOcr",
+                _ => DefaultMainOcrEngine
+            };
+        }
+
+        /// <summary>
+        /// 메인 번역용 OCR 엔진 enum을 사용자 표시명으로 변환합니다.
+        /// </summary>
+        public string GetMainOcrEngineDisplayName(MainOcrEngine engine)
+        {
+            return engine switch
+            {
+                MainOcrEngine.Tesseract => "Tesseract",
+                MainOcrEngine.EasyOcr => "EasyOCR",
+                MainOcrEngine.PaddleOcr => "PaddleOCR",
+                _ => "Windows OCR"
             };
         }
 
@@ -559,6 +615,18 @@ namespace GameTranslator
     public enum ConfiguredOcrEngine
     {
         All,
+        WindowsOcr,
+        Tesseract,
+        EasyOcr,
+        PaddleOcr
+    }
+
+    /// <summary>
+    /// 메인 번역 파이프라인에서 실제 OCR에 사용할 엔진 단일 선택값입니다.
+    /// 진단용 다중 선택과 분리해, 런타임에서는 하나의 엔진만 고르게 합니다.
+    /// </summary>
+    public enum MainOcrEngine
+    {
         WindowsOcr,
         Tesseract,
         EasyOcr,

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Hotkeys.cs
@@ -133,6 +133,7 @@ namespace GameTranslator
                 FontWeight = FontWeights.Bold
             });
             TxtHotkeyGuide.Inlines.Add(new Run($"  번역기: {engineStr}"));
+            TxtHotkeyGuide.Inlines.Add(new Run($"  OCR: {GetCurrentMainOcrEngineShortName()}"));
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
@@ -88,8 +88,9 @@ namespace GameTranslator
             string geminiKey = ReadGeminiKey();
 
             string currentEngine = GetCurrentTranslationEngineDisplayName();
+            string currentMainOcrEngineName = settingsService.GetMainOcrEngineDisplayName(currentMainOcrEngine);
 
-            AppendLog($"프로그램이 시작되었습니다. (적용 엔진: {currentEngine})");
+            AppendLog($"프로그램이 시작되었습니다. (적용 엔진: {currentEngine}, OCR: {currentMainOcrEngineName})");
 
             // 🌟 [추가] 프로그램 시작 시 현재 세팅값(API 키 제외)을 로그에 기록합니다.
             string log_gLang = ini.Read("GameLanguage") ?? "ko";
@@ -102,10 +103,12 @@ namespace GameTranslator
             string log_local_llm_endpoint = ReadLocalLlmEndpoint();
             string log_local_llm_model = ReadLocalLlmModel();
             string log_content_mode = settingsService.GetTranslationContentModeTag(ReadTranslationContentMode());
+            string log_main_ocr_engine = settingsService.GetMainOcrEngineDisplayName(ReadMainOcrEngine());
 
             AppendLog($"[현재 세팅]");
             AppendLog($"\t[게임 언어\t\t\t: {log_gLang}\t]");
             AppendLog($"\t[번역 언어\t\t\t: {log_tLang}\t]");
+            AppendLog($"\t[OCR 엔진\t\t\t: {log_main_ocr_engine}\t]");
             AppendLog($"\t[Threshold\t\t\t: {log_threshold}\t]");
             AppendLog($"\t[Scale\t\t\t: {log_scale}배\t]");
             AppendLog($"\t[번역 주기\t\t\t: {log_interval}초\t]");

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Settings.cs
@@ -113,6 +113,7 @@ namespace GameTranslator
             EnsureNormalizedSetting("EasyOcrLanguageCodes", settingsService.NormalizeEasyOcrLanguageCodes(ini.Read("EasyOcrLanguageCodes")));
             EnsureNormalizedSetting("PaddleOcrPythonPath", settingsService.NormalizePaddleOcrPythonPath(ini.Read("PaddleOcrPythonPath")));
             EnsureNormalizedSetting("PaddleOcrLanguageCodes", settingsService.NormalizePaddleOcrLanguageCodes(ini.Read("PaddleOcrLanguageCodes")));
+            EnsureNormalizedSetting("MainOcrEngine", settingsService.GetMainOcrEngineTag(settingsService.NormalizeMainOcrEngine(ini.Read("MainOcrEngine"))));
 
             if (string.IsNullOrWhiteSpace(ini.Read("SaveDebugImages")))
             {
@@ -236,6 +237,15 @@ namespace GameTranslator
         }
 
         /// <summary>
+        /// 메인 번역 파이프라인에서 사용할 OCR 엔진 단일 선택값을 읽습니다.
+        /// 현재는 Windows OCR/Tesseract를 우선 지원하고, EasyOCR/PaddleOCR는 같은 슬롯에 후속 추가할 수 있게 유지합니다.
+        /// </summary>
+        private MainOcrEngine ReadMainOcrEngine()
+        {
+            return settingsService.NormalizeMainOcrEngine(ini.Read("MainOcrEngine"));
+        }
+
+        /// <summary>
         /// 번역 결과를 매번 클립보드에 자동 복사할지 읽습니다.
         /// 기본값은 OFF이며, 설정창에서 켠 경우에만 동작합니다.
         /// </summary>
@@ -254,6 +264,8 @@ namespace GameTranslator
         {
             gameLang = ini.Read("GameLanguage") ?? "ko";
             targetLang = ini.Read("TargetLanguage") ?? "ko";
+            currentMainOcrEngine = ReadMainOcrEngine();
+            lastMainOcrFallbackNotice = "";
 
             TranslationEngineMode configuredEngine = ReadTranslationEngineMode();
             string geminiKey = ReadGeminiKey();

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -31,6 +31,31 @@ namespace GameTranslator
     /// </summary>
     public partial class MainWindow
     {
+        private sealed class TranslationOcrSelectionResult
+        {
+            public MainOcrEngine Engine { get; set; } = MainOcrEngine.WindowsOcr;
+            public string EngineDisplayName { get; set; } = "";
+            public string PreprocessName { get; set; } = "";
+            public string SelectedLanguageCode { get; set; } = "";
+            public int Score { get; set; }
+            public List<OcrLine> Lines { get; set; } = new List<OcrLine>();
+            public Dictionary<string, OcrResult> WindowsOcrResults { get; set; }
+        }
+
+        private sealed class ExternalOcrSelectionAttempt
+        {
+            public TranslationOcrSelectionResult Result { get; set; }
+            public string FailureDetail { get; set; } = "";
+        }
+
+        private sealed class ExternalOcrRunResult
+        {
+            public bool Success { get; set; }
+            public string LanguageCodes { get; set; } = "";
+            public IReadOnlyList<string> Lines { get; set; } = Array.Empty<string>();
+            public string ErrorMessage { get; set; } = "";
+        }
+
         /// <summary>
         /// Ctrl+0으로 순환되는 자동 번역 상태입니다.
         /// Off는 타이머 정지, Fast/Auto/Accurate는 각각 속도/균형/정확도 우선 OCR 전략입니다.
@@ -155,6 +180,39 @@ namespace GameTranslator
                 TranslationEngineMode.LocalLlm => "Local LLM 번역",
                 _ => "Google 무료 번역"
             };
+        }
+
+        /// <summary>
+        /// 현재 메인 번역 파이프라인에 연결된 OCR 엔진의 짧은 표시명을 반환합니다.
+        /// 상단 안내 문구처럼 공간이 좁은 위치에서 사용합니다.
+        /// </summary>
+        private string GetCurrentMainOcrEngineShortName()
+        {
+            return currentMainOcrEngine switch
+            {
+                MainOcrEngine.Tesseract => "Tesseract",
+                MainOcrEngine.EasyOcr => "EasyOCR",
+                MainOcrEngine.PaddleOcr => "PaddleOCR",
+                _ => "Windows"
+            };
+        }
+
+        private void ClearMainOcrFallbackNotice()
+        {
+            lastMainOcrFallbackNotice = "";
+        }
+
+        private void NotifyMainOcrFallbackOnce(MainOcrEngine requestedEngine, string detail)
+        {
+            string displayMessage = $"{settingsService.GetMainOcrEngineDisplayName(requestedEngine)} OCR 실패, Windows OCR로 전환";
+            if (string.Equals(lastMainOcrFallbackNotice, displayMessage, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            lastMainOcrFallbackNotice = displayMessage;
+            AppendLog($"{displayMessage}. 상세: {detail}");
+            ShowTranslationApiStatus(displayMessage);
         }
 
         /// <summary>
@@ -347,7 +405,7 @@ namespace GameTranslator
                 }
 
                 // 3. 모드별 후보 전략으로 OCR을 수행하고 가장 점수가 높은 후보를 선택합니다.
-                OcrResultCandidate bestCandidate = await SelectBestOcrCandidateAsync(resizedBitmap, threshold, processingMode, contentMode, performanceStats);
+                TranslationOcrSelectionResult bestCandidate = await SelectBestTranslationOcrCandidateAsync(resizedBitmap, threshold, processingMode, contentMode, performanceStats);
 
                 if (bestCandidate == null || bestCandidate.Lines.Count == 0 || bestCandidate.Score <= 0)
                 {
@@ -355,13 +413,13 @@ namespace GameTranslator
                     return;
                 }
 
-                var ocrResults = bestCandidate.Results;
+                var ocrResults = bestCandidate.WindowsOcrResults;
                 var mergedLines = bestCandidate.Lines;
                 performanceStats.SelectedPreprocessName = bestCandidate.PreprocessName;
                 performanceStats.SelectedOcrLanguages = bestCandidate.SelectedLanguageCode;
                 performanceStats.SelectedScore = bestCandidate.Score;
                 performanceStats.MergedLineCount = mergedLines.Count;
-                AppendLog("DEBUG", $"OCR 모드: {GetOcrProcessingModeLabel(processingMode)}, 전처리 선택: {bestCandidate.PreprocessName}, 언어 선택: {bestCandidate.SelectedLanguageCode} (점수 {bestCandidate.Score})", "System");
+                AppendLog("DEBUG", $"OCR 엔진: {bestCandidate.EngineDisplayName}, OCR 모드: {GetOcrProcessingModeLabel(processingMode)}, 전처리 선택: {bestCandidate.PreprocessName}, 언어 선택: {bestCandidate.SelectedLanguageCode} (점수 {bestCandidate.Score})", "System");
 
                 string currentRawTextCombined = string.Join("\n", mergedLines.Select(l => l.Text.Trim()));
                 if (currentRawTextCombined == lastRawTextCombined)
@@ -411,44 +469,46 @@ namespace GameTranslator
 
                         string characterNameGold = parsedChatLine.CharacterLabel;
                         string bestMessage = parsedChatLine.Message;
-                        int bestScore = -1;
-
-                        double mTop = chatLine.Top - 5;
-                        double mBot = chatLine.Bottom + 5;
-
-                        foreach (var kvp in ocrResults)
+                        if (ocrResults != null)
                         {
-                            var linesInBand = kvp.Value.Lines
-                                .Where(l => l.Words.Count > 0 && l.Words.Any(w => w.BoundingRect.Bottom > mTop && w.BoundingRect.Top < mBot))
-                                .OrderBy(l => l.Words.First().BoundingRect.Left);
+                            int bestScore = -1;
+                            double mTop = chatLine.Top - 5;
+                            double mBot = chatLine.Bottom + 5;
 
-                            if (linesInBand.Any())
+                            foreach (var kvp in ocrResults)
                             {
-                                string fullText = string.Join(" ", linesInBand.Select(l => l.Text.Trim()));
-                                string msgOnly = fullText;
+                                var linesInBand = kvp.Value.Lines
+                                    .Where(l => l.Words.Count > 0 && l.Words.Any(w => w.BoundingRect.Bottom > mTop && w.BoundingRect.Top < mBot))
+                                    .OrderBy(l => l.Words.First().BoundingRect.Left);
 
-                                int subCIdx = fullText.LastIndexOfAny(new char[] { ':', ';', '：', '!' });
-                                if (subCIdx != -1)
+                                if (linesInBand.Any())
                                 {
-                                    msgOnly = fullText.Substring(subCIdx + 1).Trim();
-                                }
-                                else
-                                {
-                                    int brIdx = fullText.LastIndexOfAny(new char[] { ']', ')' });
-                                    if (brIdx != -1) msgOnly = fullText.Substring(brIdx + 1).Trim();
-                                    else msgOnly = "";
-                                }
+                                    string fullText = string.Join(" ", linesInBand.Select(l => l.Text.Trim()));
+                                    string msgOnly = fullText;
 
-                                int score = msgOnly.Length;
-                                if (kvp.Key == "zh-Hans-CN" && Regex.IsMatch(msgOnly, @"[\u4e00-\u9fa5]")) score += 40000;
-                                else if (kvp.Key == "en-US" && Regex.IsMatch(msgOnly, @"[a-zA-Z]{2,}")) score += 30000;
-                                else if (kvp.Key == "ja" && Regex.IsMatch(msgOnly, @"[ぁ-んァ-ヶ]")) score += 20000;
-                                else if (kvp.Key == "ru" && Regex.IsMatch(msgOnly, @"[а-яА-ЯёЁ]")) score += 10000;
+                                    int subCIdx = fullText.LastIndexOfAny(new char[] { ':', ';', '：', '!' });
+                                    if (subCIdx != -1)
+                                    {
+                                        msgOnly = fullText.Substring(subCIdx + 1).Trim();
+                                    }
+                                    else
+                                    {
+                                        int brIdx = fullText.LastIndexOfAny(new char[] { ']', ')' });
+                                        if (brIdx != -1) msgOnly = fullText.Substring(brIdx + 1).Trim();
+                                        else msgOnly = "";
+                                    }
 
-                                if (score > bestScore)
-                                {
-                                    bestScore = score;
-                                    bestMessage = msgOnly;
+                                    int score = msgOnly.Length;
+                                    if (kvp.Key == "zh-Hans-CN" && Regex.IsMatch(msgOnly, @"[\u4e00-\u9fa5]")) score += 40000;
+                                    else if (kvp.Key == "en-US" && Regex.IsMatch(msgOnly, @"[a-zA-Z]{2,}")) score += 30000;
+                                    else if (kvp.Key == "ja" && Regex.IsMatch(msgOnly, @"[ぁ-んァ-ヶ]")) score += 20000;
+                                    else if (kvp.Key == "ru" && Regex.IsMatch(msgOnly, @"[а-яА-ЯёЁ]")) score += 10000;
+
+                                    if (score > bestScore)
+                                    {
+                                        bestScore = score;
+                                        bestMessage = msgOnly;
+                                    }
                                 }
                             }
                         }
@@ -523,6 +583,226 @@ namespace GameTranslator
                 .Where(translationPromptBuilder.HasMeaningfulEtcContent);
 
             return string.Join(Environment.NewLine, lines);
+        }
+
+        /// <summary>
+        /// 현재 설정된 메인 OCR 엔진에 맞춰 번역 파이프라인에서 사용할 OCR 후보를 선택합니다.
+        /// Windows OCR은 기존 경로를 유지하고, 외부 OCR은 공통 외부 엔진 경로로 분기한 뒤 실패 시 Windows OCR로 fallback합니다.
+        /// </summary>
+        private async Task<TranslationOcrSelectionResult> SelectBestTranslationOcrCandidateAsync(
+            Bitmap resizedBitmap,
+            int threshold,
+            OcrProcessingMode processingMode,
+            TranslationContentMode contentMode,
+            OcrPerformanceStats performanceStats)
+        {
+            if (currentMainOcrEngine == MainOcrEngine.WindowsOcr)
+            {
+                ClearMainOcrFallbackNotice();
+                return await SelectBestWindowsOcrCandidateAsync(resizedBitmap, threshold, processingMode, contentMode, performanceStats);
+            }
+
+            ExternalOcrSelectionAttempt externalAttempt = await SelectBestExternalOcrCandidateAsync(
+                currentMainOcrEngine,
+                resizedBitmap,
+                threshold,
+                processingMode,
+                contentMode,
+                performanceStats);
+
+            if (externalAttempt.Result != null)
+            {
+                ClearMainOcrFallbackNotice();
+                return externalAttempt.Result;
+            }
+
+            NotifyMainOcrFallbackOnce(currentMainOcrEngine, externalAttempt.FailureDetail);
+            return await SelectBestWindowsOcrCandidateAsync(resizedBitmap, threshold, processingMode, contentMode, performanceStats);
+        }
+
+        /// <summary>
+        /// 기존 Windows OCR 후보 선택 경로를 메인 OCR 엔진 공통 결과 모델로 감싼 래퍼입니다.
+        /// </summary>
+        private async Task<TranslationOcrSelectionResult> SelectBestWindowsOcrCandidateAsync(
+            Bitmap resizedBitmap,
+            int threshold,
+            OcrProcessingMode processingMode,
+            TranslationContentMode contentMode,
+            OcrPerformanceStats performanceStats)
+        {
+            OcrResultCandidate candidate = await SelectBestOcrCandidateAsync(resizedBitmap, threshold, processingMode, contentMode, performanceStats);
+            if (candidate == null)
+            {
+                return null;
+            }
+
+            return new TranslationOcrSelectionResult
+            {
+                Engine = MainOcrEngine.WindowsOcr,
+                EngineDisplayName = settingsService.GetMainOcrEngineDisplayName(MainOcrEngine.WindowsOcr),
+                PreprocessName = candidate.PreprocessName,
+                SelectedLanguageCode = candidate.SelectedLanguageCode,
+                Score = candidate.Score,
+                Lines = candidate.Lines,
+                WindowsOcrResults = candidate.Results
+            };
+        }
+
+        /// <summary>
+        /// 외부 OCR 엔진 메인 번역 경로 공통 선택기입니다.
+        /// 현재는 Tesseract만 구현하고, 이후 EasyOCR/PaddleOCR를 같은 슬롯에 추가할 수 있게 switch를 열어둡니다.
+        /// </summary>
+        private async Task<ExternalOcrSelectionAttempt> SelectBestExternalOcrCandidateAsync(
+            MainOcrEngine engine,
+            Bitmap resizedBitmap,
+            int threshold,
+            OcrProcessingMode processingMode,
+            TranslationContentMode contentMode,
+            OcrPerformanceStats performanceStats)
+        {
+            var attempt = new ExternalOcrSelectionAttempt
+            {
+                FailureDetail = $"{settingsService.GetMainOcrEngineDisplayName(engine)} 메인 OCR 경로가 아직 준비되지 않았습니다."
+            };
+
+            IReadOnlyList<OcrPreprocessKind> preprocessKinds = ocrService.CreateEvaluationPlan(processingMode)
+                .SelectMany(step => step.PreprocessKinds)
+                .Distinct()
+                .ToList();
+
+            Stopwatch preprocessStopwatch = Stopwatch.StartNew();
+            List<PreprocessedOcrImage> preprocessedImages = ocrImagePreprocessor.CreatePreprocessedOcrImages(resizedBitmap, threshold, preprocessKinds.ToArray());
+            preprocessStopwatch.Stop();
+            performanceStats.PreprocessMs += preprocessStopwatch.ElapsedMilliseconds;
+            performanceStats.PreprocessCandidateCount += preprocessedImages.Count;
+
+            TranslationOcrSelectionResult bestSelection = null;
+
+            try
+            {
+                foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
+                {
+                    Stopwatch cropStopwatch = Stopwatch.StartNew();
+                    using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
+                    cropStopwatch.Stop();
+                    performanceStats.CropMs += cropStopwatch.ElapsedMilliseconds;
+
+                    Stopwatch ocrStopwatch = Stopwatch.StartNew();
+                    ExternalOcrRunResult runResult = await RunSelectedExternalMainOcrAsync(engine, croppedBitmap);
+                    ocrStopwatch.Stop();
+                    performanceStats.OcrMs += ocrStopwatch.ElapsedMilliseconds;
+                    performanceStats.OcrLanguageCallCount++;
+
+                    if (!runResult.Success)
+                    {
+                        attempt.FailureDetail = runResult.ErrorMessage;
+                        continue;
+                    }
+
+                    List<OcrLine> candidateLines = BuildExternalMainOcrLines(runResult.Lines, contentMode);
+                    if (candidateLines.Count == 0)
+                    {
+                        attempt.FailureDetail = $"{settingsService.GetMainOcrEngineDisplayName(engine)}가 유효한 OCR 결과를 반환하지 않았습니다.";
+                        continue;
+                    }
+
+                    Stopwatch scoringStopwatch = Stopwatch.StartNew();
+                    int candidateScore = ScoreOcrCandidate(candidateLines, contentMode);
+                    scoringStopwatch.Stop();
+                    performanceStats.ScoringMs += scoringStopwatch.ElapsedMilliseconds;
+
+                    var selection = new TranslationOcrSelectionResult
+                    {
+                        Engine = engine,
+                        EngineDisplayName = settingsService.GetMainOcrEngineDisplayName(engine),
+                        PreprocessName = preprocessedImage.Name,
+                        SelectedLanguageCode = runResult.LanguageCodes,
+                        Score = candidateScore,
+                        Lines = candidateLines
+                    };
+
+                    if (bestSelection == null || selection.Score > bestSelection.Score)
+                    {
+                        bestSelection = selection;
+                    }
+                }
+            }
+            finally
+            {
+                foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
+                {
+                    preprocessedImage.Dispose();
+                }
+            }
+
+            attempt.Result = bestSelection;
+            if (bestSelection != null)
+            {
+                attempt.FailureDetail = "";
+            }
+
+            return attempt;
+        }
+
+        private async Task<ExternalOcrRunResult> RunSelectedExternalMainOcrAsync(MainOcrEngine engine, Bitmap croppedBitmap)
+        {
+            switch (engine)
+            {
+                case MainOcrEngine.Tesseract:
+                {
+                    TesseractCliOcrResult runResult = await Task.Run(() =>
+                        tesseractCliOcrAdapter.Recognize(
+                            croppedBitmap,
+                            ReadTesseractExecutablePath(),
+                            tesseractCliOcrAdapter.BuildLanguageCodes(ReadTesseractLanguageCodes(), gameLang),
+                            timeoutMs: 15000));
+
+                    return new ExternalOcrRunResult
+                    {
+                        Success = runResult.Success,
+                        LanguageCodes = runResult.LanguageCodes,
+                        Lines = runResult.Lines,
+                        ErrorMessage = string.IsNullOrWhiteSpace(runResult.ErrorMessage)
+                            ? "Tesseract OCR 실행 실패"
+                            : runResult.ErrorMessage
+                    };
+                }
+                case MainOcrEngine.EasyOcr:
+                    return new ExternalOcrRunResult
+                    {
+                        Success = false,
+                        ErrorMessage = "EasyOCR 메인 번역 경로는 아직 연결되지 않았습니다."
+                    };
+                case MainOcrEngine.PaddleOcr:
+                    return new ExternalOcrRunResult
+                    {
+                        Success = false,
+                        ErrorMessage = "PaddleOCR 메인 번역 경로는 아직 연결되지 않았습니다."
+                    };
+                default:
+                    return new ExternalOcrRunResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Windows OCR은 외부 OCR 경로로 호출할 수 없습니다."
+                    };
+            }
+        }
+
+        private List<OcrLine> BuildExternalMainOcrLines(IReadOnlyList<string> lines, TranslationContentMode contentMode)
+        {
+            List<OcrLine> rawLines = (lines ?? Array.Empty<string>())
+                .Select((text, index) => new OcrLine
+                {
+                    Top = index * 24,
+                    Bottom = index * 24 + 20,
+                    Text = (text ?? "").Trim()
+                })
+                .Where(line => !string.IsNullOrWhiteSpace(line.Text))
+                .ToList();
+
+            return contentMode == TranslationContentMode.Strinova
+                ? ocrService.NormalizeMergedLinesForSelection(rawLines, characterNames, contentMode)
+                : rawLines;
         }
 
         /// <summary>

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -44,6 +44,8 @@ namespace GameTranslator
         public IniFile ini;
         private string gameLang = "ko";
         private string targetLang = "ko";
+        private MainOcrEngine currentMainOcrEngine = MainOcrEngine.WindowsOcr;
+        private string lastMainOcrFallbackNotice = "";
 
         private uint modTrans, modAuto, modSettings;
         private uint keyTrans, keyAuto, keySettings;

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.Presets.cs
@@ -297,6 +297,7 @@ namespace GameTranslator
             _ini.Write("AutoCopyTranslationResult", CheckAutoCopyTranslationResult?.IsChecked == true ? "true" : "false", section);
             _ini.Write("TranslationContentMode", GetSelectedTranslationContentModeTag(), section);
             _ini.Write("TranslationEngine", GetSelectedTag(ComboTranslationEngine, SettingsService.DefaultTranslationEngine), section);
+            _ini.Write("MainOcrEngine", GetSelectedTag(ComboMainOcrEngine, SettingsService.DefaultMainOcrEngine), section);
             _ini.Write("OcrEngineSelection", _settingsService.GetConfiguredOcrEngineSelectionTag(configuredOcrEngines), section);
             _ini.Write("GeminiModel", _settingsService.NormalizeGeminiModel(TxtGeminiModel?.Text), section);
             _ini.Write("LocalLlmEndpoint", _settingsService.NormalizeLocalLlmEndpoint(TxtLocalLlmEndpoint?.Text), section);
@@ -341,6 +342,7 @@ namespace GameTranslator
                 _settingsService.IsEnabled(SettingsService.DefaultAutoCopyTranslationResult));
             ApplyTranslationContentMode(_settingsService.NormalizeTranslationContentMode(ReadPresetValue(section, "TranslationContentMode", SettingsService.DefaultTranslationContentMode)));
             SetComboByTag(ComboTranslationEngine, _settingsService.GetTranslationEngineTag(_settingsService.NormalizeTranslationEngineMode(ReadPresetValue(section, "TranslationEngine", SettingsService.DefaultTranslationEngine))));
+            SetComboByTag(ComboMainOcrEngine, _settingsService.GetMainOcrEngineTag(_settingsService.NormalizeMainOcrEngine(ReadPresetValue(section, "MainOcrEngine", SettingsService.DefaultMainOcrEngine))));
             ApplyConfiguredOcrEngineSelection(_settingsService.NormalizeConfiguredOcrEngineSelection(ReadPresetValue(section, "OcrEngineSelection", SettingsService.DefaultOcrEngineSelection)));
             TxtGeminiModel.Text = _settingsService.NormalizeGeminiModel(ReadPresetValue(section, "GeminiModel", SettingsService.DefaultGeminiModel));
             TxtLocalLlmEndpoint.Text = _settingsService.NormalizeLocalLlmEndpoint(ReadPresetValue(section, "LocalLlmEndpoint", SettingsService.DefaultLocalLlmEndpoint));

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -292,6 +292,19 @@
 
                     <GroupBox Header="OCR 테스트 / 진단" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
                         <StackPanel Margin="10">
+                            <TextBlock Text="메인 번역용 OCR 엔진:"
+                                       Margin="0,0,0,5"
+                                       Foreground="#CCC"/>
+                            <ComboBox x:Name="ComboMainOcrEngine" Height="24" Margin="0,0,0,6" Background="#333" Foreground="Black">
+                                <ComboBoxItem Content="Windows OCR (기본)" Tag="WindowsOcr"/>
+                                <ComboBoxItem Content="Tesseract (실험)" Tag="Tesseract"/>
+                            </ComboBox>
+                            <TextBlock Text="현재 메인 번역 경로는 Windows OCR/Tesseract만 연결되어 있습니다. EasyOCR/PaddleOCR는 같은 구조로 추후 추가할 수 있게 준비합니다."
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,10"
+                                       Foreground="#AFAFAF"
+                                       FontSize="11"/>
+
                             <TextBlock Text="진단 점수에 사용할 OCR 엔진:"
                                        Margin="0,0,0,5"
                                        Foreground="#CCC"/>

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -141,6 +141,11 @@ namespace GameTranslator
                 TranslationEngineMode engineMode = _settingsService.NormalizeTranslationEngineMode(_ini.Read("TranslationEngine"));
                 SetComboByTag(ComboTranslationEngine, _settingsService.GetTranslationEngineTag(engineMode));
             }
+            if (ComboMainOcrEngine != null)
+            {
+                MainOcrEngine mainOcrEngine = _settingsService.NormalizeMainOcrEngine(_ini.Read("MainOcrEngine"));
+                SetComboByTag(ComboMainOcrEngine, _settingsService.GetMainOcrEngineTag(mainOcrEngine));
+            }
             ApplyConfiguredOcrEngineSelection(_settingsService.NormalizeConfiguredOcrEngineSelection(_ini.Read("OcrEngineSelection")));
             if (TxtResultHistoryLimit != null)
             {
@@ -644,6 +649,7 @@ namespace GameTranslator
             _ini.Write("AutoCopyTranslationResult", CheckAutoCopyTranslationResult?.IsChecked == true ? "true" : "false");
             _ini.Write("TranslationContentMode", GetSelectedTranslationContentModeTag());
             _ini.Write("TranslationEngine", GetSelectedTag(ComboTranslationEngine, SettingsService.DefaultTranslationEngine));
+            _ini.Write("MainOcrEngine", GetSelectedTag(ComboMainOcrEngine, SettingsService.DefaultMainOcrEngine));
             _ini.Write("OcrEngineSelection", _settingsService.GetConfiguredOcrEngineSelectionTag(configuredOcrEngines));
             _ini.Write("GeminiKey", PasswordGeminiKey?.Password?.Trim() ?? "");
             _ini.Write("GeminiModel", _settingsService.NormalizeGeminiModel(TxtGeminiModel?.Text));


### PR DESCRIPTION
## 요약
- 환경설정에 메인 번역용 OCR 단일 선택 추가
- 실제 번역 파이프라인에서 Windows OCR / Tesseract 전환 적용
- Tesseract 실패 시 Windows OCR fallback + 안내 추가
- 추후 EasyOCR / PaddleOCR를 같은 슬롯에 추가하기 쉽게 공통 외부 OCR 경로 분리

## 변경 사항
- `MainOcrEngine` 설정 추가 및 정규화
- 메인 번역 OCR 선택 UI 추가
- 런타임 설정 즉시 반영
- Windows OCR 기존 경로 유지, 외부 OCR 경로 분리
- Tesseract 메인 OCR 경로 연결
- 설정/단축키 로그에 현재 OCR 엔진 표시
- 프리셋 저장/불러오기에 `MainOcrEngine` 포함

## 검증
- `git diff --check`
- `dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true`
- `dotnet build GameChatTranslator.sln -c Release -p:EnableWindowsTargeting=true`
- `dotnet publish GameChatTranslator/GameChatTranslator.csproj -c Release -r win-x64 --self-contained true -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o /tmp/gct-publish-main-ocr-engine-selection`
