### PR TITLE
기능: OCR 상주 워커 1차 적용

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
@@ -53,6 +53,23 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void BuildWorkerStartArguments_IncludesWorkerFlag()
+        {
+            var values = _adapter.BuildWorkerStartArguments("easyocr_runner.py");
+
+            Assert.Equal(
+                new[]
+                {
+                    "-X",
+                    "utf8",
+                    "-u",
+                    "easyocr_runner.py",
+                    "--worker"
+                },
+                values);
+        }
+
+        [Fact]
         public void BuildPythonCandidates_IncludesPyLauncherFallback()
         {
             var values = _adapter.GetPythonCandidatesForTesting("");
@@ -106,6 +123,37 @@ namespace GameChatTranslator.Tests
             Assert.Equal("ja+en", group.LanguageCodes);
             Assert.True(group.Success);
             Assert.Equal("猫は可愛い", Assert.Single(group.Lines).Text);
+        }
+
+        [Fact]
+        public void ParseWorkerResponse_ReadsTopLevelFieldsAndGroups()
+        {
+            EasyOcrCliAdapter.EasyOcrWorkerResponse response = EasyOcrCliAdapter.ParseWorkerResponse(
+                """
+                {
+                  "requestId": "req-1",
+                  "ok": true,
+                  "error": "",
+                  "errorCode": "",
+                  "groups": [
+                    {
+                      "language_codes": "ko+en",
+                      "success": true,
+                      "error": "",
+                      "lines": [
+                        { "top": 3, "bottom": 9, "text": "테스트" }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+            Assert.NotNull(response);
+            Assert.Equal("req-1", response.RequestId);
+            Assert.True(response.Ok);
+            EasyOcrCliAdapter.EasyOcrWorkerGroup group = Assert.Single(response.Groups);
+            Assert.Equal("ko+en", group.LanguageCodes);
+            Assert.Equal("테스트", Assert.Single(group.Lines).Text);
         }
     }
 }

--- a/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
@@ -78,6 +78,23 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void BuildWorkerStartArguments_IncludesWorkerFlag()
+        {
+            var values = _adapter.BuildWorkerStartArguments("paddleocr_runner.py");
+
+            Assert.Equal(
+                new[]
+                {
+                    "-X",
+                    "utf8",
+                    "-u",
+                    "paddleocr_runner.py",
+                    "--worker"
+                },
+                values);
+        }
+
+        [Fact]
         public void BuildPythonCandidates_IncludesPyLauncherFallback()
         {
             var values = _adapter.GetPythonCandidatesForTesting("");
@@ -106,6 +123,44 @@ namespace GameChatTranslator.Tests
             Assert.Contains("paddleocr", message, System.StringComparison.OrdinalIgnoreCase);
             Assert.Contains("paddlepaddle", message, System.StringComparison.OrdinalIgnoreCase);
             Assert.Contains("py -m pip", message, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void ParseWorkerResponse_ReadsTopLevelFieldsAndImages()
+        {
+            PaddleOcrCliAdapter.PaddleOcrWorkerResponse response = PaddleOcrCliAdapter.ParseWorkerResponse(
+                """
+                {
+                  "requestId": "req-1",
+                  "ok": true,
+                  "error": "",
+                  "errorCode": "",
+                  "images": [
+                    {
+                      "index": 0,
+                      "groups": [
+                        {
+                          "languageCodes": "korean",
+                          "success": true,
+                          "error": "",
+                          "lines": [
+                            { "top": 2, "bottom": 8, "text": "테스트" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+            Assert.NotNull(response);
+            Assert.Equal("req-1", response.RequestId);
+            Assert.True(response.Ok);
+            PaddleOcrCliAdapter.PaddleOcrWorkerImage image = Assert.Single(response.Images);
+            Assert.Equal(0, image.Index);
+            PaddleOcrCliAdapter.PaddleOcrWorkerGroup group = Assert.Single(image.Groups);
+            Assert.Equal("korean", group.LanguageCodes);
+            Assert.Equal("테스트", Assert.Single(group.Lines).Text);
         }
     }
 }

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="../GameChatTranslator/Core/OcrLanguageStatusFormatter.cs" Link="Core/OcrLanguageStatusFormatter.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDuplicateTextComparer.cs" Link="Core/OcrDuplicateTextComparer.cs" />
+    <Compile Include="../GameChatTranslator/Core/PersistentPythonOcrWorker.cs" Link="Core/PersistentPythonOcrWorker.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
     <Compile Include="../GameChatTranslator/Core/EasyOcrCliAdapter.cs" Link="Core/EasyOcrCliAdapter.cs" />
     <Compile Include="../GameChatTranslator/Core/PaddleOcrCliAdapter.cs" Link="Core/PaddleOcrCliAdapter.cs" />

--- a/GameChatTranslator/Core/EasyOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/EasyOcrCliAdapter.cs
@@ -17,9 +17,11 @@ namespace GameTranslator
     /// 메인 번역 경로는 건드리지 않고, OCR 진단 화면에서 Win OCR/Tesseract와 비교하기 위한 배치 실행만 담당합니다.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public sealed class EasyOcrCliAdapter
+    public sealed class EasyOcrCliAdapter : IDisposable
     {
         private const string RunnerFileName = "easyocr_runner.py";
+        private readonly Dictionary<string, PersistentPythonOcrWorker> workerByPythonPath = new Dictionary<string, PersistentPythonOcrWorker>(StringComparer.OrdinalIgnoreCase);
+        private readonly object workerSync = new object();
 
         private static readonly Dictionary<string, string> AppLanguageToEasyOcrMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -160,7 +162,7 @@ namespace GameTranslator
             {
                 foreach (string pythonPath in GetPythonCandidates(configuredPythonPath))
                 {
-                    EasyOcrCliBatchResult runResult = TryRecognizeInternal(
+                    EasyOcrCliBatchResult runResult = TryRecognizeWithResidentWorker(
                         pythonPath,
                         runnerScriptPath,
                         inputFilePath,
@@ -193,6 +195,19 @@ namespace GameTranslator
             }
         }
 
+        public void Dispose()
+        {
+            lock (workerSync)
+            {
+                foreach (PersistentPythonOcrWorker worker in workerByPythonPath.Values)
+                {
+                    worker.Dispose();
+                }
+
+                workerByPythonPath.Clear();
+            }
+        }
+
         internal string GetRunnerScriptPath()
         {
             return Path.Combine(AppContext.BaseDirectory, RunnerFileName);
@@ -214,6 +229,18 @@ namespace GameTranslator
                 string.Join("|", languageCombinations ?? Array.Empty<string>()),
                 "--gpu",
                 "false"
+            };
+        }
+
+        internal IReadOnlyList<string> BuildWorkerStartArguments(string runnerScriptPath)
+        {
+            return new[]
+            {
+                "-X",
+                "utf8",
+                "-u",
+                runnerScriptPath,
+                "--worker"
             };
         }
 
@@ -360,6 +387,110 @@ namespace GameTranslator
             }
         }
 
+        private EasyOcrCliBatchResult TryRecognizeWithResidentWorker(
+            string pythonExecutablePath,
+            string runnerScriptPath,
+            string inputFilePath,
+            IReadOnlyList<string> languageCombinations,
+            int timeoutMs)
+        {
+            try
+            {
+                PersistentPythonOcrWorker worker = GetOrCreateWorker(pythonExecutablePath, runnerScriptPath);
+                string requestJson = JsonSerializer.Serialize(new EasyOcrWorkerRequest
+                {
+                    RequestId = Guid.NewGuid().ToString("N"),
+                    ImagePath = inputFilePath,
+                    Groups = string.Join("|", languageCombinations ?? Array.Empty<string>()),
+                    Gpu = false
+                });
+
+                PersistentPythonOcrWorkerResult workerResult = worker.SendRequestAsync(requestJson, timeoutMs).GetAwaiter().GetResult();
+                if (!workerResult.Success)
+                {
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        EmptyToFallback(workerResult.ErrorMessage, "EasyOCR 워커 요청에 실패했습니다."),
+                        isPythonMissing: workerResult.IsPythonMissing);
+                }
+
+                EasyOcrWorkerResponse response = ParseWorkerResponse(workerResult.ResponseJson);
+                if (response == null)
+                {
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        "EasyOCR 워커 응답을 해석하지 못했습니다.");
+                }
+
+                if (!response.Ok)
+                {
+                    bool isModuleMissing = string.Equals(response.ErrorCode, "module_missing", StringComparison.OrdinalIgnoreCase);
+                    string errorMessage = isModuleMissing
+                        ? GetFailureMessageForExitCode(3, response.Error)
+                        : EmptyToFallback(response.Error, "EasyOCR 워커가 오류를 반환했습니다.");
+
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        errorMessage,
+                        isModuleMissing: isModuleMissing);
+                }
+
+                List<EasyOcrCliGroupResult> groupResults = ConvertWorkerGroupsToResults(response.Groups);
+                if (groupResults.Count == 0)
+                {
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        EmptyToFallback(workerResult.StandardError, "EasyOCR 결과를 읽지 못했습니다."));
+                }
+
+                int successCount = groupResults.Count(group => group.Success);
+                if (successCount == 0)
+                {
+                    string firstErrorMessage = groupResults
+                        .Select(group => group.ErrorMessage)
+                        .FirstOrDefault(message => !string.IsNullOrWhiteSpace(message));
+                    return EasyOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCombinations,
+                        EmptyToFallback(firstErrorMessage, "EasyOCR 결과가 모두 실패했습니다."));
+                }
+
+                return EasyOcrCliBatchResult.CreateSuccess(
+                    pythonExecutablePath,
+                    languageCombinations,
+                    groupResults,
+                    workerResult.StandardError);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                lock (workerSync)
+                {
+                    if (workerByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorker worker))
+                    {
+                        worker.Dispose();
+                        workerByPythonPath.Remove(pythonExecutablePath);
+                    }
+                }
+
+                return EasyOcrCliBatchResult.CreateFailure(
+                    pythonExecutablePath,
+                    languageCombinations,
+                    "python 또는 py 실행 파일을 찾지 못했습니다.",
+                    isPythonMissing: true);
+            }
+            catch (Exception ex)
+            {
+                return EasyOcrCliBatchResult.CreateFailure(
+                    pythonExecutablePath,
+                    languageCombinations,
+                    ex.Message);
+            }
+        }
+
         internal static List<EasyOcrCliGroupResult> ParseGroupResults(string json)
         {
             EasyOcrRunnerResponse response = JsonSerializer.Deserialize<EasyOcrRunnerResponse>(json ?? "", new JsonSerializerOptions
@@ -384,9 +515,50 @@ namespace GameTranslator
                 .ToList();
         }
 
+        internal static EasyOcrWorkerResponse ParseWorkerResponse(string json)
+        {
+            return JsonSerializer.Deserialize<EasyOcrWorkerResponse>(json ?? "", new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+        }
+
+        internal static List<EasyOcrCliGroupResult> ConvertWorkerGroupsToResults(IReadOnlyList<EasyOcrWorkerGroup> groups)
+        {
+            return (groups ?? Array.Empty<EasyOcrWorkerGroup>())
+                .Select(group => new EasyOcrCliGroupResult(
+                    group?.LanguageCodes ?? "",
+                    group?.Success ?? false,
+                    (group?.Lines ?? new List<EasyOcrWorkerLine>())
+                        .Where(line => !string.IsNullOrWhiteSpace(line?.Text))
+                        .Select(line => new OcrLine
+                        {
+                            Top = line.Top,
+                            Bottom = line.Bottom,
+                            Text = line.Text.Trim()
+                        })
+                        .ToList(),
+                    group?.Error ?? ""))
+                .ToList();
+        }
+
         private static string EmptyToFallback(string value, string fallback)
         {
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+
+        private PersistentPythonOcrWorker GetOrCreateWorker(string pythonExecutablePath, string runnerScriptPath)
+        {
+            lock (workerSync)
+            {
+                if (!workerByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorker worker))
+                {
+                    worker = new PersistentPythonOcrWorker(pythonExecutablePath, runnerScriptPath);
+                    workerByPythonPath.Add(pythonExecutablePath, worker);
+                }
+
+                return worker;
+            }
         }
 
         private sealed class EasyOcrRunnerResponse
@@ -404,6 +576,39 @@ namespace GameTranslator
         }
 
         private sealed class EasyOcrRunnerLine
+        {
+            public double Top { get; set; }
+            public double Bottom { get; set; }
+            public string Text { get; set; } = "";
+        }
+
+        private sealed class EasyOcrWorkerRequest
+        {
+            public string RequestId { get; set; } = "";
+            public string ImagePath { get; set; } = "";
+            public string Groups { get; set; } = "";
+            public bool Gpu { get; set; }
+        }
+
+        internal sealed class EasyOcrWorkerResponse
+        {
+            public string RequestId { get; set; } = "";
+            public bool Ok { get; set; }
+            public string Error { get; set; } = "";
+            public string ErrorCode { get; set; } = "";
+            public List<EasyOcrWorkerGroup> Groups { get; set; } = new List<EasyOcrWorkerGroup>();
+        }
+
+        internal sealed class EasyOcrWorkerGroup
+        {
+            [JsonPropertyName("language_codes")]
+            public string LanguageCodes { get; set; } = "";
+            public bool Success { get; set; }
+            public string Error { get; set; } = "";
+            public List<EasyOcrWorkerLine> Lines { get; set; } = new List<EasyOcrWorkerLine>();
+        }
+
+        internal sealed class EasyOcrWorkerLine
         {
             public double Top { get; set; }
             public double Bottom { get; set; }

--- a/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
@@ -16,9 +16,11 @@ namespace GameTranslator
     /// 메인 번역 경로는 건드리지 않고, OCR 진단 화면에서 Win OCR/Tesseract/EasyOCR와 비교하기 위한 배치 실행만 담당합니다.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public sealed class PaddleOcrCliAdapter
+    public sealed class PaddleOcrCliAdapter : IDisposable
     {
         private const string RunnerFileName = "paddleocr_runner.py";
+        private readonly Dictionary<string, PersistentPythonOcrWorker> workerByPythonPath = new Dictionary<string, PersistentPythonOcrWorker>(StringComparer.OrdinalIgnoreCase);
+        private readonly object workerSync = new object();
 
         private static readonly Dictionary<string, string> AppLanguageToPaddleOcrMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -174,7 +176,7 @@ namespace GameTranslator
             {
                 foreach (string pythonPath in GetPythonCandidates(configuredPythonPath))
                 {
-                    PaddleOcrCliBatchResult runResult = TryRecognizeInternal(
+                    PaddleOcrCliBatchResult runResult = TryRecognizeWithResidentWorker(
                         pythonPath,
                         runnerScriptPath,
                         inputFilePaths,
@@ -210,6 +212,19 @@ namespace GameTranslator
             }
         }
 
+        public void Dispose()
+        {
+            lock (workerSync)
+            {
+                foreach (PersistentPythonOcrWorker worker in workerByPythonPath.Values)
+                {
+                    worker.Dispose();
+                }
+
+                workerByPythonPath.Clear();
+            }
+        }
+
         internal string GetRunnerScriptPath()
         {
             return Path.Combine(AppContext.BaseDirectory, RunnerFileName);
@@ -239,6 +254,18 @@ namespace GameTranslator
                 string.Join("|", languageCandidates ?? Array.Empty<string>()),
                 "--gpu",
                 "false"
+            };
+        }
+
+        internal IReadOnlyList<string> BuildWorkerStartArguments(string runnerScriptPath)
+        {
+            return new[]
+            {
+                "-X",
+                "utf8",
+                "-u",
+                runnerScriptPath,
+                "--worker"
             };
         }
 
@@ -379,6 +406,111 @@ namespace GameTranslator
             }
         }
 
+        private PaddleOcrCliBatchResult TryRecognizeWithResidentWorker(
+            string pythonExecutablePath,
+            string runnerScriptPath,
+            IReadOnlyList<string> inputFilePaths,
+            IReadOnlyList<string> languageCandidates,
+            int timeoutMs)
+        {
+            try
+            {
+                PersistentPythonOcrWorker worker = GetOrCreateWorker(pythonExecutablePath, runnerScriptPath);
+                string requestJson = JsonSerializer.Serialize(new PaddleOcrWorkerRequest
+                {
+                    RequestId = Guid.NewGuid().ToString("N"),
+                    ImagePaths = inputFilePaths?.ToList() ?? new List<string>(),
+                    Groups = string.Join("|", languageCandidates ?? Array.Empty<string>()),
+                    Gpu = false
+                });
+
+                PersistentPythonOcrWorkerResult workerResult = worker.SendRequestAsync(requestJson, timeoutMs).GetAwaiter().GetResult();
+                if (!workerResult.Success)
+                {
+                    return PaddleOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCandidates,
+                        EmptyToFallback(workerResult.ErrorMessage, "PaddleOCR 워커 요청에 실패했습니다."),
+                        isPythonMissing: workerResult.IsPythonMissing);
+                }
+
+                PaddleOcrWorkerResponse response = ParseWorkerResponse(workerResult.ResponseJson);
+                if (response == null)
+                {
+                    return PaddleOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCandidates,
+                        "PaddleOCR 워커 응답을 해석하지 못했습니다.");
+                }
+
+                if (!response.Ok)
+                {
+                    bool isModuleMissing = string.Equals(response.ErrorCode, "module_missing", StringComparison.OrdinalIgnoreCase);
+                    string errorMessage = isModuleMissing
+                        ? GetFailureMessageForExitCode(3, response.Error)
+                        : EmptyToFallback(response.Error, "PaddleOCR 워커가 오류를 반환했습니다.");
+
+                    return PaddleOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCandidates,
+                        errorMessage,
+                        isModuleMissing: isModuleMissing);
+                }
+
+                List<PaddleOcrCliImageResult> imageResults = ConvertWorkerImagesToResults(response.Images);
+                if (imageResults.Count == 0)
+                {
+                    return PaddleOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCandidates,
+                        EmptyToFallback(workerResult.StandardError, "PaddleOCR 결과를 읽지 못했습니다."));
+                }
+
+                int successCount = imageResults.Sum(image => image.GroupResults.Count(group => group.Success));
+                if (successCount == 0)
+                {
+                    string firstErrorMessage = imageResults
+                        .SelectMany(image => image.GroupResults)
+                        .Select(group => group.ErrorMessage)
+                        .FirstOrDefault(message => !string.IsNullOrWhiteSpace(message));
+                    return PaddleOcrCliBatchResult.CreateFailure(
+                        pythonExecutablePath,
+                        languageCandidates,
+                        EmptyToFallback(firstErrorMessage, "PaddleOCR 결과가 모두 실패했습니다."));
+                }
+
+                return PaddleOcrCliBatchResult.CreateSuccess(
+                    pythonExecutablePath,
+                    languageCandidates,
+                    imageResults,
+                    workerResult.StandardError);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                lock (workerSync)
+                {
+                    if (workerByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorker worker))
+                    {
+                        worker.Dispose();
+                        workerByPythonPath.Remove(pythonExecutablePath);
+                    }
+                }
+
+                return PaddleOcrCliBatchResult.CreateFailure(
+                    pythonExecutablePath,
+                    languageCandidates,
+                    "python 또는 py 실행 파일을 찾지 못했습니다.",
+                    isPythonMissing: true);
+            }
+            catch (Exception ex)
+            {
+                return PaddleOcrCliBatchResult.CreateFailure(
+                    pythonExecutablePath,
+                    languageCandidates,
+                    ex.Message);
+            }
+        }
+
         private static List<PaddleOcrCliImageResult> ParseImageResults(string json)
         {
             PaddleOcrRunnerResponse response = JsonSerializer.Deserialize<PaddleOcrRunnerResponse>(json ?? "", new JsonSerializerOptions
@@ -437,9 +569,55 @@ namespace GameTranslator
             return new List<PaddleOcrCliImageResult>();
         }
 
+        internal static PaddleOcrWorkerResponse ParseWorkerResponse(string json)
+        {
+            return JsonSerializer.Deserialize<PaddleOcrWorkerResponse>(json ?? "", new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+        }
+
+        internal static List<PaddleOcrCliImageResult> ConvertWorkerImagesToResults(IReadOnlyList<PaddleOcrWorkerImage> images)
+        {
+            return (images ?? Array.Empty<PaddleOcrWorkerImage>())
+                .OrderBy(image => image?.Index ?? int.MaxValue)
+                .Select(image => new PaddleOcrCliImageResult(
+                    image?.Index ?? -1,
+                    (image?.Groups ?? new List<PaddleOcrWorkerGroup>())
+                        .Select(group => new PaddleOcrCliGroupResult(
+                            group?.LanguageCodes ?? "",
+                            group?.Success ?? false,
+                            (group?.Lines ?? new List<PaddleOcrWorkerLine>())
+                                .Where(line => !string.IsNullOrWhiteSpace(line?.Text))
+                                .Select(line => new OcrLine
+                                {
+                                    Top = line.Top,
+                                    Bottom = line.Bottom,
+                                    Text = line.Text.Trim()
+                                })
+                                .ToList(),
+                            group?.Error ?? ""))
+                        .ToList()))
+                .ToList();
+        }
+
         private static string EmptyToFallback(string value, string fallback)
         {
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+
+        private PersistentPythonOcrWorker GetOrCreateWorker(string pythonExecutablePath, string runnerScriptPath)
+        {
+            lock (workerSync)
+            {
+                if (!workerByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorker worker))
+                {
+                    worker = new PersistentPythonOcrWorker(pythonExecutablePath, runnerScriptPath);
+                    workerByPythonPath.Add(pythonExecutablePath, worker);
+                }
+
+                return worker;
+            }
         }
 
         private sealed class PaddleOcrRunnerResponse
@@ -463,6 +641,44 @@ namespace GameTranslator
         }
 
         private sealed class PaddleOcrRunnerLine
+        {
+            public double Top { get; set; }
+            public double Bottom { get; set; }
+            public string Text { get; set; } = "";
+        }
+
+        private sealed class PaddleOcrWorkerRequest
+        {
+            public string RequestId { get; set; } = "";
+            public List<string> ImagePaths { get; set; } = new List<string>();
+            public string Groups { get; set; } = "";
+            public bool Gpu { get; set; }
+        }
+
+        internal sealed class PaddleOcrWorkerResponse
+        {
+            public string RequestId { get; set; } = "";
+            public bool Ok { get; set; }
+            public string Error { get; set; } = "";
+            public string ErrorCode { get; set; } = "";
+            public List<PaddleOcrWorkerImage> Images { get; set; } = new List<PaddleOcrWorkerImage>();
+        }
+
+        internal sealed class PaddleOcrWorkerImage
+        {
+            public int Index { get; set; }
+            public List<PaddleOcrWorkerGroup> Groups { get; set; } = new List<PaddleOcrWorkerGroup>();
+        }
+
+        internal sealed class PaddleOcrWorkerGroup
+        {
+            public string LanguageCodes { get; set; } = "";
+            public bool Success { get; set; }
+            public string Error { get; set; } = "";
+            public List<PaddleOcrWorkerLine> Lines { get; set; } = new List<PaddleOcrWorkerLine>();
+        }
+
+        internal sealed class PaddleOcrWorkerLine
         {
             public double Top { get; set; }
             public double Bottom { get; set; }

--- a/GameChatTranslator/Core/PersistentPythonOcrWorker.cs
+++ b/GameChatTranslator/Core/PersistentPythonOcrWorker.cs
@@ -1,0 +1,386 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GameTranslator
+{
+    [SupportedOSPlatform("windows")]
+    public sealed class PersistentPythonOcrWorker : IDisposable
+    {
+        public const int DefaultInitializationTimeoutMs = 30000;
+
+        private const int MaxCapturedStandardErrorLines = 64;
+
+        private readonly string pythonExecutablePath;
+        private readonly string runnerScriptPath;
+        private readonly SemaphoreSlim requestLock = new SemaphoreSlim(1, 1);
+        private readonly object processSync = new object();
+        private readonly Queue<string> standardErrorLines = new Queue<string>();
+
+        private Process process;
+        private Task standardErrorPumpTask = Task.CompletedTask;
+        private bool isWarm;
+        private bool disposed;
+
+        public PersistentPythonOcrWorker(string pythonExecutablePath, string runnerScriptPath)
+        {
+            this.pythonExecutablePath = pythonExecutablePath ?? "";
+            this.runnerScriptPath = runnerScriptPath ?? "";
+        }
+
+        public string PythonExecutablePath => pythonExecutablePath;
+        public string RunnerScriptPath => runnerScriptPath;
+
+        public async Task<PersistentPythonOcrWorkerResult> SendRequestAsync(string requestJson, int requestTimeoutMs)
+        {
+            if (string.IsNullOrWhiteSpace(requestJson))
+            {
+                throw new ArgumentException("요청 JSON이 비어 있습니다.", nameof(requestJson));
+            }
+
+            await requestLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                bool startedNow;
+                try
+                {
+                    startedNow = EnsureStarted();
+                }
+                catch (Win32Exception)
+                {
+                    return PersistentPythonOcrWorkerResult.CreateFailure(
+                        "python 또는 py 실행 파일을 찾지 못했습니다.",
+                        isPythonMissing: true);
+                }
+                catch (Exception ex)
+                {
+                    return PersistentPythonOcrWorkerResult.CreateFailure(ex.Message);
+                }
+
+                ClearStandardErrorLines();
+
+                bool usedInitializationTimeout = startedNow || !isWarm;
+                int effectiveTimeoutMs = usedInitializationTimeout
+                    ? Math.Max(DefaultInitializationTimeoutMs, requestTimeoutMs)
+                    : requestTimeoutMs;
+
+                try
+                {
+                    Process currentProcess = process;
+                    if (currentProcess == null || currentProcess.HasExited)
+                    {
+                        RestartProcess();
+                        currentProcess = process;
+                    }
+
+                    if (currentProcess == null)
+                    {
+                        return PersistentPythonOcrWorkerResult.CreateFailure("Python 워커를 시작하지 못했습니다.");
+                    }
+
+                    await currentProcess.StandardInput.WriteLineAsync(requestJson).ConfigureAwait(false);
+                    await currentProcess.StandardInput.FlushAsync().ConfigureAwait(false);
+
+                    string responseLine = await currentProcess.StandardOutput.ReadLineAsync()
+                        .WaitAsync(TimeSpan.FromMilliseconds(effectiveTimeoutMs))
+                        .ConfigureAwait(false);
+
+                    if (string.IsNullOrWhiteSpace(responseLine))
+                    {
+                        RestartProcess();
+                        return PersistentPythonOcrWorkerResult.CreateFailure(
+                            "Python 워커가 빈 응답을 반환했습니다.",
+                            standardError: GetCapturedStandardErrorText());
+                    }
+
+                    isWarm = true;
+                    return PersistentPythonOcrWorkerResult.CreateSuccess(
+                        responseLine,
+                        GetCapturedStandardErrorText(),
+                        usedInitializationTimeout);
+                }
+                catch (TimeoutException)
+                {
+                    string standardError = GetCapturedStandardErrorText();
+                    RestartProcess();
+                    return PersistentPythonOcrWorkerResult.CreateFailure(
+                        $"Python 워커 응답이 {effectiveTimeoutMs}ms 안에 도착하지 않았습니다.",
+                        standardError,
+                        timedOut: true);
+                }
+                catch (Win32Exception)
+                {
+                    RestartProcess();
+                    return PersistentPythonOcrWorkerResult.CreateFailure(
+                        "python 또는 py 실행 파일을 찾지 못했습니다.",
+                        isPythonMissing: true,
+                        standardError: GetCapturedStandardErrorText());
+                }
+                catch (Exception ex)
+                {
+                    string standardError = GetCapturedStandardErrorText();
+                    RestartProcess();
+                    return PersistentPythonOcrWorkerResult.CreateFailure(ex.Message, standardError);
+                }
+            }
+            finally
+            {
+                requestLock.Release();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            StopProcess();
+        }
+
+        internal IReadOnlyList<string> BuildWorkerStartArguments()
+        {
+            return new[]
+            {
+                "-X",
+                "utf8",
+                "-u",
+                runnerScriptPath,
+                "--worker"
+            };
+        }
+
+        private bool EnsureStarted()
+        {
+            lock (processSync)
+            {
+                ThrowIfDisposed();
+
+                if (process != null && !process.HasExited)
+                {
+                    return false;
+                }
+
+                StopProcessUnsafe();
+
+                var processStartInfo = new ProcessStartInfo
+                {
+                    FileName = pythonExecutablePath,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    StandardInputEncoding = Encoding.UTF8,
+                    StandardOutputEncoding = Encoding.UTF8,
+                    StandardErrorEncoding = Encoding.UTF8
+                };
+
+                foreach (string argument in BuildWorkerStartArguments())
+                {
+                    processStartInfo.ArgumentList.Add(argument);
+                }
+
+                process = Process.Start(processStartInfo);
+                if (process == null)
+                {
+                    throw new InvalidOperationException("Python 워커 프로세스를 시작하지 못했습니다.");
+                }
+
+                isWarm = false;
+                standardErrorPumpTask = PumpStandardErrorAsync(process);
+                return true;
+            }
+        }
+
+        private void RestartProcess()
+        {
+            lock (processSync)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                StopProcessUnsafe();
+                try
+                {
+                    EnsureStarted();
+                }
+                catch
+                {
+                    StopProcessUnsafe();
+                }
+            }
+        }
+
+        private void StopProcess()
+        {
+            lock (processSync)
+            {
+                StopProcessUnsafe();
+            }
+        }
+
+        private void StopProcessUnsafe()
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                process.Dispose();
+            }
+            catch
+            {
+            }
+
+            process = null;
+            isWarm = false;
+            ClearStandardErrorLines();
+        }
+
+        private async Task PumpStandardErrorAsync(Process currentProcess)
+        {
+            try
+            {
+                while (true)
+                {
+                    string line = await currentProcess.StandardError.ReadLineAsync().ConfigureAwait(false);
+                    if (line == null)
+                    {
+                        break;
+                    }
+
+                    AppendStandardErrorLine(line);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void AppendStandardErrorLine(string line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return;
+            }
+
+            lock (standardErrorLines)
+            {
+                standardErrorLines.Enqueue(line.Trim());
+                while (standardErrorLines.Count > MaxCapturedStandardErrorLines)
+                {
+                    standardErrorLines.Dequeue();
+                }
+            }
+        }
+
+        private void ClearStandardErrorLines()
+        {
+            lock (standardErrorLines)
+            {
+                standardErrorLines.Clear();
+            }
+        }
+
+        private string GetCapturedStandardErrorText()
+        {
+            lock (standardErrorLines)
+            {
+                return string.Join(Environment.NewLine, standardErrorLines.ToArray());
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(PersistentPythonOcrWorker));
+            }
+        }
+    }
+
+    public sealed class PersistentPythonOcrWorkerResult
+    {
+        private PersistentPythonOcrWorkerResult(
+            bool success,
+            string responseJson,
+            string errorMessage,
+            string standardError,
+            bool isPythonMissing,
+            bool timedOut,
+            bool usedInitializationTimeout)
+        {
+            Success = success;
+            ResponseJson = responseJson ?? "";
+            ErrorMessage = errorMessage ?? "";
+            StandardError = standardError ?? "";
+            IsPythonMissing = isPythonMissing;
+            TimedOut = timedOut;
+            UsedInitializationTimeout = usedInitializationTimeout;
+        }
+
+        public bool Success { get; }
+        public string ResponseJson { get; }
+        public string ErrorMessage { get; }
+        public string StandardError { get; }
+        public bool IsPythonMissing { get; }
+        public bool TimedOut { get; }
+        public bool UsedInitializationTimeout { get; }
+
+        public static PersistentPythonOcrWorkerResult CreateSuccess(
+            string responseJson,
+            string standardError,
+            bool usedInitializationTimeout)
+        {
+            return new PersistentPythonOcrWorkerResult(
+                true,
+                responseJson,
+                "",
+                standardError,
+                false,
+                false,
+                usedInitializationTimeout);
+        }
+
+        public static PersistentPythonOcrWorkerResult CreateFailure(
+            string errorMessage,
+            string standardError = "",
+            bool isPythonMissing = false,
+            bool timedOut = false)
+        {
+            return new PersistentPythonOcrWorkerResult(
+                false,
+                "",
+                errorMessage,
+                standardError,
+                isPythonMissing,
+                timedOut,
+                false);
+        }
+    }
+}

--- a/GameChatTranslator/Distribution/easyocr_runner.py
+++ b/GameChatTranslator/Distribution/easyocr_runner.py
@@ -4,11 +4,17 @@ import sys
 import warnings
 
 
+EASYOCR_MODULE = None
+EASYOCR_IMPORT_ERROR = None
+READER_CACHE = {}
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--image", required=True)
-    parser.add_argument("--groups", required=True)
+    parser.add_argument("--image")
+    parser.add_argument("--groups")
     parser.add_argument("--gpu", default="false")
+    parser.add_argument("--worker", action="store_true")
     return parser.parse_args()
 
 
@@ -142,34 +148,58 @@ def build_lines(results):
     return lines
 
 
-def main():
-    args = parse_args()
-    language_groups = parse_language_groups(args.groups)
-    if not language_groups:
-        print("EasyOCR language groups are empty.", file=sys.stderr)
-        return 2
+def import_easyocr():
+    global EASYOCR_MODULE
+    global EASYOCR_IMPORT_ERROR
 
-    use_gpu = str(args.gpu).strip().lower() in ("1", "true", "yes", "y", "on")
+    if EASYOCR_MODULE is not None:
+        return EASYOCR_MODULE
+
+    if EASYOCR_IMPORT_ERROR is not None:
+        raise EASYOCR_IMPORT_ERROR
 
     try:
         import easyocr
-    except Exception:
-        print("EasyOCR module is not installed.", file=sys.stderr)
-        return 3
+        EASYOCR_MODULE = easyocr
+        return EASYOCR_MODULE
+    except Exception as exc:
+        EASYOCR_IMPORT_ERROR = exc
+        raise
 
-    warnings.filterwarnings(
-        "ignore",
-        message=".*pin_memory.*",
-        category=UserWarning,
-    )
 
-    response = {"groups": []}
+def get_reader(languages, use_gpu):
+    cache_key = ("+".join(languages), bool(use_gpu))
+    if cache_key in READER_CACHE:
+        return READER_CACHE[cache_key]
+
+    easyocr = import_easyocr()
+    reader = easyocr.Reader(languages, gpu=use_gpu, verbose=False)
+    READER_CACHE[cache_key] = reader
+    return reader
+
+
+def run_groups(image_path, raw_groups, use_gpu):
+    language_groups = parse_language_groups(raw_groups)
+    if not language_groups:
+        return {
+            "ok": False,
+            "error": "EasyOCR language groups are empty.",
+            "errorCode": "invalid_request",
+            "groups": []
+        }
+
+    response = {
+        "ok": True,
+        "error": "",
+        "errorCode": "",
+        "groups": []
+    }
 
     for languages in language_groups:
         language_codes = "+".join(languages)
         try:
-            reader = easyocr.Reader(languages, gpu=use_gpu, verbose=False)
-            results = reader.readtext(args.image, detail=1, paragraph=False)
+            reader = get_reader(languages, use_gpu)
+            results = reader.readtext(image_path, detail=1, paragraph=False)
             response["groups"].append(
                 {
                     "language_codes": language_codes,
@@ -188,7 +218,107 @@ def main():
                 }
             )
 
-    print(json.dumps(response, ensure_ascii=False))
+    return response
+
+
+def write_worker_response(payload):
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def run_worker():
+    warnings.filterwarnings(
+        "ignore",
+        message=".*pin_memory.*",
+        category=UserWarning,
+    )
+
+    while True:
+        raw_line = sys.stdin.readline()
+        if raw_line == "":
+            return 0
+
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        request_id = ""
+        try:
+            payload = json.loads(raw_line)
+            request_id = str(payload.get("requestId", "")).strip()
+            image_path = str(payload.get("imagePath", "")).strip()
+            raw_groups = str(payload.get("groups", "")).strip()
+            use_gpu = bool(payload.get("gpu", False))
+
+            if not image_path:
+                write_worker_response(
+                    {
+                        "requestId": request_id,
+                        "ok": False,
+                        "error": "EasyOCR image path is empty.",
+                        "errorCode": "invalid_request",
+                        "groups": []
+                    }
+                )
+                continue
+
+            try:
+                response = run_groups(image_path, raw_groups, use_gpu)
+            except Exception as exc:
+                write_worker_response(
+                    {
+                        "requestId": request_id,
+                        "ok": False,
+                        "error": str(exc),
+                        "errorCode": "module_missing" if EASYOCR_IMPORT_ERROR is not None else "runtime_error",
+                        "groups": []
+                    }
+                )
+                continue
+
+            response["requestId"] = request_id
+            write_worker_response(response)
+        except Exception as exc:
+            write_worker_response(
+                {
+                    "requestId": request_id,
+                    "ok": False,
+                    "error": str(exc),
+                    "errorCode": "runtime_error",
+                    "groups": []
+                }
+            )
+
+
+def main():
+    args = parse_args()
+    use_gpu = str(args.gpu).strip().lower() in ("1", "true", "yes", "y", "on")
+
+    if args.worker:
+        return run_worker()
+
+    if not args.image:
+        print("EasyOCR image path is empty.", file=sys.stderr)
+        return 2
+
+    warnings.filterwarnings(
+        "ignore",
+        message=".*pin_memory.*",
+        category=UserWarning,
+    )
+
+    try:
+        import_easyocr()
+    except Exception:
+        print("EasyOCR module is not installed.", file=sys.stderr)
+        return 3
+
+    response = run_groups(args.image, args.groups, use_gpu)
+    if not response.get("ok", False):
+        print(response.get("error", "EasyOCR execution failed."), file=sys.stderr)
+        return 4
+
+    print(json.dumps({"groups": response["groups"]}, ensure_ascii=False))
     return 0
 
 

--- a/GameChatTranslator/Distribution/paddleocr_runner.py
+++ b/GameChatTranslator/Distribution/paddleocr_runner.py
@@ -5,23 +5,22 @@ import sys
 import warnings
 
 
+PADDLEOCR_IMPORT_ERROR = None
+OCR_CACHE = {}
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--image")
     parser.add_argument("--images")
-    parser.add_argument("--groups", required=True)
+    parser.add_argument("--groups")
     parser.add_argument("--gpu", default="false")
+    parser.add_argument("--worker", action="store_true")
     return parser.parse_args()
 
 
-def parse_image_paths(args):
-    if getattr(args, "images", None):
-        return [value.strip() for value in args.images.split("|") if value.strip()]
-
-    if getattr(args, "image", None):
-        return [args.image.strip()] if str(args.image).strip() else []
-
-    return []
+def parse_image_paths(raw_value):
+    return [value.strip() for value in (raw_value or "").split("|") if value.strip()]
 
 
 def parse_language_groups(raw_value):
@@ -239,9 +238,20 @@ def recognize_with_legacy_ocr(ocr, image_path):
     return build_lines_from_words(build_words_from_legacy_payload(results))
 
 
+def import_paddleocr():
+    global PADDLEOCR_IMPORT_ERROR
+
+    if PADDLEOCR_IMPORT_ERROR is not None:
+        raise PADDLEOCR_IMPORT_ERROR
+
+    try:
+        import paddleocr  # noqa: F401
+    except Exception as exc:
+        PADDLEOCR_IMPORT_ERROR = exc
+        raise
+
+
 def create_ocr(language_code, use_gpu):
-    # PaddlePaddle 3.3.x CPU inference can fail in PIR/oneDNN conversion.
-    # Set this before importing paddleocr so the diagnostic runner stays usable.
     os.environ.setdefault("FLAGS_enable_pir_api", "0")
 
     from paddleocr import PaddleOCR
@@ -265,6 +275,17 @@ def create_ocr(language_code, use_gpu):
     return ocr
 
 
+def get_ocr(language_code, use_gpu):
+    cache_key = (language_code, bool(use_gpu))
+    if cache_key in OCR_CACHE:
+        return OCR_CACHE[cache_key]
+
+    import_paddleocr()
+    ocr = create_ocr(language_code, use_gpu)
+    OCR_CACHE[cache_key] = ocr
+    return ocr
+
+
 def recognize_image(ocr, image_path):
     if hasattr(ocr, "predict"):
         return recognize_with_predict(ocr, image_path)
@@ -272,29 +293,28 @@ def recognize_image(ocr, image_path):
     return recognize_with_legacy_ocr(ocr, image_path)
 
 
-def main():
-    args = parse_args()
-    image_paths = parse_image_paths(args)
-    language_groups = parse_language_groups(args.groups)
+def run_groups(image_paths, raw_groups, use_gpu):
+    language_groups = parse_language_groups(raw_groups)
     if not image_paths:
-        print("PaddleOCR image paths are empty.", file=sys.stderr)
-        return 2
+        return {
+            "ok": False,
+            "error": "PaddleOCR image paths are empty.",
+            "errorCode": "invalid_request",
+            "images": []
+        }
 
     if not language_groups:
-        print("PaddleOCR language groups are empty.", file=sys.stderr)
-        return 2
-
-    use_gpu = str(args.gpu).strip().lower() in ("1", "true", "yes", "y", "on")
-
-    try:
-        import paddleocr  # noqa: F401
-    except Exception:
-        print("PaddleOCR module is not installed.", file=sys.stderr)
-        return 3
-
-    warnings.filterwarnings("ignore")
+        return {
+            "ok": False,
+            "error": "PaddleOCR language groups are empty.",
+            "errorCode": "invalid_request",
+            "images": []
+        }
 
     response = {
+        "ok": True,
+        "error": "",
+        "errorCode": "",
         "images": [
             {
                 "index": index,
@@ -306,7 +326,7 @@ def main():
 
     for language_code in language_groups:
         try:
-            ocr = create_ocr(language_code, use_gpu)
+            ocr = get_ocr(language_code, use_gpu)
             for index, image_path in enumerate(image_paths):
                 lines = recognize_image(ocr, image_path)
                 response["images"][index]["groups"].append(
@@ -329,7 +349,87 @@ def main():
                     }
                 )
 
-    print(json.dumps(response, ensure_ascii=False))
+    return response
+
+
+def write_worker_response(payload):
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def run_worker():
+    warnings.filterwarnings("ignore")
+
+    while True:
+        raw_line = sys.stdin.readline()
+        if raw_line == "":
+            return 0
+
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        request_id = ""
+        try:
+            payload = json.loads(raw_line)
+            request_id = str(payload.get("requestId", "")).strip()
+            image_paths = payload.get("imagePaths") or []
+            if not isinstance(image_paths, list):
+                image_paths = []
+            image_paths = [str(path).strip() for path in image_paths if str(path).strip()]
+            raw_groups = str(payload.get("groups", "")).strip()
+            use_gpu = bool(payload.get("gpu", False))
+
+            try:
+                response = run_groups(image_paths, raw_groups, use_gpu)
+            except Exception as exc:
+                write_worker_response(
+                    {
+                        "requestId": request_id,
+                        "ok": False,
+                        "error": str(exc),
+                        "errorCode": "module_missing" if PADDLEOCR_IMPORT_ERROR is not None else "runtime_error",
+                        "images": []
+                    }
+                )
+                continue
+
+            response["requestId"] = request_id
+            write_worker_response(response)
+        except Exception as exc:
+            write_worker_response(
+                {
+                    "requestId": request_id,
+                    "ok": False,
+                    "error": str(exc),
+                    "errorCode": "runtime_error",
+                    "images": []
+                }
+            )
+
+
+def main():
+    args = parse_args()
+    use_gpu = str(args.gpu).strip().lower() in ("1", "true", "yes", "y", "on")
+
+    if args.worker:
+        return run_worker()
+
+    image_paths = parse_image_paths(args.images or args.image)
+    warnings.filterwarnings("ignore")
+
+    try:
+        import_paddleocr()
+    except Exception:
+        print("PaddleOCR module is not installed.", file=sys.stderr)
+        return 3
+
+    response = run_groups(image_paths, args.groups, use_gpu)
+    if not response.get("ok", False):
+        print(response.get("error", "PaddleOCR execution failed."), file=sys.stderr)
+        return 4
+
+    print(json.dumps({"images": response["images"]}, ensure_ascii=False))
     return 0
 
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
@@ -202,6 +202,8 @@ namespace GameTranslator
             }
             logViewerWindow?.CloseForShutdown();
             ocrDiagnosticWindow?.Close();
+            easyOcrCliAdapter.Dispose();
+            paddleOcrCliAdapter.Dispose();
             UnregisterHotKey(_windowHandle, ID_HOTKEY_MOVE_LOCK);
             UnregisterHotKey(_windowHandle, ID_HOTKEY_AREA_SELECT);
             UnregisterHotKey(_windowHandle, ID_HOTKEY_TRANSLATE);


### PR DESCRIPTION
## 변경 내용
- EasyOCR / PaddleOCR를 Process.Start 1회 실행형 resident worker로 전환했습니다
- 공용 PersistentPythonOcrWorker를 추가하고 lazy init + request lock + timeout/restart를 반영했습니다
- python runner에 worker 모드를 추가해 line-delimited JSON IPC를 지원합니다
- 앱 종료 시 worker 프로세스를 정리합니다
- 관련 단위 테스트를 추가했습니다

## 검증
- git diff --check
- $HOME/.dotnet/dotnet build GameChatTranslator/GameChatTranslator.csproj -c Release -p:EnableWindowsTargeting=true
- $HOME/.dotnet/dotnet test GameChatTranslator.Tests/GameChatTranslator.Tests.csproj