### PR TITLE
성능: UI 스레드 병목 완화 및 README 비교표 추가

### DIFF
--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -61,6 +61,28 @@ namespace GameTranslator
             public string ErrorMessage { get; set; } = "";
         }
 
+        private sealed class TranslationCaptureFrame : IDisposable
+        {
+            public TranslationCaptureFrame(Bitmap rawBitmap, Bitmap resizedBitmap, long captureMs, long resizeMs)
+            {
+                RawBitmap = rawBitmap;
+                ResizedBitmap = resizedBitmap;
+                CaptureMs = captureMs;
+                ResizeMs = resizeMs;
+            }
+
+            public Bitmap RawBitmap { get; }
+            public Bitmap ResizedBitmap { get; }
+            public long CaptureMs { get; }
+            public long ResizeMs { get; }
+
+            public void Dispose()
+            {
+                ResizedBitmap.Dispose();
+                RawBitmap.Dispose();
+            }
+        }
+
         /// <summary>
         /// Ctrl+=으로 순환되는 자동 번역 상태입니다.
         /// Off는 타이머 정지, Fast/Auto/Accurate는 각각 속도/균형/정확도 우선 OCR 전략입니다.
@@ -89,7 +111,7 @@ namespace GameTranslator
 
             if (isAutoTranslating)
             {
-                runTranslation(GetCurrentOcrProcessingMode());
+                _ = runTranslationAsync(GetCurrentOcrProcessingMode());
                 autoTranslateTimer.Start();
             }
             else
@@ -348,14 +370,14 @@ namespace GameTranslator
         /// </summary>
         private void runTranslation()
         {
-            runTranslation(OcrProcessingMode.Accurate);
+            _ = runTranslationAsync(OcrProcessingMode.Accurate);
         }
 
         /// <summary>
         /// 화면 캡처부터 OCR, 번역 API 호출, 번역창 출력까지 한 번의 번역 사이클을 수행합니다.
         /// <paramref name="processingMode"/>는 이번 실행에서 사용할 OCR 전처리/언어 후보 전략입니다.
         /// </summary>
-        private async void runTranslation(OcrProcessingMode processingMode)
+        private async Task runTranslationAsync(OcrProcessingMode processingMode)
         {
             if (isTranslating || gameChatArea == Rectangle.Empty) return;
             isTranslating = true;
@@ -368,41 +390,18 @@ namespace GameTranslator
             int threshold = SettingsValueNormalizer.NormalizeThreshold(ini.Read("Threshold"));
             int scaleFactor = SettingsValueNormalizer.NormalizeScaleFactor(ini.Read("ScaleFactor"));
             TranslationContentMode contentMode = ReadTranslationContentMode();
+            Rectangle captureArea = GetCapturePixelArea();
+            bool shouldSaveDebugImages = ShouldSaveDebugImages();
 
             try
             {
-                // 1. 저장된 채팅 영역을 실제 화면 픽셀 기준으로 캡처합니다.
-                Stopwatch captureStopwatch = Stopwatch.StartNew();
-                Rectangle captureArea = GetCapturePixelArea();
-                using Bitmap rawBitmap = new Bitmap(captureArea.Width, captureArea.Height);
-                using (Graphics g = Graphics.FromImage(rawBitmap))
-                {
-                    IntPtr hdcSrc = GetWindowDC(IntPtr.Zero);
-                    IntPtr hdcDest = g.GetHdc();
-                    BitBlt(hdcDest, 0, 0, captureArea.Width, captureArea.Height, hdcSrc, captureArea.X, captureArea.Y, 0x00CC0020);
-                    g.ReleaseHdc(hdcDest);
-                    ReleaseDC(IntPtr.Zero, hdcSrc);
-                }
-                captureStopwatch.Stop();
-                performanceStats.CaptureMs += captureStopwatch.ElapsedMilliseconds;
+                using TranslationCaptureFrame captureFrame = await Task.Run(() => CaptureAndResizeTranslationFrame(captureArea, scaleFactor));
+                performanceStats.CaptureMs += captureFrame.CaptureMs;
+                performanceStats.ResizeMs += captureFrame.ResizeMs;
 
-                // 2. OCR 인식률 향상을 위해 설정된 배율만큼 이미지를 확대합니다.
-                Stopwatch resizeStopwatch = Stopwatch.StartNew();
-                int newWidth = rawBitmap.Width * scaleFactor;
-                int newHeight = rawBitmap.Height * scaleFactor;
-                using Bitmap resizedBitmap = new Bitmap(newWidth, newHeight);
-                using (Graphics g = Graphics.FromImage(resizedBitmap))
+                if (shouldSaveDebugImages)
                 {
-                    g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
-                    g.DrawImage(rawBitmap, 0, 0, newWidth, newHeight);
-                }
-                resizeStopwatch.Stop();
-                performanceStats.ResizeMs += resizeStopwatch.ElapsedMilliseconds;
-
-                if (ShouldSaveDebugImages())
-                {
-                    // 🌟 [프레임 방어 최적화] 메인 스레드 대기 방지를 위해 복사본을 만들어 백그라운드 저장
-                    Bitmap rawClone = new Bitmap(rawBitmap);
+                    Bitmap rawClone = new Bitmap(captureFrame.RawBitmap);
                     _ = Task.Run(() =>
                     {
                         using (rawClone) SaveDebugImage(rawClone, "[Origin]");
@@ -410,7 +409,7 @@ namespace GameTranslator
                 }
 
                 // 3. 모드별 후보 전략으로 OCR을 수행하고 가장 점수가 높은 후보를 선택합니다.
-                TranslationOcrSelectionResult bestCandidate = await SelectBestTranslationOcrCandidateAsync(resizedBitmap, threshold, processingMode, contentMode, performanceStats);
+                TranslationOcrSelectionResult bestCandidate = await SelectBestTranslationOcrCandidateAsync(captureFrame.ResizedBitmap, threshold, processingMode, contentMode, performanceStats);
 
                 if (bestCandidate == null || bestCandidate.Lines.Count == 0 || bestCandidate.Score <= 0)
                 {
@@ -550,6 +549,60 @@ namespace GameTranslator
                 totalStopwatch.Stop();
                 AppendOcrPerformanceLog(performanceStats, totalStopwatch.ElapsedMilliseconds);
                 isTranslating = false;
+            }
+        }
+
+        private TranslationCaptureFrame CaptureAndResizeTranslationFrame(Rectangle captureArea, int scaleFactor)
+        {
+            Stopwatch captureStopwatch = Stopwatch.StartNew();
+            Bitmap rawBitmap = new Bitmap(captureArea.Width, captureArea.Height);
+
+            try
+            {
+                using (Graphics g = Graphics.FromImage(rawBitmap))
+                {
+                    IntPtr hdcSrc = GetWindowDC(IntPtr.Zero);
+                    IntPtr hdcDest = g.GetHdc();
+
+                    try
+                    {
+                        BitBlt(hdcDest, 0, 0, captureArea.Width, captureArea.Height, hdcSrc, captureArea.X, captureArea.Y, 0x00CC0020);
+                    }
+                    finally
+                    {
+                        g.ReleaseHdc(hdcDest);
+                        ReleaseDC(IntPtr.Zero, hdcSrc);
+                    }
+                }
+
+                captureStopwatch.Stop();
+
+                Stopwatch resizeStopwatch = Stopwatch.StartNew();
+                int newWidth = rawBitmap.Width * scaleFactor;
+                int newHeight = rawBitmap.Height * scaleFactor;
+                Bitmap resizedBitmap = new Bitmap(newWidth, newHeight);
+
+                try
+                {
+                    using (Graphics g = Graphics.FromImage(resizedBitmap))
+                    {
+                        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+                        g.DrawImage(rawBitmap, 0, 0, newWidth, newHeight);
+                    }
+                }
+                catch
+                {
+                    resizedBitmap.Dispose();
+                    throw;
+                }
+
+                resizeStopwatch.Stop();
+                return new TranslationCaptureFrame(rawBitmap, resizedBitmap, captureStopwatch.ElapsedMilliseconds, resizeStopwatch.ElapsedMilliseconds);
+            }
+            catch
+            {
+                rawBitmap.Dispose();
+                throw;
             }
         }
 
@@ -699,7 +752,7 @@ namespace GameTranslator
                 .ToList();
 
             Stopwatch preprocessStopwatch = Stopwatch.StartNew();
-            List<PreprocessedOcrImage> preprocessedImages = ocrImagePreprocessor.CreatePreprocessedOcrImages(resizedBitmap, threshold, preprocessKinds.ToArray());
+            List<PreprocessedOcrImage> preprocessedImages = await Task.Run(() => ocrImagePreprocessor.CreatePreprocessedOcrImages(resizedBitmap, threshold, preprocessKinds.ToArray()));
             preprocessStopwatch.Stop();
             performanceStats.PreprocessMs += preprocessStopwatch.ElapsedMilliseconds;
             performanceStats.PreprocessCandidateCount += preprocessedImages.Count;
@@ -711,7 +764,7 @@ namespace GameTranslator
                 foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
                 {
                     Stopwatch cropStopwatch = Stopwatch.StartNew();
-                    using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
+                    using Bitmap croppedBitmap = await Task.Run(() => CropForOcr(preprocessedImage.Bitmap));
                     cropStopwatch.Stop();
                     performanceStats.CropMs += cropStopwatch.ElapsedMilliseconds;
 
@@ -1087,7 +1140,7 @@ namespace GameTranslator
         {
             OcrResultCandidate bestCandidate = null;
             Stopwatch preprocessStopwatch = Stopwatch.StartNew();
-            List<PreprocessedOcrImage> preprocessedImages = ocrImagePreprocessor.CreatePreprocessedOcrImages(resizedBitmap, threshold, preprocessKinds);
+            List<PreprocessedOcrImage> preprocessedImages = await Task.Run(() => ocrImagePreprocessor.CreatePreprocessedOcrImages(resizedBitmap, threshold, preprocessKinds));
             preprocessStopwatch.Stop();
             performanceStats.PreprocessMs += preprocessStopwatch.ElapsedMilliseconds;
             performanceStats.PreprocessCandidateCount += preprocessedImages.Count;
@@ -1097,7 +1150,7 @@ namespace GameTranslator
                 foreach (PreprocessedOcrImage preprocessedImage in preprocessedImages)
                 {
                     Stopwatch cropStopwatch = Stopwatch.StartNew();
-                    using Bitmap croppedBitmap = CropForOcr(preprocessedImage.Bitmap);
+                    using Bitmap croppedBitmap = await Task.Run(() => CropForOcr(preprocessedImage.Bitmap));
                     cropStopwatch.Stop();
                     performanceStats.CropMs += cropStopwatch.ElapsedMilliseconds;
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.xaml.cs
@@ -122,7 +122,7 @@ namespace GameTranslator
 
             autoTranslateTimer = new DispatcherTimer();
             autoTranslateTimer.Interval = TimeSpan.FromSeconds(intervalSeconds);
-            autoTranslateTimer.Tick += (s, e) => { if (!isTranslating) runTranslation(GetCurrentOcrProcessingMode()); };
+            autoTranslateTimer.Tick += (s, e) => { if (!isTranslating) _ = runTranslationAsync(GetCurrentOcrProcessingMode()); };
 
             string[] tags = { "ko", "en-US", "zh-Hans-CN", "ja", "ru" };
             foreach (var tag in tags)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,13 @@ py -m pip install "paddleocr[all]"
 | EasyOCR | 실험 기능입니다. Python/패키지 설치가 필요하며, 실패하면 Tesseract -> Windows OCR 순서로 자동 fallback 합니다. |
 | PaddleOCR | 실험 기능입니다. Python/패키지 설치가 필요하며, 실패하면 Tesseract -> Windows OCR 순서로 자동 fallback 합니다. |
 
+| 엔진 | 메인 번역 사용 | 준비물 | 속도 경향 | 장점 | 주의점 |
+|:---|:---|:---|:---|:---|:---|
+| Windows OCR | 기본 경로 | Windows OCR 언어팩 | 빠름 | 설치만 끝나면 바로 동작, 앱 내부 의존성 적음 | 언어팩 설치/재부팅 필요, 난잡한 배경에서는 인식률 한계가 있음 |
+| Tesseract | 선택 가능 | `tesseract.exe`, 언어 데이터 | 중간 | 외부 의존성이 단순하고 fallback 체인 중간 단계로 안정적 | 언어 데이터 품질 영향이 크고, Windows OCR보다 느릴 수 있음 |
+| EasyOCR | 선택 가능 | Python, `torch`, `torchvision`, `easyocr` | 느림 | 난잡한 채팅 이미지나 일부 폰트에서 강한 경우가 있음 | Python 기동 비용이 크고, 현재는 실험 기능 성격이 강함 |
+| PaddleOCR | 선택 가능 | Python, `paddlepaddle`, `paddleocr` | 느림 | 중국어 계열이나 특정 UI 폰트에서 강한 경우가 있음 | Python 기동 비용이 크고, 설치 의존성이 가장 무거운 편 |
+
 ### 5. 번역 엔진 선택
 
 환경설정창의 **기본 번역 엔진**에서 Google / Gemini / Local LLM을 선택합니다.
@@ -253,6 +260,12 @@ py -m pip install "paddleocr[all]"
 | ETC | 채팅 포맷과 무관하게 OCR로 읽은 전체 내용을 하나의 번역 대상으로 사용합니다. 다른 게임이나 일반 화면 텍스트 테스트에 사용할 수 있습니다. |
 
 ## 번역 엔진
+
+| 엔진 | 네트워크 | 비용/준비 | 장점 | 주의점 | 추천 상황 |
+|:---|:---|:---|:---|:---|:---|
+| Google | 인터넷 필요 | 별도 API 키 없음 | 가장 빨리 시작 가능, fallback 기본값으로 안정적 | OCR 오타 복원 능력은 제한적 | 빠른 테스트, 기본값 유지, 다른 엔진 실패 대비 |
+| Gemini | 인터넷 필요 | Gemini API 키 필요 | 문맥 복원과 번역 품질이 좋아 OCR 노이즈에 강함 | API 할당량, 서버 혼잡, 모델명 설정 영향이 있음 | 품질 우선, 외부 API 사용 가능 환경 |
+| Local LLM | 로컬 서버 | LM Studio 또는 OpenAI 호환 서버 필요 | 외부 API 없이 내부 서버로 번역 가능 | 모델 준비, 서버 메모리/속도, 프롬프트 튜닝이 필요 | 인터넷 제약이 있거나 로컬 실험을 하고 싶은 경우 |
 
 ### Google
 


### PR DESCRIPTION
## 요약
- runTranslation 캡처/리사이즈 구간을 백그라운드로 분리
- OCR 전처리/크롭 후보 생성 일부를 Task.Run으로 오프로딩
- README에 OCR 엔진/번역 엔진 비교표 추가

## 검증
- git diff --check
- $HOME/.dotnet/dotnet test GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
- $HOME/.dotnet/dotnet build GameChatTranslator/GameChatTranslator.csproj -c Release -p:EnableWindowsTargeting=true
