### PR TITLE
기능: OCR fuzzy dedupe 추가

### DIFF
--- a/GameChatTranslator.Tests/Core/Text/OcrDuplicateTextComparerTests.cs
+++ b/GameChatTranslator.Tests/Core/Text/OcrDuplicateTextComparerTests.cs
@@ -1,0 +1,60 @@
+using GameTranslator;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    public class OcrDuplicateTextComparerTests
+    {
+        [Fact]
+        public void NormalizeForComparison_CollapsesWhitespaceAndRemovesSimplePunctuation()
+        {
+            string normalized = OcrDuplicateTextComparer.NormalizeForComparison("  Hello...   world?!  ");
+
+            Assert.Equal("HELLO WORLD", normalized);
+        }
+
+        [Fact]
+        public void Compare_ShortText_UsesExactMatchOnly()
+        {
+            OcrDuplicateTextComparisonResult result = OcrDuplicateTextComparer.Compare("가자!", "가자?");
+
+            Assert.False(result.IsDuplicate);
+            Assert.False(result.UsedFuzzyComparison);
+        }
+
+        [Fact]
+        public void Compare_LongTextWithWhitespaceAndPunctuationNoise_ReturnsDuplicate()
+        {
+            OcrDuplicateTextComparisonResult result = OcrDuplicateTextComparer.Compare(
+                "[미셸]: hello...   world!",
+                "[미셸]: hello.. world");
+
+            Assert.True(result.IsDuplicate);
+            Assert.True(result.UsedFuzzyComparison);
+            Assert.Equal(0, result.EditDistance);
+        }
+
+        [Fact]
+        public void Compare_LongTextWithSmallOcrNoise_ReturnsDuplicate()
+        {
+            OcrDuplicateTextComparisonResult result = OcrDuplicateTextComparer.Compare(
+                "[미셸]: this is a long sample message",
+                "[미셸]: this is a long samplf message");
+
+            Assert.True(result.IsDuplicate);
+            Assert.True(result.UsedFuzzyComparison);
+            Assert.True(result.EditDistance <= OcrDuplicateTextComparer.MaximumEditDistance);
+        }
+
+        [Fact]
+        public void Compare_ClearlyDifferentLongText_ReturnsNotDuplicate()
+        {
+            OcrDuplicateTextComparisonResult result = OcrDuplicateTextComparer.Compare(
+                "[미셸]: this is a long sample message",
+                "[미셸]: completely different translated input");
+
+            Assert.False(result.IsDuplicate);
+            Assert.True(result.UsedFuzzyComparison);
+        }
+    }
+}

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="../GameChatTranslator/Core/OcrPerformanceReport.cs" Link="Core/OcrPerformanceReport.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrLanguageStatusFormatter.cs" Link="Core/OcrLanguageStatusFormatter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
+    <Compile Include="../GameChatTranslator/Core/OcrDuplicateTextComparer.cs" Link="Core/OcrDuplicateTextComparer.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
     <Compile Include="../GameChatTranslator/Core/EasyOcrCliAdapter.cs" Link="Core/EasyOcrCliAdapter.cs" />
     <Compile Include="../GameChatTranslator/Core/PaddleOcrCliAdapter.cs" Link="Core/PaddleOcrCliAdapter.cs" />

--- a/GameChatTranslator/Core/OcrDuplicateTextComparer.cs
+++ b/GameChatTranslator/Core/OcrDuplicateTextComparer.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace GameTranslator
+{
+    public sealed class OcrDuplicateTextComparisonResult
+    {
+        public bool IsDuplicate { get; set; }
+        public bool UsedFuzzyComparison { get; set; }
+        public string PreviousNormalizedText { get; set; } = "";
+        public string CurrentNormalizedText { get; set; } = "";
+        public int EditDistance { get; set; } = int.MaxValue;
+        public double Similarity { get; set; }
+    }
+
+    public static class OcrDuplicateTextComparer
+    {
+        public const int MinimumFuzzyLength = 10;
+        public const int MaximumEditDistance = 2;
+        public const double MinimumSimilarity = 0.90d;
+
+        private static readonly HashSet<char> IgnoredPunctuationCharacters = new HashSet<char>
+        {
+            '.', ',', '!', '?', ';', ':',
+            '…', '·', '•', '`', '\'', '"',
+            '‘', '’', '“', '”',
+            '。', '，', '！', '？', '：', '；'
+        };
+
+        public static OcrDuplicateTextComparisonResult Compare(string previousText, string currentText)
+        {
+            var result = new OcrDuplicateTextComparisonResult
+            {
+                PreviousNormalizedText = NormalizeForComparison(previousText),
+                CurrentNormalizedText = NormalizeForComparison(currentText)
+            };
+
+            if (string.IsNullOrWhiteSpace(previousText) || string.IsNullOrWhiteSpace(currentText))
+            {
+                return result;
+            }
+
+            if (string.Equals(previousText, currentText, StringComparison.Ordinal))
+            {
+                result.IsDuplicate = true;
+                result.EditDistance = 0;
+                result.Similarity = 1d;
+                return result;
+            }
+
+            int comparisonLength = Math.Max(result.PreviousNormalizedText.Length, result.CurrentNormalizedText.Length);
+            if (comparisonLength < MinimumFuzzyLength)
+            {
+                return result;
+            }
+
+            result.UsedFuzzyComparison = true;
+
+            if (string.Equals(result.PreviousNormalizedText, result.CurrentNormalizedText, StringComparison.Ordinal))
+            {
+                result.IsDuplicate = true;
+                result.EditDistance = 0;
+                result.Similarity = 1d;
+                return result;
+            }
+
+            result.EditDistance = ComputeLevenshteinDistance(result.PreviousNormalizedText, result.CurrentNormalizedText);
+            result.Similarity = ComputeSimilarity(result.PreviousNormalizedText, result.CurrentNormalizedText, result.EditDistance);
+            result.IsDuplicate = result.EditDistance <= MaximumEditDistance || result.Similarity >= MinimumSimilarity;
+            return result;
+        }
+
+        public static string NormalizeForComparison(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "";
+            }
+
+            string collapsedWhitespace = Regex.Replace(value.Trim(), @"\s+", " ");
+            var builder = new StringBuilder(collapsedWhitespace.Length);
+
+            foreach (char character in collapsedWhitespace)
+            {
+                if (IgnoredPunctuationCharacters.Contains(character))
+                {
+                    continue;
+                }
+
+                builder.Append(char.IsLetter(character) ? char.ToUpperInvariant(character) : character);
+            }
+
+            return Regex.Replace(builder.ToString().Trim(), @"\s+", " ");
+        }
+
+        private static double ComputeSimilarity(string previousText, string currentText, int distance)
+        {
+            int maxLength = Math.Max(previousText?.Length ?? 0, currentText?.Length ?? 0);
+            if (maxLength <= 0)
+            {
+                return 1d;
+            }
+
+            return 1d - ((double)distance / maxLength);
+        }
+
+        private static int ComputeLevenshteinDistance(string source, string target)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                return target?.Length ?? 0;
+            }
+
+            if (string.IsNullOrEmpty(target))
+            {
+                return source.Length;
+            }
+
+            var distances = new int[source.Length + 1, target.Length + 1];
+
+            for (int i = 0; i <= source.Length; i++)
+            {
+                distances[i, 0] = i;
+            }
+
+            for (int j = 0; j <= target.Length; j++)
+            {
+                distances[0, j] = j;
+            }
+
+            for (int i = 1; i <= source.Length; i++)
+            {
+                for (int j = 1; j <= target.Length; j++)
+                {
+                    int cost = source[i - 1] == target[j - 1] ? 0 : 1;
+                    distances[i, j] = Math.Min(
+                        Math.Min(
+                            distances[i - 1, j] + 1,
+                            distances[i, j - 1] + 1),
+                        distances[i - 1, j - 1] + cost);
+                }
+            }
+
+            return distances[source.Length, target.Length];
+        }
+    }
+}

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Translation.cs
@@ -426,8 +426,17 @@ namespace GameTranslator
                 AppendLog("DEBUG", $"OCR 엔진: {bestCandidate.EngineDisplayName}, OCR 모드: {GetOcrProcessingModeLabel(processingMode)}, 전처리 선택: {bestCandidate.PreprocessName}, 언어 선택: {bestCandidate.SelectedLanguageCode} (점수 {bestCandidate.Score})", "System");
 
                 string currentRawTextCombined = string.Join("\n", mergedLines.Select(l => l.Text.Trim()));
-                if (currentRawTextCombined == lastRawTextCombined)
+                OcrDuplicateTextComparisonResult duplicateComparison = OcrDuplicateTextComparer.Compare(lastRawTextCombined, currentRawTextCombined);
+                if (duplicateComparison.IsDuplicate)
                 {
+                    if (duplicateComparison.UsedFuzzyComparison)
+                    {
+                        AppendLog(
+                            "DEBUG",
+                            $"유사 OCR 중복으로 스킵됨: distance={duplicateComparison.EditDistance}, similarity={duplicateComparison.Similarity:0.00}",
+                            "System");
+                    }
+
                     performanceStats.Outcome = "DuplicateOcrText";
                     return;
                 }


### PR DESCRIPTION
## 변경 내용
- OCR 중복 판별기를 추가해 정규화 + fuzzy dedupe를 지원합니다
- 10자 미만 텍스트는 기존처럼 exact match만 중복으로 처리합니다
- 10자 이상 텍스트는 편집거리/유사도 기준으로 중복 번역을 건너뜁니다
- 관련 단위 테스트를 추가했습니다

## 검증
- git diff --check
- $HOME/.dotnet/dotnet test GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
- $HOME/.dotnet/dotnet build GameChatTranslator/GameChatTranslator.csproj -c Release -p:EnableWindowsTargeting=true