### PR TITLE
기능: OCR 제거 스크립트 추가

### DIFF
--- a/GameChatTranslator/Distribution/OcrInstall.ps1
+++ b/GameChatTranslator/Distribution/OcrInstall.ps1
@@ -1,4 +1,8 @@
 param(
+    [Parameter()]
+    [ValidateSet("Install", "Uninstall")]
+    [string]$Action = "Install",
+
     [Parameter(Mandatory = $true)]
     [ValidateSet("EasyOCR", "PaddleOCR", "Tesseract")]
     [string]$Engine
@@ -121,6 +125,68 @@ function Set-IniValue {
 
     $insertIndex = $sectionEnd
     [void]$lines.Insert($insertIndex, "$Key=$Value")
+    [System.IO.File]::WriteAllLines($ConfigPath, $lines)
+}
+
+function Remove-IniKey {
+    param(
+        [string]$ConfigPath,
+        [string]$Section,
+        [string]$Key
+    )
+
+    if (-not (Test-Path $ConfigPath)) {
+        return
+    }
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    foreach ($line in [System.IO.File]::ReadAllLines($ConfigPath)) {
+        [void]$lines.Add($line)
+    }
+
+    $sectionStart = -1
+    $sectionEnd = $lines.Count
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $trimmed = $lines[$i].Trim()
+        if (-not ($trimmed.StartsWith("[") -and $trimmed.EndsWith("]"))) {
+            continue
+        }
+
+        $sectionName = $trimmed.Substring(1, $trimmed.Length - 2)
+        if ($sectionStart -lt 0) {
+            if ($sectionName.Equals($Section, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $sectionStart = $i
+            }
+
+            continue
+        }
+
+        $sectionEnd = $i
+        break
+    }
+
+    if ($sectionStart -lt 0) {
+        return
+    }
+
+    for ($i = $sectionStart + 1; $i -lt $sectionEnd; $i++) {
+        $trimmed = $lines[$i].Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith(";") -or $trimmed.StartsWith("#")) {
+            continue
+        }
+
+        $separatorIndex = $trimmed.IndexOf("=")
+        if ($separatorIndex -lt 0) {
+            continue
+        }
+
+        $existingKey = $trimmed.Substring(0, $separatorIndex).Trim()
+        if ($existingKey.Equals($Key, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $lines.RemoveAt($i)
+            break
+        }
+    }
+
     [System.IO.File]::WriteAllLines($ConfigPath, $lines)
 }
 
@@ -257,6 +323,19 @@ function Invoke-WingetInstall {
     return $LASTEXITCODE -eq 0
 }
 
+function Invoke-WingetUninstall {
+    param([string]$PackageId)
+
+    $winget = Get-Command winget.exe -ErrorAction SilentlyContinue
+    if ($null -eq $winget) {
+        return $false
+    }
+
+    Write-Status "Attempting WinGet uninstall: $PackageId"
+    & $winget.Source uninstall --id $PackageId -e --accept-source-agreements --disable-interactivity
+    return $LASTEXITCODE -eq 0
+}
+
 function Ensure-Python310 {
     $pythonInfo = Find-Python310
     if ($null -ne $pythonInfo) {
@@ -384,40 +463,120 @@ function Ensure-TesseractExecutable {
     throw "Tesseract executable could not be found or installed automatically."
 }
 
+function Remove-VenvDirectory {
+    param([string]$VenvPath)
+
+    if (-not (Test-Path $VenvPath)) {
+        return $false
+    }
+
+    Write-Status "Removing virtual environment: $VenvPath"
+    Remove-Item -Path $VenvPath -Recurse -Force
+    return $true
+}
+
+function Uninstall-TesseractExecutable {
+    $removedByWinget = $false
+
+    foreach ($packageId in @("UB-Mannheim.TesseractOCR", "tesseract-ocr.tesseract")) {
+        if (Invoke-WingetUninstall -PackageId $packageId) {
+            $removedByWinget = $true
+        }
+    }
+
+    Start-Sleep -Seconds 1
+    $remaining = Find-TesseractExecutable
+
+    return [pscustomobject]@{
+        RemovedByWinget = $removedByWinget
+        RemainingExecutable = $remaining
+    }
+}
+
 $configInfo = Get-AppConfigInfo
 Write-Status ("Config path: " + $configInfo.ConfigPath)
 
-switch ($Engine) {
-    "EasyOCR" {
-        $pythonInfo = Find-EasyOcrBasePython
-        if ($null -eq $pythonInfo) {
-            throw "Python 3.8 or newer was not found. Install Python and rerun Install-EasyOCR.bat."
-        }
+switch ($Action) {
+    "Install" {
+        switch ($Engine) {
+            "EasyOCR" {
+                $pythonInfo = Find-EasyOcrBasePython
+                if ($null -eq $pythonInfo) {
+                    throw "Python 3.8 or newer was not found. Install Python and rerun Install-EasyOCR.bat."
+                }
 
-        Write-Status ("Using base Python: " + $pythonInfo.Executable)
-        $venvPath = Join-Path $configInfo.VenvRoot "easyocr"
-        $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
-        Install-PythonPackages -PythonExe $venvPython -Packages @("torch", "torchvision", "easyocr")
-        $verifiedPython = Assert-EasyOcrEnvironment -PythonExe $venvPython
-        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "EasyOcrPythonPath" -Value $verifiedPython
-        Write-Success ("EasyOCR installation completed.")
-        Write-Success ("EasyOcrPythonPath=" + $verifiedPython)
+                Write-Status ("Using base Python: " + $pythonInfo.Executable)
+                $venvPath = Join-Path $configInfo.VenvRoot "easyocr"
+                $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
+                Install-PythonPackages -PythonExe $venvPython -Packages @("torch", "torchvision", "easyocr")
+                $verifiedPython = Assert-EasyOcrEnvironment -PythonExe $venvPython
+                Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "EasyOcrPythonPath" -Value $verifiedPython
+                Write-Success ("EasyOCR installation completed.")
+                Write-Success ("EasyOcrPythonPath=" + $verifiedPython)
+            }
+            "PaddleOCR" {
+                $pythonInfo = Ensure-Python310
+                Write-Status ("Using Python 3.10: " + $pythonInfo.Executable)
+                $venvPath = Join-Path $configInfo.VenvRoot "paddleocr310"
+                $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
+                Install-PythonPackages -PythonExe $venvPython -Packages @("paddlepaddle==3.2.0", "paddleocr==3.3.3")
+                $verifiedPython = Assert-PaddleOcrEnvironment -PythonExe $venvPython
+                Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "PaddleOcrPythonPath" -Value $verifiedPython
+                Write-Success ("PaddleOCR installation completed.")
+                Write-Success ("PaddleOcrPythonPath=" + $verifiedPython)
+            }
+            "Tesseract" {
+                $tesseractExe = Ensure-TesseractExecutable
+                Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "TesseractExePath" -Value $tesseractExe
+                Write-Success ("Tesseract installation completed.")
+                Write-Success ("TesseractExePath=" + $tesseractExe)
+            }
+        }
     }
-    "PaddleOCR" {
-        $pythonInfo = Ensure-Python310
-        Write-Status ("Using Python 3.10: " + $pythonInfo.Executable)
-        $venvPath = Join-Path $configInfo.VenvRoot "paddleocr310"
-        $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
-        Install-PythonPackages -PythonExe $venvPython -Packages @("paddlepaddle==3.2.0", "paddleocr==3.3.3")
-        $verifiedPython = Assert-PaddleOcrEnvironment -PythonExe $venvPython
-        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "PaddleOcrPythonPath" -Value $verifiedPython
-        Write-Success ("PaddleOCR installation completed.")
-        Write-Success ("PaddleOcrPythonPath=" + $verifiedPython)
-    }
-    "Tesseract" {
-        $tesseractExe = Ensure-TesseractExecutable
-        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "TesseractExePath" -Value $tesseractExe
-        Write-Success ("Tesseract installation completed.")
-        Write-Success ("TesseractExePath=" + $tesseractExe)
+    "Uninstall" {
+        switch ($Engine) {
+            "EasyOCR" {
+                $venvPath = Join-Path $configInfo.VenvRoot "easyocr"
+                $removed = Remove-VenvDirectory -VenvPath $venvPath
+                Remove-IniKey -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "EasyOcrPythonPath"
+                if ($removed) {
+                    Write-Success "EasyOCR virtual environment removed."
+                } else {
+                    Write-Status "EasyOCR virtual environment was not present."
+                }
+
+                Write-Success "EasyOcrPythonPath removed from config.ini."
+            }
+            "PaddleOCR" {
+                $venvPath = Join-Path $configInfo.VenvRoot "paddleocr310"
+                $removed = Remove-VenvDirectory -VenvPath $venvPath
+                Remove-IniKey -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "PaddleOcrPythonPath"
+                if ($removed) {
+                    Write-Success "PaddleOCR virtual environment removed."
+                } else {
+                    Write-Status "PaddleOCR virtual environment was not present."
+                }
+
+                Write-Success "PaddleOcrPythonPath removed from config.ini."
+            }
+            "Tesseract" {
+                $result = Uninstall-TesseractExecutable
+                Remove-IniKey -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "TesseractExePath"
+                if ($result.RemovedByWinget) {
+                    Write-Success "Tesseract uninstall was requested through WinGet."
+                } else {
+                    Write-Status "Tesseract was not removed automatically by WinGet."
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($result.RemainingExecutable)) {
+                    Write-Status ("Tesseract executable still exists: " + $result.RemainingExecutable)
+                    Write-Status "If Tesseract was installed manually, remove it from Windows Apps or delete the portable folder yourself."
+                } else {
+                    Write-Success "Tesseract executable was not detected after uninstall."
+                }
+
+                Write-Success "TesseractExePath removed from config.ini."
+            }
+        }
     }
 }

--- a/GameChatTranslator/Distribution/Uninstall-All-OCR.bat
+++ b/GameChatTranslator/Distribution/Uninstall-All-OCR.bat
@@ -1,0 +1,34 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "FAILED=0"
+
+echo ==========================================
+echo   GameChatTranslator OCR Remover
+echo ==========================================
+echo.
+echo This script removes EasyOCR, PaddleOCR and
+echo Tesseract helper environments.
+echo Windows OCR language packs are not removed here.
+echo.
+
+call "%~dp0Uninstall-Tesseract.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+call "%~dp0Uninstall-EasyOCR.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+call "%~dp0Uninstall-PaddleOCR.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+echo.
+echo ==========================================
+if "!FAILED!"=="0" (
+    echo [OK] OCR removal steps completed.
+) else (
+    echo [WARN] Some OCR removal steps failed.
+)
+echo ==========================================
+echo.
+pause
+exit /b !FAILED!

--- a/GameChatTranslator/Distribution/Uninstall-EasyOCR.bat
+++ b/GameChatTranslator/Distribution/Uninstall-EasyOCR.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Action Uninstall -Engine EasyOCR
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] EasyOCR removal finished.
+) else (
+    echo [FAIL] EasyOCR removal failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/Uninstall-PaddleOCR.bat
+++ b/GameChatTranslator/Distribution/Uninstall-PaddleOCR.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Action Uninstall -Engine PaddleOCR
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] PaddleOCR removal finished.
+) else (
+    echo [FAIL] PaddleOCR removal failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/Uninstall-Tesseract.bat
+++ b/GameChatTranslator/Distribution/Uninstall-Tesseract.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Action Uninstall -Engine Tesseract
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] Tesseract removal finished.
+) else (
+    echo [FAIL] Tesseract removal failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/readme.txt
+++ b/GameChatTranslator/Distribution/readme.txt
@@ -49,6 +49,19 @@ OCR로 읽은 전체 텍스트를 하나의 번역 대상으로 보냅니다. St
 - Install-All-OCR.bat
   LangInstall.bat, Install-Tesseract.bat, Install-EasyOCR.bat, Install-PaddleOCR.bat를 순서대로 실행합니다.
 
+- Uninstall-Tesseract.bat
+  Tesseract 제거를 시도하고, 성공 여부와 관계없이 TesseractExePath를 config.ini에서 정리합니다.
+
+- Uninstall-EasyOCR.bat
+  EasyOCR 전용 venv를 제거하고 EasyOcrPythonPath를 config.ini에서 정리합니다.
+
+- Uninstall-PaddleOCR.bat
+  PaddleOCR 전용 venv를 제거하고 PaddleOcrPythonPath를 config.ini에서 정리합니다.
+
+- Uninstall-All-OCR.bat
+  Uninstall-Tesseract.bat, Uninstall-EasyOCR.bat, Uninstall-PaddleOCR.bat를 순서대로 실행합니다.
+  Windows OCR 언어팩 제거는 포함하지 않습니다.
+
 - characters.txt
   OCR 결과에서 캐릭터명을 검증할 때 사용하는 캐릭터명 목록입니다.
   이 파일에 없는 이름은 오인식 방지를 위해 번역에서 제외될 수 있습니다.

--- a/GameChatTranslator/GameChatTranslator.csproj
+++ b/GameChatTranslator/GameChatTranslator.csproj
@@ -79,6 +79,30 @@
 	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	    <TargetPath>Install-All-OCR.bat</TargetPath>
 	  </None>
+	  <!-- Tesseract 제거/설정 정리 스크립트입니다. -->
+	  <None Update="Distribution/Uninstall-Tesseract.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Uninstall-Tesseract.bat</TargetPath>
+	  </None>
+	  <!-- EasyOCR 제거/설정 정리 스크립트입니다. -->
+	  <None Update="Distribution/Uninstall-EasyOCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Uninstall-EasyOCR.bat</TargetPath>
+	  </None>
+	  <!-- PaddleOCR 제거/설정 정리 스크립트입니다. -->
+	  <None Update="Distribution/Uninstall-PaddleOCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Uninstall-PaddleOCR.bat</TargetPath>
+	  </None>
+	  <!-- 전체 OCR 제거를 순차 실행하는 스크립트입니다. -->
+	  <None Update="Distribution/Uninstall-All-OCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Uninstall-All-OCR.bat</TargetPath>
+	  </None>
 	  <!-- 배포 zip에 들어가는 사용자용 간단 설명서입니다. 실제 파일명은 readme.txt입니다. -->
 	  <None Update="Distribution/readme.txt">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -101,7 +125,7 @@
 
 	<ItemGroup>
 	  <!-- Visual Studio 게시 프로필에서도 배포 보조 파일이 누락되지 않도록 Publish 후 루트 출력 폴더에 한 번 더 복사합니다. -->
-	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/OcrInstall.ps1;Distribution/Install-Tesseract.bat;Distribution/Install-EasyOCR.bat;Distribution/Install-PaddleOCR.bat;Distribution/Install-All-OCR.bat;Distribution/readme.txt;Distribution/easyocr_runner.py;Distribution/paddleocr_runner.py" />
+	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/OcrInstall.ps1;Distribution/Install-Tesseract.bat;Distribution/Install-EasyOCR.bat;Distribution/Install-PaddleOCR.bat;Distribution/Install-All-OCR.bat;Distribution/Uninstall-Tesseract.bat;Distribution/Uninstall-EasyOCR.bat;Distribution/Uninstall-PaddleOCR.bat;Distribution/Uninstall-All-OCR.bat;Distribution/readme.txt;Distribution/easyocr_runner.py;Distribution/paddleocr_runner.py" />
 	</ItemGroup>
 
 	<Target Name="CopyDistributionFilesToPublishDirectory" AfterTargets="Publish" Condition="'$(PublishDir)' != ''">

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ GameChatTranslator는 OCR 엔진별로 필요한 설치 조건이 다릅니다.
 ```text
 - Install-Tesseract.bat
 - 설치가 끝나면 TesseractExePath를 config.ini에 자동 기록
+- Uninstall-Tesseract.bat
+- 제거 시 TesseractExePath를 config.ini에서 정리
 ```
 
 주의:
@@ -189,6 +191,8 @@ py -m pip install torch torchvision easyocr
 - Install-EasyOCR.bat
 - 현재 설치된 Python 3.8+를 사용
 - 전용 venv를 만든 뒤 EasyOcrPythonPath를 config.ini에 자동 기록
+- Uninstall-EasyOCR.bat
+- 제거 시 venv와 EasyOcrPythonPath를 함께 정리
 ```
 
 주의:
@@ -222,6 +226,8 @@ py -m pip install "paddleocr[all]"
 - Python 3.10 전용 venv 생성
 - paddlepaddle==3.2.0 / paddleocr==3.3.3 설치
 - PaddleOcrPythonPath를 config.ini에 자동 기록
+- Uninstall-PaddleOCR.bat
+- 제거 시 venv와 PaddleOcrPythonPath를 함께 정리
 ```
 
 주의:
@@ -240,6 +246,7 @@ py -m pip install "paddleocr[all]"
 
 미설치 언어가 있으면 `LangInstall.bat`를 관리자 권한으로 실행하고 재부팅한 뒤 다시 확인합니다.
 EasyOCR / PaddleOCR / Tesseract까지 한 번에 준비하려면 `Install-All-OCR.bat`를 사용할 수 있습니다.
+EasyOCR / PaddleOCR / Tesseract를 한 번에 정리하려면 `Uninstall-All-OCR.bat`를 사용할 수 있습니다. 이 스크립트에는 Windows OCR 언어팩 제거가 포함되지 않습니다.
 
 ### 2. 캡처 영역 지정
 


### PR DESCRIPTION
## 작업 내용
- OcrInstall.ps1에 Uninstall 동작 추가
- OCR 제거 스크립트 추가
  - Uninstall-Tesseract.bat
  - Uninstall-EasyOCR.bat
  - Uninstall-PaddleOCR.bat
  - Uninstall-All-OCR.bat
- EasyOCR / PaddleOCR 전용 venv 제거
- Tesseract uninstall 시도 후 config.ini 키 정리
- config.ini의 [OCR] 경로 키 정리
- README 및 배포 readme 반영

## 검증
- git diff --check 통과
- dotnet build -c Release -p:EnableWindowsTargeting=true 성공
- dotnet test: 468 passed, 0 failed

## 주의
- 이 PR은 #195 위에 쌓인 stacked PR입니다.
- Windows OCR 언어팩 제거는 포함하지 않습니다. 별도 PR로 분리합니다.
- WSL2 환경이라 .bat / PowerShell 스크립트의 Windows 실실행 검증은 아직 못 했습니다.