### PR TITLE
기능: OCR 자동 설치 스크립트 추가

### DIFF
--- a/GameChatTranslator/Distribution/Install-All-OCR.bat
+++ b/GameChatTranslator/Distribution/Install-All-OCR.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "FAILED=0"
+
+echo ==========================================
+echo   GameChatTranslator OCR Installer
+echo ==========================================
+echo.
+echo This script runs Windows OCR, Tesseract,
+echo EasyOCR and PaddleOCR setup in sequence.
+echo.
+
+if exist "%~dp0LangInstall.bat" (
+    call "%~dp0LangInstall.bat"
+    if errorlevel 1 set "FAILED=1"
+)
+
+call "%~dp0Install-Tesseract.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+call "%~dp0Install-EasyOCR.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+call "%~dp0Install-PaddleOCR.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+echo.
+echo ==========================================
+if "!FAILED!"=="0" (
+    echo [OK] OCR installation steps completed.
+) else (
+    echo [WARN] Some OCR installation steps failed.
+)
+echo ==========================================
+echo.
+pause
+exit /b !FAILED!

--- a/GameChatTranslator/Distribution/Install-EasyOCR.bat
+++ b/GameChatTranslator/Distribution/Install-EasyOCR.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Engine EasyOCR
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] EasyOCR installation finished.
+) else (
+    echo [FAIL] EasyOCR installation failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/Install-PaddleOCR.bat
+++ b/GameChatTranslator/Distribution/Install-PaddleOCR.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Engine PaddleOCR
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] PaddleOCR installation finished.
+) else (
+    echo [FAIL] PaddleOCR installation failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/Install-Tesseract.bat
+++ b/GameChatTranslator/Distribution/Install-Tesseract.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Engine Tesseract
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] Tesseract installation finished.
+) else (
+    echo [FAIL] Tesseract installation failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/OcrInstall.ps1
+++ b/GameChatTranslator/Distribution/OcrInstall.ps1
@@ -1,0 +1,423 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("EasyOCR", "PaddleOCR", "Tesseract")]
+    [string]$Engine
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$appFolderName = "GameChatTranslator"
+$portableMarkerFileName = "portable.mode"
+$ocrSectionName = "OCR"
+
+function Write-Status {
+    param([string]$Message)
+    Write-Host "[INFO] $Message"
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "[OK] $Message"
+}
+
+function Get-AppConfigInfo {
+    $installRoot = [System.IO.Path]::GetFullPath($scriptRoot)
+    $portableConfigPath = Join-Path $installRoot "config.ini"
+    $portableMarkerPath = Join-Path $installRoot $portableMarkerFileName
+    $isPortable = (Test-Path $portableConfigPath) -or (Test-Path $portableMarkerPath)
+
+    if ($isPortable) {
+        $rootDirectory = $installRoot
+    } else {
+        $rootDirectory = Join-Path $env:LOCALAPPDATA $appFolderName
+    }
+
+    $configPath = Join-Path $rootDirectory "config.ini"
+    $venvRoot = Join-Path $rootDirectory "venvs"
+    [System.IO.Directory]::CreateDirectory($rootDirectory) | Out-Null
+    [System.IO.Directory]::CreateDirectory($venvRoot) | Out-Null
+
+    return [pscustomobject]@{
+        InstallRoot = $installRoot
+        RootDirectory = $rootDirectory
+        ConfigPath = $configPath
+        VenvRoot = $venvRoot
+        IsPortable = $isPortable
+    }
+}
+
+function Set-IniValue {
+    param(
+        [string]$ConfigPath,
+        [string]$Section,
+        [string]$Key,
+        [string]$Value
+    )
+
+    $configDirectory = Split-Path -Parent $ConfigPath
+    if (-not [string]::IsNullOrWhiteSpace($configDirectory)) {
+        [System.IO.Directory]::CreateDirectory($configDirectory) | Out-Null
+    }
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    if (Test-Path $ConfigPath) {
+        foreach ($line in [System.IO.File]::ReadAllLines($ConfigPath)) {
+            [void]$lines.Add($line)
+        }
+    }
+
+    $sectionStart = -1
+    $sectionEnd = $lines.Count
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $trimmed = $lines[$i].Trim()
+        if (-not ($trimmed.StartsWith("[") -and $trimmed.EndsWith("]"))) {
+            continue
+        }
+
+        $sectionName = $trimmed.Substring(1, $trimmed.Length - 2)
+        if ($sectionStart -lt 0) {
+            if ($sectionName.Equals($Section, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $sectionStart = $i
+            }
+
+            continue
+        }
+
+        $sectionEnd = $i
+        break
+    }
+
+    if ($sectionStart -lt 0) {
+        if ($lines.Count -gt 0 -and -not [string]::IsNullOrWhiteSpace($lines[$lines.Count - 1])) {
+            [void]$lines.Add("")
+        }
+
+        [void]$lines.Add("[$Section]")
+        [void]$lines.Add("$Key=$Value")
+        [System.IO.File]::WriteAllLines($ConfigPath, $lines)
+        return
+    }
+
+    for ($i = $sectionStart + 1; $i -lt $sectionEnd; $i++) {
+        $trimmed = $lines[$i].Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith(";") -or $trimmed.StartsWith("#")) {
+            continue
+        }
+
+        $separatorIndex = $trimmed.IndexOf("=")
+        if ($separatorIndex -lt 0) {
+            continue
+        }
+
+        $existingKey = $trimmed.Substring(0, $separatorIndex).Trim()
+        if ($existingKey.Equals($Key, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $lines[$i] = "$Key=$Value"
+            [System.IO.File]::WriteAllLines($ConfigPath, $lines)
+            return
+        }
+    }
+
+    $insertIndex = $sectionEnd
+    [void]$lines.Insert($insertIndex, "$Key=$Value")
+    [System.IO.File]::WriteAllLines($ConfigPath, $lines)
+}
+
+function Get-PythonInfoFromExecutable {
+    param([string]$PythonExe)
+
+    if ([string]::IsNullOrWhiteSpace($PythonExe) -or -not (Test-Path $PythonExe)) {
+        return $null
+    }
+
+    try {
+        $json = & $PythonExe -c "import json,sys; print(json.dumps({'major':sys.version_info[0],'minor':sys.version_info[1],'micro':sys.version_info[2],'executable':sys.executable}))" 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
+            return $null
+        }
+
+        $parsed = $json | ConvertFrom-Json
+        return [pscustomobject]@{
+            Executable = [string]$parsed.executable
+            Major = [int]$parsed.major
+            Minor = [int]$parsed.minor
+            Micro = [int]$parsed.micro
+        }
+    } catch {
+        return $null
+    }
+}
+
+function Get-PythonInfoFromPyLauncher {
+    param([string]$VersionArgument)
+
+    $pyCommand = Get-Command py.exe -ErrorAction SilentlyContinue
+    if ($null -eq $pyCommand) {
+        return $null
+    }
+
+    try {
+        $json = & $pyCommand.Source $VersionArgument -c "import json,sys; print(json.dumps({'major':sys.version_info[0],'minor':sys.version_info[1],'micro':sys.version_info[2],'executable':sys.executable}))" 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
+            return $null
+        }
+
+        $parsed = $json | ConvertFrom-Json
+        return [pscustomobject]@{
+            Executable = [string]$parsed.executable
+            Major = [int]$parsed.major
+            Minor = [int]$parsed.minor
+            Micro = [int]$parsed.micro
+        }
+    } catch {
+        return $null
+    }
+}
+
+function Get-InstalledPythonCandidates {
+    $candidates = New-Object System.Collections.Generic.List[string]
+
+    $pythonCommand = Get-Command python.exe -ErrorAction SilentlyContinue
+    if ($null -ne $pythonCommand -and -not [string]::IsNullOrWhiteSpace($pythonCommand.Source)) {
+        [void]$candidates.Add($pythonCommand.Source)
+    }
+
+    $searchPatterns = @(
+        (Join-Path $env:LOCALAPPDATA "Programs\Python\Python*\python.exe"),
+        "C:\Program Files\Python*\python.exe",
+        "C:\Program Files (x86)\Python*\python.exe"
+    )
+
+    foreach ($pattern in $searchPatterns) {
+        foreach ($file in Get-ChildItem -Path $pattern -File -ErrorAction SilentlyContinue) {
+            [void]$candidates.Add($file.FullName)
+        }
+    }
+
+    return $candidates |
+        Select-Object -Unique |
+        ForEach-Object { Get-PythonInfoFromExecutable $_ } |
+        Where-Object { $null -ne $_ }
+}
+
+function Find-EasyOcrBasePython {
+    $candidates = New-Object System.Collections.Generic.List[object]
+
+    foreach ($versionArgument in @("-3.13", "-3.12", "-3.11", "-3.10", "-3.9", "-3.8")) {
+        $info = Get-PythonInfoFromPyLauncher -VersionArgument $versionArgument
+        if ($null -ne $info) {
+            [void]$candidates.Add($info)
+        }
+    }
+
+    foreach ($info in Get-InstalledPythonCandidates) {
+        [void]$candidates.Add($info)
+    }
+
+    return $candidates |
+        Group-Object Executable |
+        ForEach-Object { $_.Group[0] } |
+        Where-Object { $_.Major -eq 3 -and $_.Minor -ge 8 } |
+        Sort-Object Minor, Micro -Descending |
+        Select-Object -First 1
+}
+
+function Find-Python310 {
+    $candidates = New-Object System.Collections.Generic.List[object]
+
+    $launcherInfo = Get-PythonInfoFromPyLauncher -VersionArgument "-3.10"
+    if ($null -ne $launcherInfo) {
+        [void]$candidates.Add($launcherInfo)
+    }
+
+    foreach ($info in Get-InstalledPythonCandidates) {
+        if ($info.Major -eq 3 -and $info.Minor -eq 10) {
+            [void]$candidates.Add($info)
+        }
+    }
+
+    return $candidates |
+        Group-Object Executable |
+        ForEach-Object { $_.Group[0] } |
+        Sort-Object Micro -Descending |
+        Select-Object -First 1
+}
+
+function Invoke-WingetInstall {
+    param([string]$PackageId)
+
+    $winget = Get-Command winget.exe -ErrorAction SilentlyContinue
+    if ($null -eq $winget) {
+        return $false
+    }
+
+    Write-Status "Attempting WinGet install: $PackageId"
+    & $winget.Source install --id $PackageId -e --accept-package-agreements --accept-source-agreements --disable-interactivity
+    return $LASTEXITCODE -eq 0
+}
+
+function Ensure-Python310 {
+    $pythonInfo = Find-Python310
+    if ($null -ne $pythonInfo) {
+        return $pythonInfo
+    }
+
+    if (-not (Invoke-WingetInstall -PackageId "Python.Python.3.10")) {
+        throw "Python 3.10 installation failed. Install Python 3.10 and rerun this script."
+    }
+
+    Start-Sleep -Seconds 2
+    $pythonInfo = Find-Python310
+    if ($null -eq $pythonInfo) {
+        throw "Python 3.10 was installed, but python.exe could not be located automatically."
+    }
+
+    return $pythonInfo
+}
+
+function Ensure-Venv {
+    param(
+        [string]$BasePythonExe,
+        [string]$VenvPath
+    )
+
+    $venvPython = Join-Path $VenvPath "Scripts\python.exe"
+    if (-not (Test-Path $venvPython)) {
+        Write-Status "Creating virtual environment: $VenvPath"
+        & $BasePythonExe -m venv $VenvPath
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path $venvPython)) {
+            throw "Virtual environment creation failed: $VenvPath"
+        }
+    }
+
+    return $venvPython
+}
+
+function Install-PythonPackages {
+    param(
+        [string]$PythonExe,
+        [string[]]$Packages
+    )
+
+    Write-Status "Upgrading pip"
+    & $PythonExe -m pip install -U pip
+    if ($LASTEXITCODE -ne 0) {
+        throw "pip upgrade failed."
+    }
+
+    Write-Status "Installing packages: $($Packages -join ', ')"
+    & $PythonExe -m pip install @Packages
+    if ($LASTEXITCODE -ne 0) {
+        throw "Package installation failed."
+    }
+}
+
+function Assert-EasyOcrEnvironment {
+    param([string]$PythonExe)
+
+    $output = & $PythonExe -c "import easyocr, torch, torchvision, sys; print(sys.executable)" 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($output)) {
+        throw "EasyOCR import verification failed."
+    }
+
+    return ($output | Select-Object -Last 1).Trim()
+}
+
+function Assert-PaddleOcrEnvironment {
+    param([string]$PythonExe)
+
+    $output = & $PythonExe -c "import paddle, paddleocr, sys; print(paddle.__version__); print(paddleocr.__version__); print(sys.executable)" 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($output)) {
+        throw "PaddleOCR import verification failed."
+    }
+
+    $lines = @($output | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($lines.Count -lt 3) {
+        throw "PaddleOCR version verification output was incomplete."
+    }
+
+    if ($lines[0].Trim() -ne "3.2.0" -or $lines[1].Trim() -ne "3.3.3") {
+        throw "Unexpected Paddle package versions. Expected paddlepaddle 3.2.0 and paddleocr 3.3.3."
+    }
+
+    return $lines[2].Trim()
+}
+
+function Find-TesseractExecutable {
+    $candidates = New-Object System.Collections.Generic.List[string]
+
+    $tesseractCommand = Get-Command tesseract.exe -ErrorAction SilentlyContinue
+    if ($null -ne $tesseractCommand -and -not [string]::IsNullOrWhiteSpace($tesseractCommand.Source)) {
+        [void]$candidates.Add($tesseractCommand.Source)
+    }
+
+    foreach ($path in @(
+        "C:\Program Files\Tesseract-OCR\tesseract.exe",
+        "C:\Program Files (x86)\Tesseract-OCR\tesseract.exe",
+        (Join-Path $env:LOCALAPPDATA "Programs\Tesseract-OCR\tesseract.exe")
+    )) {
+        if (Test-Path $path) {
+            [void]$candidates.Add($path)
+        }
+    }
+
+    return $candidates | Select-Object -Unique | Select-Object -First 1
+}
+
+function Ensure-TesseractExecutable {
+    $tesseractExe = Find-TesseractExecutable
+    if (-not [string]::IsNullOrWhiteSpace($tesseractExe)) {
+        return $tesseractExe
+    }
+
+    foreach ($packageId in @("UB-Mannheim.TesseractOCR", "tesseract-ocr.tesseract")) {
+        if (Invoke-WingetInstall -PackageId $packageId) {
+            Start-Sleep -Seconds 2
+            $tesseractExe = Find-TesseractExecutable
+            if (-not [string]::IsNullOrWhiteSpace($tesseractExe)) {
+                return $tesseractExe
+            }
+        }
+    }
+
+    throw "Tesseract executable could not be found or installed automatically."
+}
+
+$configInfo = Get-AppConfigInfo
+Write-Status ("Config path: " + $configInfo.ConfigPath)
+
+switch ($Engine) {
+    "EasyOCR" {
+        $pythonInfo = Find-EasyOcrBasePython
+        if ($null -eq $pythonInfo) {
+            throw "Python 3.8 or newer was not found. Install Python and rerun Install-EasyOCR.bat."
+        }
+
+        Write-Status ("Using base Python: " + $pythonInfo.Executable)
+        $venvPath = Join-Path $configInfo.VenvRoot "easyocr"
+        $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
+        Install-PythonPackages -PythonExe $venvPython -Packages @("torch", "torchvision", "easyocr")
+        $verifiedPython = Assert-EasyOcrEnvironment -PythonExe $venvPython
+        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "EasyOcrPythonPath" -Value $verifiedPython
+        Write-Success ("EasyOCR installation completed.")
+        Write-Success ("EasyOcrPythonPath=" + $verifiedPython)
+    }
+    "PaddleOCR" {
+        $pythonInfo = Ensure-Python310
+        Write-Status ("Using Python 3.10: " + $pythonInfo.Executable)
+        $venvPath = Join-Path $configInfo.VenvRoot "paddleocr310"
+        $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
+        Install-PythonPackages -PythonExe $venvPython -Packages @("paddlepaddle==3.2.0", "paddleocr==3.3.3")
+        $verifiedPython = Assert-PaddleOcrEnvironment -PythonExe $venvPython
+        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "PaddleOcrPythonPath" -Value $verifiedPython
+        Write-Success ("PaddleOCR installation completed.")
+        Write-Success ("PaddleOcrPythonPath=" + $verifiedPython)
+    }
+    "Tesseract" {
+        $tesseractExe = Ensure-TesseractExecutable
+        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "TesseractExePath" -Value $tesseractExe
+        Write-Success ("Tesseract installation completed.")
+        Write-Success ("TesseractExePath=" + $tesseractExe)
+    }
+}

--- a/GameChatTranslator/Distribution/readme.txt
+++ b/GameChatTranslator/Distribution/readme.txt
@@ -35,6 +35,20 @@ OCR로 읽은 전체 텍스트를 하나의 번역 대상으로 보냅니다. St
   일본어, 중국어, 러시아어 OCR 언어팩 설치를 돕는 스크립트입니다.
   반드시 관리자 권한으로 실행해야 하며, 설치 후 재부팅이 필요합니다.
 
+- Install-Tesseract.bat
+  Tesseract 설치를 시도하고, 성공하면 TesseractExePath를 config.ini에 자동 기록합니다.
+
+- Install-EasyOCR.bat
+  현재 설치된 Python 3.8+로 EasyOCR 전용 venv를 만들고,
+  torch / torchvision / easyocr를 설치한 뒤 EasyOcrPythonPath를 config.ini에 자동 기록합니다.
+
+- Install-PaddleOCR.bat
+  Python 3.10 venv를 만들고 paddlepaddle==3.2.0 / paddleocr==3.3.3 조합을 설치한 뒤
+  PaddleOcrPythonPath를 config.ini에 자동 기록합니다.
+
+- Install-All-OCR.bat
+  LangInstall.bat, Install-Tesseract.bat, Install-EasyOCR.bat, Install-PaddleOCR.bat를 순서대로 실행합니다.
+
 - characters.txt
   OCR 결과에서 캐릭터명을 검증할 때 사용하는 캐릭터명 목록입니다.
   이 파일에 없는 이름은 오인식 방지를 위해 번역에서 제외될 수 있습니다.
@@ -83,6 +97,8 @@ OCR로 읽은 전체 텍스트를 하나의 번역 대상으로 보냅니다. St
 3) 선택한 언어팩 설치가 진행됩니다.
 4) 설치 완료 후 반드시 Windows를 재부팅하세요.
 5) 재부팅 후 프로그램을 실행하면 Windows OCR 엔진이 설치된 언어를 자동으로 감지합니다.
+6) Tesseract / EasyOCR / PaddleOCR는 각각 Install-Tesseract.bat, Install-EasyOCR.bat, Install-PaddleOCR.bat로 설치할 수 있습니다.
+7) 스크립트가 성공하면 config.ini의 OCR 경로 키를 자동으로 갱신합니다.
 
 언어팩이 없으면 해당 언어 OCR 엔진을 만들 수 없어 외국어 채팅 인식률이 떨어집니다.
 한국어와 영어만 사용할 경우에도 재부팅은 권장합니다.

--- a/GameChatTranslator/GameChatTranslator.csproj
+++ b/GameChatTranslator/GameChatTranslator.csproj
@@ -49,6 +49,36 @@
 	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	    <TargetPath>LangInstall.bat</TargetPath>
 	  </None>
+	  <!-- OCR 자동 설치 PowerShell 스크립트입니다. 엔진별 .bat가 이 파일을 호출합니다. -->
+	  <None Update="Distribution/OcrInstall.ps1">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>OcrInstall.ps1</TargetPath>
+	  </None>
+	  <!-- Tesseract 자동 설치/경로 기록 스크립트입니다. -->
+	  <None Update="Distribution/Install-Tesseract.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Install-Tesseract.bat</TargetPath>
+	  </None>
+	  <!-- EasyOCR 자동 설치/경로 기록 스크립트입니다. -->
+	  <None Update="Distribution/Install-EasyOCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Install-EasyOCR.bat</TargetPath>
+	  </None>
+	  <!-- PaddleOCR 자동 설치/경로 기록 스크립트입니다. -->
+	  <None Update="Distribution/Install-PaddleOCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Install-PaddleOCR.bat</TargetPath>
+	  </None>
+	  <!-- 전체 OCR 설치를 순차 실행하는 스크립트입니다. -->
+	  <None Update="Distribution/Install-All-OCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Install-All-OCR.bat</TargetPath>
+	  </None>
 	  <!-- 배포 zip에 들어가는 사용자용 간단 설명서입니다. 실제 파일명은 readme.txt입니다. -->
 	  <None Update="Distribution/readme.txt">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -71,7 +101,7 @@
 
 	<ItemGroup>
 	  <!-- Visual Studio 게시 프로필에서도 배포 보조 파일이 누락되지 않도록 Publish 후 루트 출력 폴더에 한 번 더 복사합니다. -->
-	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/readme.txt;Distribution/easyocr_runner.py;Distribution/paddleocr_runner.py" />
+	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/OcrInstall.ps1;Distribution/Install-Tesseract.bat;Distribution/Install-EasyOCR.bat;Distribution/Install-PaddleOCR.bat;Distribution/Install-All-OCR.bat;Distribution/readme.txt;Distribution/easyocr_runner.py;Distribution/paddleocr_runner.py" />
 	</ItemGroup>
 
 	<Target Name="CopyDistributionFilesToPublishDirectory" AfterTargets="Publish" Condition="'$(PublishDir)' != ''">

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ GameChatTranslator는 OCR 엔진별로 필요한 설치 조건이 다릅니다.
 - config.ini의 TesseractExePath에 실행 파일 경로 지정
 ```
 
+설치 스크립트:
+```text
+- Install-Tesseract.bat
+- 설치가 끝나면 TesseractExePath를 config.ini에 자동 기록
+```
+
 주의:
 - 설치되어 있지 않거나 실패하면 Windows OCR로 자동 fallback 됩니다.
 - EasyOCR / PaddleOCR를 메인 OCR로 선택한 경우에도 외부 OCR 실패 시 Tesseract -> Windows OCR 순서로 자동 fallback 합니다.
@@ -176,6 +182,13 @@ GameChatTranslator는 OCR 엔진별로 필요한 설치 조건이 다릅니다.
 설치 예시:
 ```bash
 py -m pip install torch torchvision easyocr
+```
+
+설치 스크립트:
+```text
+- Install-EasyOCR.bat
+- 현재 설치된 Python 3.8+를 사용
+- 전용 venv를 만든 뒤 EasyOcrPythonPath를 config.ini에 자동 기록
 ```
 
 주의:
@@ -203,6 +216,14 @@ py -m pip install paddlepaddle
 py -m pip install "paddleocr[all]"
 ```
 
+설치 스크립트:
+```text
+- Install-PaddleOCR.bat
+- Python 3.10 전용 venv 생성
+- paddlepaddle==3.2.0 / paddleocr==3.3.3 설치
+- PaddleOcrPythonPath를 config.ini에 자동 기록
+```
+
 주의:
 - 메인 번역 경로에서 선택할 수 있습니다.
 - 현재는 resident worker를 lazy init으로 사용합니다. 첫 요청은 Python 기동과 모델 로딩 때문에 느릴 수 있지만, 이후 요청은 같은 워커를 재사용합니다.
@@ -218,6 +239,7 @@ py -m pip install "paddleocr[all]"
 환경설정창의 OCR 언어팩 상태 영역에서 한국어, 영어, 중국어, 일본어, 러시아어 OCR 설치 여부를 확인할 수 있습니다.
 
 미설치 언어가 있으면 `LangInstall.bat`를 관리자 권한으로 실행하고 재부팅한 뒤 다시 확인합니다.
+EasyOCR / PaddleOCR / Tesseract까지 한 번에 준비하려면 `Install-All-OCR.bat`를 사용할 수 있습니다.
 
 ### 2. 캡처 영역 지정
 


### PR DESCRIPTION
## 작업 내용
- OCR 자동 설치 스크립트 추가
  - Install-Tesseract.bat
  - Install-EasyOCR.bat
  - Install-PaddleOCR.bat
  - Install-All-OCR.bat
  - OcrInstall.ps1
- 설치 성공 후 config.ini의 OCR 경로 키 자동 기록
  - [OCR] TesseractExePath
  - [OCR] EasyOcrPythonPath
  - [OCR] PaddleOcrPythonPath
- portable / LocalAppData 모드 분기 처리
- README 및 배포 readme 반영

## 검증
- git diff --check 통과
- dotnet build -c Release -p:EnableWindowsTargeting=true 성공
- dotnet test: 468 passed, 0 failed

## 주의
- WSL2 환경이라 .bat / PowerShell 스크립트의 Windows 실실행 검증은 아직 못 했습니다.
- PR 머지 전/후 Windows에서 Install-EasyOCR.bat / Install-PaddleOCR.bat / Install-All-OCR.bat 1회 실행 확인이 필요합니다.