### PR TITLE
기능: OCR shared worker registry 적용

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/PersistentPythonOcrWorkerRegistryTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/PersistentPythonOcrWorkerRegistryTests.cs
@@ -1,0 +1,59 @@
+using GameTranslator;
+using System.Runtime.Versioning;
+using Xunit;
+
+namespace GameChatTranslator.Tests
+{
+    [SupportedOSPlatform("windows")]
+    public class PersistentPythonOcrWorkerRegistryTests : System.IDisposable
+    {
+        public PersistentPythonOcrWorkerRegistryTests()
+        {
+            PersistentPythonOcrWorkerRegistry.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            PersistentPythonOcrWorkerRegistry.ResetForTesting();
+        }
+
+        [Fact]
+        public void Acquire_SameKey_ReusesSingleWorkerEntry()
+        {
+            using PersistentPythonOcrWorkerLease firstLease =
+                PersistentPythonOcrWorkerRegistry.Acquire("easyocr_runner.py", "python", "easyocr_runner.py");
+            using PersistentPythonOcrWorkerLease secondLease =
+                PersistentPythonOcrWorkerRegistry.Acquire("easyocr_runner.py", "python", "easyocr_runner.py");
+
+            Assert.Same(firstLease.Worker, secondLease.Worker);
+            Assert.Equal(1, PersistentPythonOcrWorkerRegistry.GetEntryCountForTesting());
+        }
+
+        [Fact]
+        public void Acquire_DifferentEngineKeys_CreatesSeparateEntries()
+        {
+            using PersistentPythonOcrWorkerLease easyLease =
+                PersistentPythonOcrWorkerRegistry.Acquire("easyocr_runner.py", "python", "easyocr_runner.py");
+            using PersistentPythonOcrWorkerLease paddleLease =
+                PersistentPythonOcrWorkerRegistry.Acquire("paddleocr_runner.py", "python", "paddleocr_runner.py");
+
+            Assert.NotSame(easyLease.Worker, paddleLease.Worker);
+            Assert.Equal(2, PersistentPythonOcrWorkerRegistry.GetEntryCountForTesting());
+        }
+
+        [Fact]
+        public void Dispose_LastLease_RemovesRegistryEntry()
+        {
+            PersistentPythonOcrWorkerLease firstLease =
+                PersistentPythonOcrWorkerRegistry.Acquire("easyocr_runner.py", "python", "easyocr_runner.py");
+            PersistentPythonOcrWorkerLease secondLease =
+                PersistentPythonOcrWorkerRegistry.Acquire("easyocr_runner.py", "python", "easyocr_runner.py");
+
+            firstLease.Dispose();
+            Assert.Equal(1, PersistentPythonOcrWorkerRegistry.GetEntryCountForTesting());
+
+            secondLease.Dispose();
+            Assert.Equal(0, PersistentPythonOcrWorkerRegistry.GetEntryCountForTesting());
+        }
+    }
+}

--- a/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
+++ b/GameChatTranslator.Tests/GameChatTranslator.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="../GameChatTranslator/Core/OcrService.cs" Link="Core/OcrService.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDuplicateTextComparer.cs" Link="Core/OcrDuplicateTextComparer.cs" />
     <Compile Include="../GameChatTranslator/Core/PersistentPythonOcrWorker.cs" Link="Core/PersistentPythonOcrWorker.cs" />
+    <Compile Include="../GameChatTranslator/Core/PersistentPythonOcrWorkerRegistry.cs" Link="Core/PersistentPythonOcrWorkerRegistry.cs" />
     <Compile Include="../GameChatTranslator/Core/OcrDiagnosticExporter.cs" Link="Core/OcrDiagnosticExporter.cs" />
     <Compile Include="../GameChatTranslator/Core/EasyOcrCliAdapter.cs" Link="Core/EasyOcrCliAdapter.cs" />
     <Compile Include="../GameChatTranslator/Core/PaddleOcrCliAdapter.cs" Link="Core/PaddleOcrCliAdapter.cs" />

--- a/GameChatTranslator/Core/EasyOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/EasyOcrCliAdapter.cs
@@ -20,7 +20,7 @@ namespace GameTranslator
     public sealed class EasyOcrCliAdapter : IDisposable
     {
         private const string RunnerFileName = "easyocr_runner.py";
-        private readonly Dictionary<string, PersistentPythonOcrWorker> workerByPythonPath = new Dictionary<string, PersistentPythonOcrWorker>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, PersistentPythonOcrWorkerLease> workerLeaseByPythonPath = new Dictionary<string, PersistentPythonOcrWorkerLease>(StringComparer.OrdinalIgnoreCase);
         private readonly object workerSync = new object();
 
         private static readonly Dictionary<string, string> AppLanguageToEasyOcrMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -199,12 +199,12 @@ namespace GameTranslator
         {
             lock (workerSync)
             {
-                foreach (PersistentPythonOcrWorker worker in workerByPythonPath.Values)
+                foreach (PersistentPythonOcrWorkerLease workerLease in workerLeaseByPythonPath.Values)
                 {
-                    worker.Dispose();
+                    workerLease.Dispose();
                 }
 
-                workerByPythonPath.Clear();
+                workerLeaseByPythonPath.Clear();
             }
         }
 
@@ -498,14 +498,7 @@ namespace GameTranslator
             }
             catch (System.ComponentModel.Win32Exception)
             {
-                lock (workerSync)
-                {
-                    if (workerByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorker worker))
-                    {
-                        worker.Dispose();
-                        workerByPythonPath.Remove(pythonExecutablePath);
-                    }
-                }
+                ReleaseWorkerLease(pythonExecutablePath);
 
                 return EasyOcrCliBatchResult.CreateFailure(
                     pythonExecutablePath,
@@ -582,13 +575,32 @@ namespace GameTranslator
         {
             lock (workerSync)
             {
-                if (!workerByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorker worker))
+                if (!workerLeaseByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorkerLease workerLease))
                 {
-                    worker = new PersistentPythonOcrWorker(pythonExecutablePath, runnerScriptPath);
-                    workerByPythonPath.Add(pythonExecutablePath, worker);
+                    workerLease = PersistentPythonOcrWorkerRegistry.Acquire(RunnerFileName, pythonExecutablePath, runnerScriptPath);
+                    workerLeaseByPythonPath.Add(pythonExecutablePath, workerLease);
                 }
 
-                return worker;
+                return workerLease.Worker;
+            }
+        }
+
+        private void ReleaseWorkerLease(string pythonExecutablePath)
+        {
+            if (string.IsNullOrWhiteSpace(pythonExecutablePath))
+            {
+                return;
+            }
+
+            lock (workerSync)
+            {
+                if (!workerLeaseByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorkerLease workerLease))
+                {
+                    return;
+                }
+
+                workerLease.Dispose();
+                workerLeaseByPythonPath.Remove(pythonExecutablePath);
             }
         }
 

--- a/GameChatTranslator/Core/EasyOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/EasyOcrCliAdapter.cs
@@ -19,6 +19,7 @@ namespace GameTranslator
     [SupportedOSPlatform("windows")]
     public sealed class EasyOcrCliAdapter : IDisposable
     {
+        private const string EngineType = "easyocr";
         private const string RunnerFileName = "easyocr_runner.py";
         private readonly Dictionary<string, PersistentPythonOcrWorkerLease> workerLeaseByPythonPath = new Dictionary<string, PersistentPythonOcrWorkerLease>(StringComparer.OrdinalIgnoreCase);
         private readonly object workerSync = new object();
@@ -577,7 +578,7 @@ namespace GameTranslator
             {
                 if (!workerLeaseByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorkerLease workerLease))
                 {
-                    workerLease = PersistentPythonOcrWorkerRegistry.Acquire(RunnerFileName, pythonExecutablePath, runnerScriptPath);
+                    workerLease = PersistentPythonOcrWorkerRegistry.Acquire(EngineType, pythonExecutablePath, runnerScriptPath);
                     workerLeaseByPythonPath.Add(pythonExecutablePath, workerLease);
                 }
 

--- a/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
@@ -19,7 +19,7 @@ namespace GameTranslator
     public sealed class PaddleOcrCliAdapter : IDisposable
     {
         private const string RunnerFileName = "paddleocr_runner.py";
-        private readonly Dictionary<string, PersistentPythonOcrWorker> workerByPythonPath = new Dictionary<string, PersistentPythonOcrWorker>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, PersistentPythonOcrWorkerLease> workerLeaseByPythonPath = new Dictionary<string, PersistentPythonOcrWorkerLease>(StringComparer.OrdinalIgnoreCase);
         private readonly object workerSync = new object();
 
         private static readonly Dictionary<string, string> AppLanguageToPaddleOcrMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -216,12 +216,12 @@ namespace GameTranslator
         {
             lock (workerSync)
             {
-                foreach (PersistentPythonOcrWorker worker in workerByPythonPath.Values)
+                foreach (PersistentPythonOcrWorkerLease workerLease in workerLeaseByPythonPath.Values)
                 {
-                    worker.Dispose();
+                    workerLease.Dispose();
                 }
 
-                workerByPythonPath.Clear();
+                workerLeaseByPythonPath.Clear();
             }
         }
 
@@ -518,14 +518,7 @@ namespace GameTranslator
             }
             catch (System.ComponentModel.Win32Exception)
             {
-                lock (workerSync)
-                {
-                    if (workerByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorker worker))
-                    {
-                        worker.Dispose();
-                        workerByPythonPath.Remove(pythonExecutablePath);
-                    }
-                }
+                ReleaseWorkerLease(pythonExecutablePath);
 
                 return PaddleOcrCliBatchResult.CreateFailure(
                     pythonExecutablePath,
@@ -641,13 +634,32 @@ namespace GameTranslator
         {
             lock (workerSync)
             {
-                if (!workerByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorker worker))
+                if (!workerLeaseByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorkerLease workerLease))
                 {
-                    worker = new PersistentPythonOcrWorker(pythonExecutablePath, runnerScriptPath);
-                    workerByPythonPath.Add(pythonExecutablePath, worker);
+                    workerLease = PersistentPythonOcrWorkerRegistry.Acquire(RunnerFileName, pythonExecutablePath, runnerScriptPath);
+                    workerLeaseByPythonPath.Add(pythonExecutablePath, workerLease);
                 }
 
-                return worker;
+                return workerLease.Worker;
+            }
+        }
+
+        private void ReleaseWorkerLease(string pythonExecutablePath)
+        {
+            if (string.IsNullOrWhiteSpace(pythonExecutablePath))
+            {
+                return;
+            }
+
+            lock (workerSync)
+            {
+                if (!workerLeaseByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorkerLease workerLease))
+                {
+                    return;
+                }
+
+                workerLease.Dispose();
+                workerLeaseByPythonPath.Remove(pythonExecutablePath);
             }
         }
 

--- a/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
@@ -18,6 +18,7 @@ namespace GameTranslator
     [SupportedOSPlatform("windows")]
     public sealed class PaddleOcrCliAdapter : IDisposable
     {
+        private const string EngineType = "paddleocr";
         private const string RunnerFileName = "paddleocr_runner.py";
         private readonly Dictionary<string, PersistentPythonOcrWorkerLease> workerLeaseByPythonPath = new Dictionary<string, PersistentPythonOcrWorkerLease>(StringComparer.OrdinalIgnoreCase);
         private readonly object workerSync = new object();
@@ -636,7 +637,7 @@ namespace GameTranslator
             {
                 if (!workerLeaseByPythonPath.TryGetValue(pythonExecutablePath, out PersistentPythonOcrWorkerLease workerLease))
                 {
-                    workerLease = PersistentPythonOcrWorkerRegistry.Acquire(RunnerFileName, pythonExecutablePath, runnerScriptPath);
+                    workerLease = PersistentPythonOcrWorkerRegistry.Acquire(EngineType, pythonExecutablePath, runnerScriptPath);
                     workerLeaseByPythonPath.Add(pythonExecutablePath, workerLease);
                 }
 

--- a/GameChatTranslator/Core/PersistentPythonOcrWorkerRegistry.cs
+++ b/GameChatTranslator/Core/PersistentPythonOcrWorkerRegistry.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+namespace GameTranslator
+{
+    [SupportedOSPlatform("windows")]
+    internal static class PersistentPythonOcrWorkerRegistry
+    {
+        private static readonly object Sync = new object();
+        private static readonly Dictionary<PersistentPythonOcrWorkerRegistryKey, RegistryEntry> Entries = new Dictionary<PersistentPythonOcrWorkerRegistryKey, RegistryEntry>();
+
+        public static PersistentPythonOcrWorkerLease Acquire(string engineType, string pythonExecutablePath, string runnerScriptPath)
+        {
+            if (string.IsNullOrWhiteSpace(engineType))
+            {
+                throw new ArgumentException("엔진 식별자가 비어 있습니다.", nameof(engineType));
+            }
+
+            var key = new PersistentPythonOcrWorkerRegistryKey(engineType, pythonExecutablePath, runnerScriptPath);
+            lock (Sync)
+            {
+                if (!Entries.TryGetValue(key, out RegistryEntry entry))
+                {
+                    entry = new RegistryEntry(new PersistentPythonOcrWorker(pythonExecutablePath, runnerScriptPath));
+                    Entries.Add(key, entry);
+                }
+
+                entry.ReferenceCount++;
+                return new PersistentPythonOcrWorkerLease(key, entry.Worker, Release);
+            }
+        }
+
+        private static void Release(PersistentPythonOcrWorkerRegistryKey key)
+        {
+            PersistentPythonOcrWorker workerToDispose = null;
+
+            lock (Sync)
+            {
+                if (!Entries.TryGetValue(key, out RegistryEntry entry))
+                {
+                    return;
+                }
+
+                entry.ReferenceCount--;
+                if (entry.ReferenceCount > 0)
+                {
+                    return;
+                }
+
+                Entries.Remove(key);
+                workerToDispose = entry.Worker;
+            }
+
+            workerToDispose?.Dispose();
+        }
+
+        internal static int GetEntryCountForTesting()
+        {
+            lock (Sync)
+            {
+                return Entries.Count;
+            }
+        }
+
+        internal static void ResetForTesting()
+        {
+            List<PersistentPythonOcrWorker> workersToDispose;
+            lock (Sync)
+            {
+                workersToDispose = new List<PersistentPythonOcrWorker>(Entries.Count);
+                foreach (RegistryEntry entry in Entries.Values)
+                {
+                    workersToDispose.Add(entry.Worker);
+                }
+
+                Entries.Clear();
+            }
+
+            foreach (PersistentPythonOcrWorker worker in workersToDispose)
+            {
+                worker.Dispose();
+            }
+        }
+
+        internal readonly struct PersistentPythonOcrWorkerRegistryKey : IEquatable<PersistentPythonOcrWorkerRegistryKey>
+        {
+            public PersistentPythonOcrWorkerRegistryKey(string engineType, string pythonExecutablePath, string runnerScriptPath)
+            {
+                EngineType = engineType ?? "";
+                PythonExecutablePath = pythonExecutablePath ?? "";
+                RunnerScriptPath = runnerScriptPath ?? "";
+            }
+
+            public string EngineType { get; }
+            public string PythonExecutablePath { get; }
+            public string RunnerScriptPath { get; }
+
+            public bool Equals(PersistentPythonOcrWorkerRegistryKey other)
+            {
+                return string.Equals(EngineType, other.EngineType, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(PythonExecutablePath, other.PythonExecutablePath, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(RunnerScriptPath, other.RunnerScriptPath, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is PersistentPythonOcrWorkerRegistryKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                var comparer = StringComparer.OrdinalIgnoreCase;
+                int hash = comparer.GetHashCode(EngineType);
+                hash = (hash * 397) ^ comparer.GetHashCode(PythonExecutablePath);
+                hash = (hash * 397) ^ comparer.GetHashCode(RunnerScriptPath);
+                return hash;
+            }
+        }
+
+        private sealed class RegistryEntry
+        {
+            public RegistryEntry(PersistentPythonOcrWorker worker)
+            {
+                Worker = worker;
+            }
+
+            public PersistentPythonOcrWorker Worker { get; }
+            public int ReferenceCount { get; set; }
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    internal sealed class PersistentPythonOcrWorkerLease : IDisposable
+    {
+        private readonly Action<PersistentPythonOcrWorkerRegistry.PersistentPythonOcrWorkerRegistryKey> releaseAction;
+        private readonly PersistentPythonOcrWorkerRegistry.PersistentPythonOcrWorkerRegistryKey key;
+        private bool disposed;
+
+        internal PersistentPythonOcrWorkerLease(
+            PersistentPythonOcrWorkerRegistry.PersistentPythonOcrWorkerRegistryKey key,
+            PersistentPythonOcrWorker worker,
+            Action<PersistentPythonOcrWorkerRegistry.PersistentPythonOcrWorkerRegistryKey> releaseAction)
+        {
+            this.key = key;
+            this.releaseAction = releaseAction;
+            Worker = worker ?? throw new ArgumentNullException(nameof(worker));
+        }
+
+        public PersistentPythonOcrWorker Worker { get; }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            releaseAction?.Invoke(key);
+        }
+    }
+}

--- a/GameChatTranslator/Properties/AssemblyInfo.cs
+++ b/GameChatTranslator/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GameChatTranslator.Tests")]


### PR DESCRIPTION
## 변경 사항
- EasyOCR / PaddleOCR resident worker를 static 공유 풀로 관리하는  추가
- 어댑터 인스턴스별 로컬 worker 보유를 lease 캐시로 전환
- 같은 engine/pythonPath/runnerScriptPath 조합에서 worker 재사용
- registry 공유/해제 동작 단위 테스트 3건 추가

## 검증
- 
-   Determining projects to restore...
  All projects are up-to-date for restore.
  GameChatTranslator -> /home/faust/work/TFClaw/data/workspaces/tfclaw_dev4/owner/GameChatTranslator-master-merge/GameChatTranslator/bin/Release/net8.0-windows10.0.19041.0/GameChatTranslator.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:03.51
-   Determining projects to restore...
  All projects are up-to-date for restore.
  GameChatTranslator.Tests -> /home/faust/work/TFClaw/data/workspaces/tfclaw_dev4/owner/GameChatTranslator-master-merge/GameChatTranslator.Tests/bin/Debug/net8.0/GameChatTranslator.Tests.dll
Test run for /home/faust/work/TFClaw/data/workspaces/tfclaw_dev4/owner/GameChatTranslator-master-merge/GameChatTranslator.Tests/bin/Debug/net8.0/GameChatTranslator.Tests.dll (.NETCoreApp,Version=v8.0)
VSTest version 17.11.1 (x64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:   453, Skipped:     0, Total:   453, Duration: 100 ms - GameChatTranslator.Tests.dll (net8.0)
