### PR TITLE
fix: resolve resident OCR worker regressions

### DIFF
--- a/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
@@ -202,5 +202,26 @@ namespace GameChatTranslator.Tests
 
             Assert.True(result.ShouldTryNextPythonCandidate);
         }
+
+        [Theory]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        public void ShouldTryNextPythonCandidateAfterEmptyWorkerPayload_ReturnsTrueForStartupRelatedFailures(
+            bool startedWorker,
+            bool restartedWorker,
+            bool usedInitializationTimeout)
+        {
+            Assert.True(EasyOcrCliAdapter.ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(
+                startedWorker,
+                restartedWorker,
+                usedInitializationTimeout));
+        }
+
+        [Fact]
+        public void ShouldTryNextPythonCandidateAfterEmptyWorkerPayload_ReturnsFalseForWarmEmptyPayload()
+        {
+            Assert.False(EasyOcrCliAdapter.ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(false, false, false));
+        }
     }
 }

--- a/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/EasyOcrCliAdapterTests.cs
@@ -1,4 +1,5 @@
 using GameTranslator;
+using System.Text.Json;
 using System.Runtime.Versioning;
 using Xunit;
 
@@ -157,6 +158,18 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void BuildWorkerRequestJson_UsesCamelCaseKeys()
+        {
+            string json = _adapter.BuildWorkerRequestJson(@"C:\temp\ocr.png", new[] { "ko+en", "ja+en" });
+            using JsonDocument document = JsonDocument.Parse(json);
+
+            Assert.Equal(@"C:\temp\ocr.png", document.RootElement.GetProperty("imagePath").GetString());
+            Assert.Equal("ko+en|ja+en", document.RootElement.GetProperty("groups").GetString());
+            Assert.True(document.RootElement.TryGetProperty("requestId", out _));
+            Assert.True(document.RootElement.TryGetProperty("gpu", out _));
+        }
+
+        [Fact]
         public void CreateFailure_PreservesResidentWorkerMetadata()
         {
             EasyOcrCliBatchResult result = EasyOcrCliBatchResult.CreateFailure(
@@ -176,6 +189,18 @@ namespace GameChatTranslator.Tests
             Assert.True(result.UsedInitializationTimeout);
             Assert.True(result.TimedOut);
             Assert.Equal("stderr", result.StandardError);
+        }
+
+        [Fact]
+        public void CreateFailure_PreservesNextPythonCandidateFlag()
+        {
+            EasyOcrCliBatchResult result = EasyOcrCliBatchResult.CreateFailure(
+                "python",
+                new[] { "ko+en" },
+                "worker exited",
+                shouldTryNextPythonCandidate: true);
+
+            Assert.True(result.ShouldTryNextPythonCandidate);
         }
     }
 }

--- a/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
@@ -216,5 +216,26 @@ namespace GameChatTranslator.Tests
 
             Assert.True(result.ShouldTryNextPythonCandidate);
         }
+
+        [Theory]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        public void ShouldTryNextPythonCandidateAfterEmptyWorkerPayload_ReturnsTrueForStartupRelatedFailures(
+            bool startedWorker,
+            bool restartedWorker,
+            bool usedInitializationTimeout)
+        {
+            Assert.True(PaddleOcrCliAdapter.ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(
+                startedWorker,
+                restartedWorker,
+                usedInitializationTimeout));
+        }
+
+        [Fact]
+        public void ShouldTryNextPythonCandidateAfterEmptyWorkerPayload_ReturnsFalseForWarmEmptyPayload()
+        {
+            Assert.False(PaddleOcrCliAdapter.ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(false, false, false));
+        }
     }
 }

--- a/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
+++ b/GameChatTranslator.Tests/Core/Ocr/PaddleOcrCliAdapterTests.cs
@@ -1,4 +1,5 @@
 using GameTranslator;
+using System.Text.Json;
 using System.Runtime.Versioning;
 using Xunit;
 
@@ -164,6 +165,20 @@ namespace GameChatTranslator.Tests
         }
 
         [Fact]
+        public void BuildWorkerRequestJson_UsesCamelCaseKeys()
+        {
+            string json = _adapter.BuildWorkerRequestJson(
+                new[] { @"C:\temp\ocr_0.png", @"C:\temp\ocr_1.png" },
+                new[] { "korean", "japan" });
+            using JsonDocument document = JsonDocument.Parse(json);
+
+            Assert.True(document.RootElement.TryGetProperty("requestId", out _));
+            Assert.Equal(2, document.RootElement.GetProperty("imagePaths").GetArrayLength());
+            Assert.Equal("korean|japan", document.RootElement.GetProperty("groups").GetString());
+            Assert.True(document.RootElement.TryGetProperty("gpu", out _));
+        }
+
+        [Fact]
         public void CreateSuccess_PreservesResidentWorkerMetadata()
         {
             PaddleOcrCliBatchResult result = PaddleOcrCliBatchResult.CreateSuccess(
@@ -188,6 +203,18 @@ namespace GameChatTranslator.Tests
             Assert.True(result.UsedInitializationTimeout);
             Assert.False(result.TimedOut);
             Assert.Equal("stderr", result.StandardError);
+        }
+
+        [Fact]
+        public void CreateFailure_PreservesNextPythonCandidateFlag()
+        {
+            PaddleOcrCliBatchResult result = PaddleOcrCliBatchResult.CreateFailure(
+                "python",
+                new[] { "korean" },
+                "worker exited",
+                shouldTryNextPythonCandidate: true);
+
+            Assert.True(result.ShouldTryNextPythonCandidate);
         }
     }
 }

--- a/GameChatTranslator/Core/EasyOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/EasyOcrCliAdapter.cs
@@ -428,6 +428,10 @@ namespace GameTranslator
                 EasyOcrWorkerResponse response = ParseWorkerResponse(workerResult.ResponseJson);
                 if (response == null)
                 {
+                    bool shouldTryNextPythonCandidate = ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(
+                        workerResult.StartedWorker,
+                        workerResult.RestartedWorker,
+                        workerResult.UsedInitializationTimeout);
                     return EasyOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
                         languageCombinations,
@@ -436,7 +440,8 @@ namespace GameTranslator
                         usedResidentWorker: true,
                         startedWorker: workerResult.StartedWorker,
                         restartedWorker: workerResult.RestartedWorker,
-                        usedInitializationTimeout: workerResult.UsedInitializationTimeout);
+                        usedInitializationTimeout: workerResult.UsedInitializationTimeout,
+                        shouldTryNextPythonCandidate: shouldTryNextPythonCandidate);
                 }
 
                 if (!response.Ok)
@@ -461,6 +466,10 @@ namespace GameTranslator
                 List<EasyOcrCliGroupResult> groupResults = ConvertWorkerGroupsToResults(response.Groups);
                 if (groupResults.Count == 0)
                 {
+                    bool shouldTryNextPythonCandidate = ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(
+                        workerResult.StartedWorker,
+                        workerResult.RestartedWorker,
+                        workerResult.UsedInitializationTimeout);
                     return EasyOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
                         languageCombinations,
@@ -469,7 +478,8 @@ namespace GameTranslator
                         usedResidentWorker: true,
                         startedWorker: workerResult.StartedWorker,
                         restartedWorker: workerResult.RestartedWorker,
-                        usedInitializationTimeout: workerResult.UsedInitializationTimeout);
+                        usedInitializationTimeout: workerResult.UsedInitializationTimeout,
+                        shouldTryNextPythonCandidate: shouldTryNextPythonCandidate);
                 }
 
                 int successCount = groupResults.Count(group => group.Success);
@@ -584,6 +594,14 @@ namespace GameTranslator
         private static string EmptyToFallback(string value, string fallback)
         {
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+
+        internal static bool ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(
+            bool startedWorker,
+            bool restartedWorker,
+            bool usedInitializationTimeout)
+        {
+            return startedWorker || restartedWorker || usedInitializationTimeout;
         }
 
         private PersistentPythonOcrWorker GetOrCreateWorker(string pythonExecutablePath, string runnerScriptPath)

--- a/GameChatTranslator/Core/EasyOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/EasyOcrCliAdapter.cs
@@ -169,10 +169,18 @@ namespace GameTranslator
                         inputFilePath,
                         languageCombinations,
                         timeoutMs);
-                    if (runResult.Success || !runResult.IsPythonMissing)
+                    if (runResult.Success)
                     {
                         return runResult;
                     }
+
+                    if (runResult.IsPythonMissing || runResult.ShouldTryNextPythonCandidate)
+                    {
+                        ReleaseWorkerLease(pythonPath);
+                        continue;
+                    }
+
+                    return runResult;
                 }
 
                 return EasyOcrCliBatchResult.CreateFailure(
@@ -398,13 +406,7 @@ namespace GameTranslator
             try
             {
                 PersistentPythonOcrWorker worker = GetOrCreateWorker(pythonExecutablePath, runnerScriptPath);
-                string requestJson = JsonSerializer.Serialize(new EasyOcrWorkerRequest
-                {
-                    RequestId = Guid.NewGuid().ToString("N"),
-                    ImagePath = inputFilePath,
-                    Groups = string.Join("|", languageCombinations ?? Array.Empty<string>()),
-                    Gpu = false
-                });
+                string requestJson = BuildWorkerRequestJson(inputFilePath, languageCombinations);
 
                 PersistentPythonOcrWorkerResult workerResult = worker.SendRequestAsync(requestJson, timeoutMs).GetAwaiter().GetResult();
                 if (!workerResult.Success)
@@ -419,7 +421,8 @@ namespace GameTranslator
                         startedWorker: workerResult.StartedWorker,
                         restartedWorker: workerResult.RestartedWorker,
                         usedInitializationTimeout: workerResult.UsedInitializationTimeout,
-                        timedOut: workerResult.TimedOut);
+                        timedOut: workerResult.TimedOut,
+                        shouldTryNextPythonCandidate: workerResult.ShouldTryNextExecutable);
                 }
 
                 EasyOcrWorkerResponse response = ParseWorkerResponse(workerResult.ResponseJson);
@@ -567,6 +570,17 @@ namespace GameTranslator
                 .ToList();
         }
 
+        internal string BuildWorkerRequestJson(string inputFilePath, IReadOnlyList<string> languageCombinations)
+        {
+            return JsonSerializer.Serialize(new EasyOcrWorkerRequest
+            {
+                RequestId = Guid.NewGuid().ToString("N"),
+                ImagePath = inputFilePath,
+                Groups = string.Join("|", languageCombinations ?? Array.Empty<string>()),
+                Gpu = false
+            });
+        }
+
         private static string EmptyToFallback(string value, string fallback)
         {
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
@@ -628,9 +642,13 @@ namespace GameTranslator
 
         private sealed class EasyOcrWorkerRequest
         {
+            [JsonPropertyName("requestId")]
             public string RequestId { get; set; } = "";
+            [JsonPropertyName("imagePath")]
             public string ImagePath { get; set; } = "";
+            [JsonPropertyName("groups")]
             public string Groups { get; set; } = "";
+            [JsonPropertyName("gpu")]
             public bool Gpu { get; set; }
         }
 
@@ -675,7 +693,8 @@ namespace GameTranslator
             bool startedWorker,
             bool restartedWorker,
             bool usedInitializationTimeout,
-            bool timedOut)
+            bool timedOut,
+            bool shouldTryNextPythonCandidate)
         {
             Success = success;
             PythonExecutablePath = pythonExecutablePath ?? "";
@@ -690,6 +709,7 @@ namespace GameTranslator
             RestartedWorker = restartedWorker;
             UsedInitializationTimeout = usedInitializationTimeout;
             TimedOut = timedOut;
+            ShouldTryNextPythonCandidate = shouldTryNextPythonCandidate;
         }
 
         public bool Success { get; }
@@ -705,6 +725,7 @@ namespace GameTranslator
         public bool RestartedWorker { get; }
         public bool UsedInitializationTimeout { get; }
         public bool TimedOut { get; }
+        public bool ShouldTryNextPythonCandidate { get; }
 
         public static EasyOcrCliBatchResult CreateSuccess(
             string pythonExecutablePath,
@@ -730,6 +751,7 @@ namespace GameTranslator
                 startedWorker,
                 restartedWorker,
                 usedInitializationTimeout,
+                false,
                 false);
         }
 
@@ -744,7 +766,8 @@ namespace GameTranslator
             bool startedWorker = false,
             bool restartedWorker = false,
             bool usedInitializationTimeout = false,
-            bool timedOut = false)
+            bool timedOut = false,
+            bool shouldTryNextPythonCandidate = false)
         {
             return new EasyOcrCliBatchResult(
                 false,
@@ -759,7 +782,8 @@ namespace GameTranslator
                 startedWorker,
                 restartedWorker,
                 usedInitializationTimeout,
-                timedOut);
+                timedOut,
+                shouldTryNextPythonCandidate);
         }
     }
 

--- a/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
@@ -448,6 +448,10 @@ namespace GameTranslator
                 PaddleOcrWorkerResponse response = ParseWorkerResponse(workerResult.ResponseJson);
                 if (response == null)
                 {
+                    bool shouldTryNextPythonCandidate = ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(
+                        workerResult.StartedWorker,
+                        workerResult.RestartedWorker,
+                        workerResult.UsedInitializationTimeout);
                     return PaddleOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
                         languageCandidates,
@@ -456,7 +460,8 @@ namespace GameTranslator
                         usedResidentWorker: true,
                         startedWorker: workerResult.StartedWorker,
                         restartedWorker: workerResult.RestartedWorker,
-                        usedInitializationTimeout: workerResult.UsedInitializationTimeout);
+                        usedInitializationTimeout: workerResult.UsedInitializationTimeout,
+                        shouldTryNextPythonCandidate: shouldTryNextPythonCandidate);
                 }
 
                 if (!response.Ok)
@@ -481,6 +486,10 @@ namespace GameTranslator
                 List<PaddleOcrCliImageResult> imageResults = ConvertWorkerImagesToResults(response.Images);
                 if (imageResults.Count == 0)
                 {
+                    bool shouldTryNextPythonCandidate = ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(
+                        workerResult.StartedWorker,
+                        workerResult.RestartedWorker,
+                        workerResult.UsedInitializationTimeout);
                     return PaddleOcrCliBatchResult.CreateFailure(
                         pythonExecutablePath,
                         languageCandidates,
@@ -489,7 +498,8 @@ namespace GameTranslator
                         usedResidentWorker: true,
                         startedWorker: workerResult.StartedWorker,
                         restartedWorker: workerResult.RestartedWorker,
-                        usedInitializationTimeout: workerResult.UsedInitializationTimeout);
+                        usedInitializationTimeout: workerResult.UsedInitializationTimeout,
+                        shouldTryNextPythonCandidate: shouldTryNextPythonCandidate);
                 }
 
                 int successCount = imageResults.Sum(image => image.GroupResults.Count(group => group.Success));
@@ -633,6 +643,14 @@ namespace GameTranslator
         private static string EmptyToFallback(string value, string fallback)
         {
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+
+        internal static bool ShouldTryNextPythonCandidateAfterEmptyWorkerPayload(
+            bool startedWorker,
+            bool restartedWorker,
+            bool usedInitializationTimeout)
+        {
+            return startedWorker || restartedWorker || usedInitializationTimeout;
         }
 
         internal string BuildWorkerRequestJson(IReadOnlyList<string> inputFilePaths, IReadOnlyList<string> languageCandidates)

--- a/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
+++ b/GameChatTranslator/Core/PaddleOcrCliAdapter.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace GameTranslator
 {
@@ -183,10 +184,18 @@ namespace GameTranslator
                         inputFilePaths,
                         languageCandidates,
                         timeoutMs);
-                    if (runResult.Success || !runResult.IsPythonMissing)
+                    if (runResult.Success)
                     {
                         return runResult;
                     }
+
+                    if (runResult.IsPythonMissing || runResult.ShouldTryNextPythonCandidate)
+                    {
+                        ReleaseWorkerLease(pythonPath);
+                        continue;
+                    }
+
+                    return runResult;
                 }
 
                 return PaddleOcrCliBatchResult.CreateFailure(
@@ -417,13 +426,7 @@ namespace GameTranslator
             try
             {
                 PersistentPythonOcrWorker worker = GetOrCreateWorker(pythonExecutablePath, runnerScriptPath);
-                string requestJson = JsonSerializer.Serialize(new PaddleOcrWorkerRequest
-                {
-                    RequestId = Guid.NewGuid().ToString("N"),
-                    ImagePaths = inputFilePaths?.ToList() ?? new List<string>(),
-                    Groups = string.Join("|", languageCandidates ?? Array.Empty<string>()),
-                    Gpu = false
-                });
+                string requestJson = BuildWorkerRequestJson(inputFilePaths, languageCandidates);
 
                 PersistentPythonOcrWorkerResult workerResult = worker.SendRequestAsync(requestJson, timeoutMs).GetAwaiter().GetResult();
                 if (!workerResult.Success)
@@ -438,7 +441,8 @@ namespace GameTranslator
                         startedWorker: workerResult.StartedWorker,
                         restartedWorker: workerResult.RestartedWorker,
                         usedInitializationTimeout: workerResult.UsedInitializationTimeout,
-                        timedOut: workerResult.TimedOut);
+                        timedOut: workerResult.TimedOut,
+                        shouldTryNextPythonCandidate: workerResult.ShouldTryNextExecutable);
                 }
 
                 PaddleOcrWorkerResponse response = ParseWorkerResponse(workerResult.ResponseJson);
@@ -631,6 +635,17 @@ namespace GameTranslator
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
         }
 
+        internal string BuildWorkerRequestJson(IReadOnlyList<string> inputFilePaths, IReadOnlyList<string> languageCandidates)
+        {
+            return JsonSerializer.Serialize(new PaddleOcrWorkerRequest
+            {
+                RequestId = Guid.NewGuid().ToString("N"),
+                ImagePaths = inputFilePaths?.ToList() ?? new List<string>(),
+                Groups = string.Join("|", languageCandidates ?? Array.Empty<string>()),
+                Gpu = false
+            });
+        }
+
         private PersistentPythonOcrWorker GetOrCreateWorker(string pythonExecutablePath, string runnerScriptPath)
         {
             lock (workerSync)
@@ -693,9 +708,13 @@ namespace GameTranslator
 
         private sealed class PaddleOcrWorkerRequest
         {
+            [JsonPropertyName("requestId")]
             public string RequestId { get; set; } = "";
+            [JsonPropertyName("imagePaths")]
             public List<string> ImagePaths { get; set; } = new List<string>();
+            [JsonPropertyName("groups")]
             public string Groups { get; set; } = "";
+            [JsonPropertyName("gpu")]
             public bool Gpu { get; set; }
         }
 
@@ -745,7 +764,8 @@ namespace GameTranslator
             bool startedWorker,
             bool restartedWorker,
             bool usedInitializationTimeout,
-            bool timedOut)
+            bool timedOut,
+            bool shouldTryNextPythonCandidate)
         {
             Success = success;
             PythonExecutablePath = pythonExecutablePath ?? "";
@@ -760,6 +780,7 @@ namespace GameTranslator
             RestartedWorker = restartedWorker;
             UsedInitializationTimeout = usedInitializationTimeout;
             TimedOut = timedOut;
+            ShouldTryNextPythonCandidate = shouldTryNextPythonCandidate;
         }
 
         public bool Success { get; }
@@ -776,6 +797,7 @@ namespace GameTranslator
         public bool RestartedWorker { get; }
         public bool UsedInitializationTimeout { get; }
         public bool TimedOut { get; }
+        public bool ShouldTryNextPythonCandidate { get; }
 
         public static PaddleOcrCliBatchResult CreateSuccess(
             string pythonExecutablePath,
@@ -801,6 +823,7 @@ namespace GameTranslator
                 startedWorker,
                 restartedWorker,
                 usedInitializationTimeout,
+                false,
                 false);
         }
 
@@ -815,7 +838,8 @@ namespace GameTranslator
             bool startedWorker = false,
             bool restartedWorker = false,
             bool usedInitializationTimeout = false,
-            bool timedOut = false)
+            bool timedOut = false,
+            bool shouldTryNextPythonCandidate = false)
         {
             return new PaddleOcrCliBatchResult(
                 false,
@@ -830,7 +854,8 @@ namespace GameTranslator
                 startedWorker,
                 restartedWorker,
                 usedInitializationTimeout,
-                timedOut);
+                timedOut,
+                shouldTryNextPythonCandidate);
         }
     }
 

--- a/GameChatTranslator/Core/PersistentPythonOcrWorker.cs
+++ b/GameChatTranslator/Core/PersistentPythonOcrWorker.cs
@@ -70,11 +70,20 @@ namespace GameTranslator
                     ? Math.Max(DefaultInitializationTimeoutMs, requestTimeoutMs)
                     : requestTimeoutMs;
 
+                Process currentProcess = null;
                 try
                 {
-                    Process currentProcess = process;
+                    currentProcess = process;
                     if (currentProcess == null || currentProcess.HasExited)
                     {
+                        if (startedNow || !isWarm)
+                        {
+                            return PersistentPythonOcrWorkerResult.CreateFailure(
+                                "Python 워커 프로세스가 시작 직후 종료되었습니다.",
+                                GetCapturedStandardErrorText(),
+                                shouldTryNextExecutable: true);
+                        }
+
                         RestartProcess();
                         currentProcess = process;
                     }
@@ -93,10 +102,12 @@ namespace GameTranslator
 
                     if (string.IsNullOrWhiteSpace(responseLine))
                     {
+                        bool shouldTryNextExecutable = (startedNow || !isWarm) && currentProcess.HasExited;
                         RestartProcess();
                         return PersistentPythonOcrWorkerResult.CreateFailure(
                             "Python 워커가 빈 응답을 반환했습니다.",
-                            standardError: GetCapturedStandardErrorText());
+                            standardError: GetCapturedStandardErrorText(),
+                            shouldTryNextExecutable: shouldTryNextExecutable);
                     }
 
                     isWarm = true;
@@ -129,8 +140,13 @@ namespace GameTranslator
                 catch (Exception ex)
                 {
                     string standardError = GetCapturedStandardErrorText();
+                    bool shouldTryNextExecutable = (startedNow || !isWarm) && (currentProcess == null || currentProcess.HasExited);
                     RestartProcess();
-                    return PersistentPythonOcrWorkerResult.CreateFailure(ex.Message, standardError, restartedWorker: true);
+                    return PersistentPythonOcrWorkerResult.CreateFailure(
+                        ex.Message,
+                        standardError,
+                        restartedWorker: true,
+                        shouldTryNextExecutable: shouldTryNextExecutable);
                 }
             }
             finally
@@ -338,7 +354,8 @@ namespace GameTranslator
             bool timedOut,
             bool usedInitializationTimeout,
             bool startedWorker,
-            bool restartedWorker)
+            bool restartedWorker,
+            bool shouldTryNextExecutable)
         {
             Success = success;
             ResponseJson = responseJson ?? "";
@@ -349,6 +366,7 @@ namespace GameTranslator
             UsedInitializationTimeout = usedInitializationTimeout;
             StartedWorker = startedWorker;
             RestartedWorker = restartedWorker;
+            ShouldTryNextExecutable = shouldTryNextExecutable;
         }
 
         public bool Success { get; }
@@ -360,6 +378,7 @@ namespace GameTranslator
         public bool UsedInitializationTimeout { get; }
         public bool StartedWorker { get; }
         public bool RestartedWorker { get; }
+        public bool ShouldTryNextExecutable { get; }
 
         public static PersistentPythonOcrWorkerResult CreateSuccess(
             string responseJson,
@@ -377,7 +396,8 @@ namespace GameTranslator
                 false,
                 usedInitializationTimeout,
                 startedWorker,
-                restartedWorker);
+                restartedWorker,
+                false);
         }
 
         public static PersistentPythonOcrWorkerResult CreateFailure(
@@ -385,7 +405,8 @@ namespace GameTranslator
             string standardError = "",
             bool isPythonMissing = false,
             bool timedOut = false,
-            bool restartedWorker = false)
+            bool restartedWorker = false,
+            bool shouldTryNextExecutable = false)
         {
             return new PersistentPythonOcrWorkerResult(
                 false,
@@ -396,7 +417,8 @@ namespace GameTranslator
                 timedOut,
                 false,
                 false,
-                restartedWorker);
+                restartedWorker,
+                shouldTryNextExecutable);
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix EasyOCR resident worker request JSON to use the camelCase keys expected by Python
- let resident worker failures on cold start fall through to the next Python candidate (`py`, `python3`) instead of failing immediately
- add regression tests for worker request serialization and next-candidate metadata

## Linked issue
- fixes #192

## Verification
- git diff --check
- `$HOME/.dotnet/dotnet build GameChatTranslator/GameChatTranslator.csproj -c Release -p:EnableWindowsTargeting=true`
- `$HOME/.dotnet/dotnet test GameChatTranslator.Tests/GameChatTranslator.Tests.csproj`

## Notes
- Windows GUI/runtime recheck is still needed for EasyOCR/PaddleOCR warm start, restart, and fallback behavior.
