### PR TITLE
기능: OCR 설치 삭제 UI 추가

### DIFF
--- a/GameChatTranslator/Distribution/OcrInstall.ps1
+++ b/GameChatTranslator/Distribution/OcrInstall.ps1
@@ -1,4 +1,8 @@
 param(
+    [Parameter()]
+    [ValidateSet("Install", "Uninstall")]
+    [string]$Action = "Install",
+
     [Parameter(Mandatory = $true)]
     [ValidateSet("EasyOCR", "PaddleOCR", "Tesseract")]
     [string]$Engine
@@ -121,6 +125,68 @@ function Set-IniValue {
 
     $insertIndex = $sectionEnd
     [void]$lines.Insert($insertIndex, "$Key=$Value")
+    [System.IO.File]::WriteAllLines($ConfigPath, $lines)
+}
+
+function Remove-IniKey {
+    param(
+        [string]$ConfigPath,
+        [string]$Section,
+        [string]$Key
+    )
+
+    if (-not (Test-Path $ConfigPath)) {
+        return
+    }
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    foreach ($line in [System.IO.File]::ReadAllLines($ConfigPath)) {
+        [void]$lines.Add($line)
+    }
+
+    $sectionStart = -1
+    $sectionEnd = $lines.Count
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $trimmed = $lines[$i].Trim()
+        if (-not ($trimmed.StartsWith("[") -and $trimmed.EndsWith("]"))) {
+            continue
+        }
+
+        $sectionName = $trimmed.Substring(1, $trimmed.Length - 2)
+        if ($sectionStart -lt 0) {
+            if ($sectionName.Equals($Section, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $sectionStart = $i
+            }
+
+            continue
+        }
+
+        $sectionEnd = $i
+        break
+    }
+
+    if ($sectionStart -lt 0) {
+        return
+    }
+
+    for ($i = $sectionStart + 1; $i -lt $sectionEnd; $i++) {
+        $trimmed = $lines[$i].Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith(";") -or $trimmed.StartsWith("#")) {
+            continue
+        }
+
+        $separatorIndex = $trimmed.IndexOf("=")
+        if ($separatorIndex -lt 0) {
+            continue
+        }
+
+        $existingKey = $trimmed.Substring(0, $separatorIndex).Trim()
+        if ($existingKey.Equals($Key, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $lines.RemoveAt($i)
+            break
+        }
+    }
+
     [System.IO.File]::WriteAllLines($ConfigPath, $lines)
 }
 
@@ -257,6 +323,19 @@ function Invoke-WingetInstall {
     return $LASTEXITCODE -eq 0
 }
 
+function Invoke-WingetUninstall {
+    param([string]$PackageId)
+
+    $winget = Get-Command winget.exe -ErrorAction SilentlyContinue
+    if ($null -eq $winget) {
+        return $false
+    }
+
+    Write-Status "Attempting WinGet uninstall: $PackageId"
+    & $winget.Source uninstall --id $PackageId -e --accept-source-agreements --disable-interactivity
+    return $LASTEXITCODE -eq 0
+}
+
 function Ensure-Python310 {
     $pythonInfo = Find-Python310
     if ($null -ne $pythonInfo) {
@@ -384,40 +463,120 @@ function Ensure-TesseractExecutable {
     throw "Tesseract executable could not be found or installed automatically."
 }
 
+function Remove-VenvDirectory {
+    param([string]$VenvPath)
+
+    if (-not (Test-Path $VenvPath)) {
+        return $false
+    }
+
+    Write-Status "Removing virtual environment: $VenvPath"
+    Remove-Item -Path $VenvPath -Recurse -Force
+    return $true
+}
+
+function Uninstall-TesseractExecutable {
+    $removedByWinget = $false
+
+    foreach ($packageId in @("UB-Mannheim.TesseractOCR", "tesseract-ocr.tesseract")) {
+        if (Invoke-WingetUninstall -PackageId $packageId) {
+            $removedByWinget = $true
+        }
+    }
+
+    Start-Sleep -Seconds 1
+    $remaining = Find-TesseractExecutable
+
+    return [pscustomobject]@{
+        RemovedByWinget = $removedByWinget
+        RemainingExecutable = $remaining
+    }
+}
+
 $configInfo = Get-AppConfigInfo
 Write-Status ("Config path: " + $configInfo.ConfigPath)
 
-switch ($Engine) {
-    "EasyOCR" {
-        $pythonInfo = Find-EasyOcrBasePython
-        if ($null -eq $pythonInfo) {
-            throw "Python 3.8 or newer was not found. Install Python and rerun Install-EasyOCR.bat."
-        }
+switch ($Action) {
+    "Install" {
+        switch ($Engine) {
+            "EasyOCR" {
+                $pythonInfo = Find-EasyOcrBasePython
+                if ($null -eq $pythonInfo) {
+                    throw "Python 3.8 or newer was not found. Install Python and rerun Install-EasyOCR.bat."
+                }
 
-        Write-Status ("Using base Python: " + $pythonInfo.Executable)
-        $venvPath = Join-Path $configInfo.VenvRoot "easyocr"
-        $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
-        Install-PythonPackages -PythonExe $venvPython -Packages @("torch", "torchvision", "easyocr")
-        $verifiedPython = Assert-EasyOcrEnvironment -PythonExe $venvPython
-        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "EasyOcrPythonPath" -Value $verifiedPython
-        Write-Success ("EasyOCR installation completed.")
-        Write-Success ("EasyOcrPythonPath=" + $verifiedPython)
+                Write-Status ("Using base Python: " + $pythonInfo.Executable)
+                $venvPath = Join-Path $configInfo.VenvRoot "easyocr"
+                $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
+                Install-PythonPackages -PythonExe $venvPython -Packages @("torch", "torchvision", "easyocr")
+                $verifiedPython = Assert-EasyOcrEnvironment -PythonExe $venvPython
+                Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "EasyOcrPythonPath" -Value $verifiedPython
+                Write-Success ("EasyOCR installation completed.")
+                Write-Success ("EasyOcrPythonPath=" + $verifiedPython)
+            }
+            "PaddleOCR" {
+                $pythonInfo = Ensure-Python310
+                Write-Status ("Using Python 3.10: " + $pythonInfo.Executable)
+                $venvPath = Join-Path $configInfo.VenvRoot "paddleocr310"
+                $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
+                Install-PythonPackages -PythonExe $venvPython -Packages @("paddlepaddle==3.2.0", "paddleocr==3.3.3")
+                $verifiedPython = Assert-PaddleOcrEnvironment -PythonExe $venvPython
+                Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "PaddleOcrPythonPath" -Value $verifiedPython
+                Write-Success ("PaddleOCR installation completed.")
+                Write-Success ("PaddleOcrPythonPath=" + $verifiedPython)
+            }
+            "Tesseract" {
+                $tesseractExe = Ensure-TesseractExecutable
+                Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "TesseractExePath" -Value $tesseractExe
+                Write-Success ("Tesseract installation completed.")
+                Write-Success ("TesseractExePath=" + $tesseractExe)
+            }
+        }
     }
-    "PaddleOCR" {
-        $pythonInfo = Ensure-Python310
-        Write-Status ("Using Python 3.10: " + $pythonInfo.Executable)
-        $venvPath = Join-Path $configInfo.VenvRoot "paddleocr310"
-        $venvPython = Ensure-Venv -BasePythonExe $pythonInfo.Executable -VenvPath $venvPath
-        Install-PythonPackages -PythonExe $venvPython -Packages @("paddlepaddle==3.2.0", "paddleocr==3.3.3")
-        $verifiedPython = Assert-PaddleOcrEnvironment -PythonExe $venvPython
-        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "PaddleOcrPythonPath" -Value $verifiedPython
-        Write-Success ("PaddleOCR installation completed.")
-        Write-Success ("PaddleOcrPythonPath=" + $verifiedPython)
-    }
-    "Tesseract" {
-        $tesseractExe = Ensure-TesseractExecutable
-        Set-IniValue -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "TesseractExePath" -Value $tesseractExe
-        Write-Success ("Tesseract installation completed.")
-        Write-Success ("TesseractExePath=" + $tesseractExe)
+    "Uninstall" {
+        switch ($Engine) {
+            "EasyOCR" {
+                $venvPath = Join-Path $configInfo.VenvRoot "easyocr"
+                $removed = Remove-VenvDirectory -VenvPath $venvPath
+                Remove-IniKey -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "EasyOcrPythonPath"
+                if ($removed) {
+                    Write-Success "EasyOCR virtual environment removed."
+                } else {
+                    Write-Status "EasyOCR virtual environment was not present."
+                }
+
+                Write-Success "EasyOcrPythonPath removed from config.ini."
+            }
+            "PaddleOCR" {
+                $venvPath = Join-Path $configInfo.VenvRoot "paddleocr310"
+                $removed = Remove-VenvDirectory -VenvPath $venvPath
+                Remove-IniKey -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "PaddleOcrPythonPath"
+                if ($removed) {
+                    Write-Success "PaddleOCR virtual environment removed."
+                } else {
+                    Write-Status "PaddleOCR virtual environment was not present."
+                }
+
+                Write-Success "PaddleOcrPythonPath removed from config.ini."
+            }
+            "Tesseract" {
+                $result = Uninstall-TesseractExecutable
+                Remove-IniKey -ConfigPath $configInfo.ConfigPath -Section $ocrSectionName -Key "TesseractExePath"
+                if ($result.RemovedByWinget) {
+                    Write-Success "Tesseract uninstall was requested through WinGet."
+                } else {
+                    Write-Status "Tesseract was not removed automatically by WinGet."
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($result.RemainingExecutable)) {
+                    Write-Status ("Tesseract executable still exists: " + $result.RemainingExecutable)
+                    Write-Status "If Tesseract was installed manually, remove it from Windows Apps or delete the portable folder yourself."
+                } else {
+                    Write-Success "Tesseract executable was not detected after uninstall."
+                }
+
+                Write-Success "TesseractExePath removed from config.ini."
+            }
+        }
     }
 }

--- a/GameChatTranslator/Distribution/Uninstall-All-OCR.bat
+++ b/GameChatTranslator/Distribution/Uninstall-All-OCR.bat
@@ -1,0 +1,34 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "FAILED=0"
+
+echo ==========================================
+echo   GameChatTranslator OCR Remover
+echo ==========================================
+echo.
+echo This script removes EasyOCR, PaddleOCR and
+echo Tesseract helper environments.
+echo Windows OCR language packs are not removed here.
+echo.
+
+call "%~dp0Uninstall-Tesseract.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+call "%~dp0Uninstall-EasyOCR.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+call "%~dp0Uninstall-PaddleOCR.bat" --no-pause
+if errorlevel 1 set "FAILED=1"
+
+echo.
+echo ==========================================
+if "!FAILED!"=="0" (
+    echo [OK] OCR removal steps completed.
+) else (
+    echo [WARN] Some OCR removal steps failed.
+)
+echo ==========================================
+echo.
+pause
+exit /b !FAILED!

--- a/GameChatTranslator/Distribution/Uninstall-EasyOCR.bat
+++ b/GameChatTranslator/Distribution/Uninstall-EasyOCR.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Action Uninstall -Engine EasyOCR
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] EasyOCR removal finished.
+) else (
+    echo [FAIL] EasyOCR removal failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/Uninstall-PaddleOCR.bat
+++ b/GameChatTranslator/Distribution/Uninstall-PaddleOCR.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Action Uninstall -Engine PaddleOCR
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] PaddleOCR removal finished.
+) else (
+    echo [FAIL] PaddleOCR removal failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/Uninstall-Tesseract.bat
+++ b/GameChatTranslator/Distribution/Uninstall-Tesseract.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0OcrInstall.ps1" -Action Uninstall -Engine Tesseract
+set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if "%EXIT_CODE%"=="0" (
+    echo [OK] Tesseract removal finished.
+) else (
+    echo [FAIL] Tesseract removal failed.
+)
+
+if /i not "%~1"=="--no-pause" pause
+exit /b %EXIT_CODE%

--- a/GameChatTranslator/Distribution/readme.txt
+++ b/GameChatTranslator/Distribution/readme.txt
@@ -49,6 +49,19 @@ OCR로 읽은 전체 텍스트를 하나의 번역 대상으로 보냅니다. St
 - Install-All-OCR.bat
   LangInstall.bat, Install-Tesseract.bat, Install-EasyOCR.bat, Install-PaddleOCR.bat를 순서대로 실행합니다.
 
+- Uninstall-Tesseract.bat
+  Tesseract 제거를 시도하고, 성공 여부와 관계없이 TesseractExePath를 config.ini에서 정리합니다.
+
+- Uninstall-EasyOCR.bat
+  EasyOCR 전용 venv를 제거하고 EasyOcrPythonPath를 config.ini에서 정리합니다.
+
+- Uninstall-PaddleOCR.bat
+  PaddleOCR 전용 venv를 제거하고 PaddleOcrPythonPath를 config.ini에서 정리합니다.
+
+- Uninstall-All-OCR.bat
+  Uninstall-Tesseract.bat, Uninstall-EasyOCR.bat, Uninstall-PaddleOCR.bat를 순서대로 실행합니다.
+  Windows OCR 언어팩 제거는 포함하지 않습니다.
+
 - characters.txt
   OCR 결과에서 캐릭터명을 검증할 때 사용하는 캐릭터명 목록입니다.
   이 파일에 없는 이름은 오인식 방지를 위해 번역에서 제외될 수 있습니다.

--- a/GameChatTranslator/GameChatTranslator.csproj
+++ b/GameChatTranslator/GameChatTranslator.csproj
@@ -79,6 +79,30 @@
 	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	    <TargetPath>Install-All-OCR.bat</TargetPath>
 	  </None>
+	  <!-- Tesseract 제거/설정 정리 스크립트입니다. -->
+	  <None Update="Distribution/Uninstall-Tesseract.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Uninstall-Tesseract.bat</TargetPath>
+	  </None>
+	  <!-- EasyOCR 제거/설정 정리 스크립트입니다. -->
+	  <None Update="Distribution/Uninstall-EasyOCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Uninstall-EasyOCR.bat</TargetPath>
+	  </None>
+	  <!-- PaddleOCR 제거/설정 정리 스크립트입니다. -->
+	  <None Update="Distribution/Uninstall-PaddleOCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Uninstall-PaddleOCR.bat</TargetPath>
+	  </None>
+	  <!-- 전체 OCR 제거를 순차 실행하는 스크립트입니다. -->
+	  <None Update="Distribution/Uninstall-All-OCR.bat">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+	    <TargetPath>Uninstall-All-OCR.bat</TargetPath>
+	  </None>
 	  <!-- 배포 zip에 들어가는 사용자용 간단 설명서입니다. 실제 파일명은 readme.txt입니다. -->
 	  <None Update="Distribution/readme.txt">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -101,7 +125,7 @@
 
 	<ItemGroup>
 	  <!-- Visual Studio 게시 프로필에서도 배포 보조 파일이 누락되지 않도록 Publish 후 루트 출력 폴더에 한 번 더 복사합니다. -->
-	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/OcrInstall.ps1;Distribution/Install-Tesseract.bat;Distribution/Install-EasyOCR.bat;Distribution/Install-PaddleOCR.bat;Distribution/Install-All-OCR.bat;Distribution/readme.txt;Distribution/easyocr_runner.py;Distribution/paddleocr_runner.py" />
+	  <DistributionPublishFile Include="Distribution/characters.txt;Distribution/LangInstall.bat;Distribution/OcrInstall.ps1;Distribution/Install-Tesseract.bat;Distribution/Install-EasyOCR.bat;Distribution/Install-PaddleOCR.bat;Distribution/Install-All-OCR.bat;Distribution/Uninstall-Tesseract.bat;Distribution/Uninstall-EasyOCR.bat;Distribution/Uninstall-PaddleOCR.bat;Distribution/Uninstall-All-OCR.bat;Distribution/readme.txt;Distribution/easyocr_runner.py;Distribution/paddleocr_runner.py" />
 	</ItemGroup>
 
 	<Target Name="CopyDistributionFilesToPublishDirectory" AfterTargets="Publish" Condition="'$(PublishDir)' != ''">

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml
@@ -290,6 +290,71 @@
                         </StackPanel>
                     </GroupBox>
 
+                    <GroupBox Header="외부 OCR 설치 / 삭제" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="EasyOCR / PaddleOCR / Tesseract 설치 스크립트를 바로 실행합니다. 설치 상태에 따라 설치/삭제 버튼을 자동으로 켜고 끕니다."
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"
+                                       Foreground="#CCC"/>
+
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="125"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Tesseract" VerticalAlignment="Center" Foreground="#CCC"/>
+                                <TextBlock x:Name="TxtTesseractPackageStatus" Grid.Column="1" VerticalAlignment="Center" Foreground="#E6E6E6" Text="상태 확인 중..."/>
+                                <Button x:Name="BtnInstallTesseractPackage" Grid.Column="2" Content="설치" Padding="8,2" Margin="6,0,6,0" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnInstallTesseractPackage_Click"/>
+                                <Button x:Name="BtnUninstallTesseractPackage" Grid.Column="3" Content="삭제" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnUninstallTesseractPackage_Click"/>
+                            </Grid>
+
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="125"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="EasyOCR" VerticalAlignment="Center" Foreground="#CCC"/>
+                                <TextBlock x:Name="TxtEasyOcrPackageStatus" Grid.Column="1" VerticalAlignment="Center" Foreground="#E6E6E6" Text="상태 확인 중..."/>
+                                <Button x:Name="BtnInstallEasyOcrPackage" Grid.Column="2" Content="설치" Padding="8,2" Margin="6,0,6,0" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnInstallEasyOcrPackage_Click"/>
+                                <Button x:Name="BtnUninstallEasyOcrPackage" Grid.Column="3" Content="삭제" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnUninstallEasyOcrPackage_Click"/>
+                            </Grid>
+
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="125"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="PaddleOCR" VerticalAlignment="Center" Foreground="#CCC"/>
+                                <TextBlock x:Name="TxtPaddleOcrPackageStatus" Grid.Column="1" VerticalAlignment="Center" Foreground="#E6E6E6" Text="상태 확인 중..."/>
+                                <Button x:Name="BtnInstallPaddleOcrPackage" Grid.Column="2" Content="설치" Padding="8,2" Margin="6,0,6,0" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnInstallPaddleOcrPackage_Click"/>
+                                <Button x:Name="BtnUninstallPaddleOcrPackage" Grid.Column="3" Content="삭제" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnUninstallPaddleOcrPackage_Click"/>
+                            </Grid>
+
+                            <TextBlock Text="Windows OCR 언어팩 제거는 시스템 전체에 영향이 있어 별도 작업으로 분리합니다. 여기의 전체 설치/삭제는 Tesseract / EasyOCR / PaddleOCR만 대상으로 합니다."
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"
+                                       Foreground="#AFAFAF"
+                                       FontSize="11"/>
+
+                            <TextBlock x:Name="TxtExternalOcrPackageStatus"
+                                       Text=""
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"
+                                       Foreground="#CCC"/>
+
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button x:Name="BtnInstallAllOcrPackages" Content="전체 설치" Padding="8,2" Margin="0,0,8,0" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnInstallAllOcrPackages_Click"/>
+                                <Button x:Name="BtnUninstallAllOcrPackages" Content="전체 삭제" Padding="8,2" Background="#444" Foreground="White" BorderThickness="0" Cursor="Hand" Click="BtnUninstallAllOcrPackages_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
+
                     <GroupBox Header="OCR 테스트 / 진단" Foreground="White" Margin="0,0,0,10" BorderBrush="#555">
                         <StackPanel Margin="10">
                             <TextBlock Text="메인 번역용 OCR 엔진:"

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -29,6 +30,7 @@ namespace GameTranslator
         private readonly OcrLanguageStatusFormatter _ocrLanguageStatusFormatter = new OcrLanguageStatusFormatter();
         private readonly DispatcherTimer _updateStatusResetTimer;
         private readonly bool _isDialogMode;
+        private bool _isOcrPackageOperationRunning;
         internal OptionSelectorPostAction RequestedActionAfterClose { get; private set; } = OptionSelectorPostAction.None;
 
         private static readonly (string Label, string Tag)[] OcrLanguageStatusTargets =
@@ -69,6 +71,7 @@ namespace GameTranslator
         {
             Loaded -= OptionSelector_Loaded;
             RefreshOcrLanguageStatus();
+            RefreshExternalOcrPackageStatus();
         }
 
         /// <summary>
@@ -317,6 +320,166 @@ namespace GameTranslator
             TxtInstallLocation.Text = string.IsNullOrWhiteSpace(locationText)
                 ? "경로 확인 실패"
                 : locationText;
+        }
+
+        private void RefreshExternalOcrPackageStatus()
+        {
+            OcrPackageInstallationState tesseractState = GetTesseractInstallationState();
+            OcrPackageInstallationState easyOcrState = GetPythonOcrInstallationState("EasyOcrPythonPath");
+            OcrPackageInstallationState paddleOcrState = GetPythonOcrInstallationState("PaddleOcrPythonPath");
+
+            ApplyOcrPackageStatus(TxtTesseractPackageStatus, tesseractState);
+            ApplyOcrPackageStatus(TxtEasyOcrPackageStatus, easyOcrState);
+            ApplyOcrPackageStatus(TxtPaddleOcrPackageStatus, paddleOcrState);
+
+            bool anyInstalled = tesseractState.IsInstalled || easyOcrState.IsInstalled || paddleOcrState.IsInstalled;
+            bool anyMissing = !tesseractState.IsInstalled || !easyOcrState.IsInstalled || !paddleOcrState.IsInstalled;
+
+            if (BtnInstallTesseractPackage != null) BtnInstallTesseractPackage.IsEnabled = !_isOcrPackageOperationRunning && !tesseractState.IsInstalled;
+            if (BtnUninstallTesseractPackage != null) BtnUninstallTesseractPackage.IsEnabled = !_isOcrPackageOperationRunning && tesseractState.IsInstalled;
+            if (BtnInstallEasyOcrPackage != null) BtnInstallEasyOcrPackage.IsEnabled = !_isOcrPackageOperationRunning && !easyOcrState.IsInstalled;
+            if (BtnUninstallEasyOcrPackage != null) BtnUninstallEasyOcrPackage.IsEnabled = !_isOcrPackageOperationRunning && easyOcrState.IsInstalled;
+            if (BtnInstallPaddleOcrPackage != null) BtnInstallPaddleOcrPackage.IsEnabled = !_isOcrPackageOperationRunning && !paddleOcrState.IsInstalled;
+            if (BtnUninstallPaddleOcrPackage != null) BtnUninstallPaddleOcrPackage.IsEnabled = !_isOcrPackageOperationRunning && paddleOcrState.IsInstalled;
+            if (BtnInstallAllOcrPackages != null) BtnInstallAllOcrPackages.IsEnabled = !_isOcrPackageOperationRunning && anyMissing;
+            if (BtnUninstallAllOcrPackages != null) BtnUninstallAllOcrPackages.IsEnabled = !_isOcrPackageOperationRunning && anyInstalled;
+        }
+
+        private void ApplyOcrPackageStatus(TextBlock textBlock, OcrPackageInstallationState state)
+        {
+            if (textBlock == null || state == null) return;
+
+            textBlock.Text = state.StatusText;
+            textBlock.Foreground = state.IsInstalled
+                ? System.Windows.Media.Brushes.LightGreen
+                : System.Windows.Media.Brushes.Gold;
+        }
+
+        private OcrPackageInstallationState GetPythonOcrInstallationState(string key)
+        {
+            string configuredPath = (_ini?.Read(key) ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(configuredPath))
+            {
+                return OcrPackageInstallationState.NotInstalled("미설치");
+            }
+
+            if (File.Exists(configuredPath))
+            {
+                return OcrPackageInstallationState.Installed($"설치됨 ({configuredPath})");
+            }
+
+            return OcrPackageInstallationState.NotInstalled($"경로 불일치 ({configuredPath})");
+        }
+
+        private OcrPackageInstallationState GetTesseractInstallationState()
+        {
+            string configuredPath = (_ini?.Read("TesseractExePath") ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(configuredPath))
+            {
+                return OcrPackageInstallationState.NotInstalled("미설치");
+            }
+
+            if (Path.IsPathRooted(configuredPath) && File.Exists(configuredPath))
+            {
+                return OcrPackageInstallationState.Installed($"설치됨 ({configuredPath})");
+            }
+
+            return OcrPackageInstallationState.NotInstalled($"경로 불일치 ({configuredPath})");
+        }
+
+        private string GetOcrScriptPath(string fileName)
+        {
+            string baseDirectory = _mainWindow?.GetInstallLocationPath();
+            if (string.IsNullOrWhiteSpace(baseDirectory))
+            {
+                baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            }
+
+            string scriptPath = Path.Combine(baseDirectory, fileName);
+            return File.Exists(scriptPath) ? scriptPath : null;
+        }
+
+        private void SetExternalOcrPackageStatus(string text, System.Windows.Media.Brush brush)
+        {
+            if (TxtExternalOcrPackageStatus == null) return;
+
+            TxtExternalOcrPackageStatus.Text = text ?? "";
+            TxtExternalOcrPackageStatus.Foreground = brush;
+        }
+
+        private async Task RunOcrPackageScriptAsync(string scriptFileName, string actionLabel)
+        {
+            string scriptPath = GetOcrScriptPath(scriptFileName);
+            if (string.IsNullOrWhiteSpace(scriptPath))
+            {
+                SetExternalOcrPackageStatus("스크립트를 찾지 못했습니다.", System.Windows.Media.Brushes.OrangeRed);
+                System.Windows.MessageBox.Show($"스크립트를 찾지 못했습니다.\n{scriptFileName}", "OCR 설치/삭제", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            _isOcrPackageOperationRunning = true;
+            RefreshExternalOcrPackageStatus();
+            SetExternalOcrPackageStatus($"{actionLabel} 실행 중...", System.Windows.Media.Brushes.LightGray);
+
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = scriptPath,
+                    Arguments = "--no-pause",
+                    WorkingDirectory = Path.GetDirectoryName(scriptPath) ?? AppDomain.CurrentDomain.BaseDirectory,
+                    UseShellExecute = true
+                };
+
+                using Process process = Process.Start(startInfo);
+                if (process == null)
+                {
+                    SetExternalOcrPackageStatus("프로세스 시작 실패", System.Windows.Media.Brushes.OrangeRed);
+                    System.Windows.MessageBox.Show($"스크립트를 시작하지 못했습니다.\n{scriptFileName}", "OCR 설치/삭제", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
+
+                await process.WaitForExitAsync();
+
+                if (process.ExitCode == 0)
+                {
+                    SetExternalOcrPackageStatus($"{actionLabel} 완료", System.Windows.Media.Brushes.LightGreen);
+                }
+                else
+                {
+                    SetExternalOcrPackageStatus($"{actionLabel} 실패", System.Windows.Media.Brushes.OrangeRed);
+                    System.Windows.MessageBox.Show($"{actionLabel} 스크립트가 실패했습니다.\n종료 코드: {process.ExitCode}", "OCR 설치/삭제", MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                SetExternalOcrPackageStatus($"{actionLabel} 실패", System.Windows.Media.Brushes.OrangeRed);
+                System.Windows.MessageBox.Show($"{actionLabel} 중 오류가 발생했습니다.\n{ex.Message}", "OCR 설치/삭제", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                _isOcrPackageOperationRunning = false;
+                RefreshExternalOcrPackageStatus();
+            }
+        }
+
+        private async Task RunOcrPackageScriptsAsync(IReadOnlyList<(string ScriptFileName, string ActionLabel)> scripts, string emptyStatusText)
+        {
+            if (scripts == null || scripts.Count == 0)
+            {
+                SetExternalOcrPackageStatus(emptyStatusText, System.Windows.Media.Brushes.LightGray);
+                RefreshExternalOcrPackageStatus();
+                return;
+            }
+
+            foreach ((string scriptFileName, string actionLabel) in scripts)
+            {
+                await RunOcrPackageScriptAsync(scriptFileName, actionLabel);
+                if (_isOcrPackageOperationRunning)
+                {
+                    break;
+                }
+            }
         }
 
         /// <summary>
@@ -854,6 +1017,76 @@ namespace GameTranslator
         private void BtnOpenOcrDiagnostic_Click(object sender, RoutedEventArgs e)
         {
             _mainWindow?.ShowOcrDiagnosticWindow();
+        }
+
+        private async void BtnInstallTesseractPackage_Click(object sender, RoutedEventArgs e)
+        {
+            await RunOcrPackageScriptAsync("Install-Tesseract.bat", "Tesseract 설치");
+        }
+
+        private async void BtnUninstallTesseractPackage_Click(object sender, RoutedEventArgs e)
+        {
+            await RunOcrPackageScriptAsync("Uninstall-Tesseract.bat", "Tesseract 삭제");
+        }
+
+        private async void BtnInstallEasyOcrPackage_Click(object sender, RoutedEventArgs e)
+        {
+            await RunOcrPackageScriptAsync("Install-EasyOCR.bat", "EasyOCR 설치");
+        }
+
+        private async void BtnUninstallEasyOcrPackage_Click(object sender, RoutedEventArgs e)
+        {
+            await RunOcrPackageScriptAsync("Uninstall-EasyOCR.bat", "EasyOCR 삭제");
+        }
+
+        private async void BtnInstallPaddleOcrPackage_Click(object sender, RoutedEventArgs e)
+        {
+            await RunOcrPackageScriptAsync("Install-PaddleOCR.bat", "PaddleOCR 설치");
+        }
+
+        private async void BtnUninstallPaddleOcrPackage_Click(object sender, RoutedEventArgs e)
+        {
+            await RunOcrPackageScriptAsync("Uninstall-PaddleOCR.bat", "PaddleOCR 삭제");
+        }
+
+        private async void BtnInstallAllOcrPackages_Click(object sender, RoutedEventArgs e)
+        {
+            var scripts = new List<(string ScriptFileName, string ActionLabel)>();
+            if (!GetTesseractInstallationState().IsInstalled) scripts.Add(("Install-Tesseract.bat", "Tesseract 설치"));
+            if (!GetPythonOcrInstallationState("EasyOcrPythonPath").IsInstalled) scripts.Add(("Install-EasyOCR.bat", "EasyOCR 설치"));
+            if (!GetPythonOcrInstallationState("PaddleOcrPythonPath").IsInstalled) scripts.Add(("Install-PaddleOCR.bat", "PaddleOCR 설치"));
+            await RunOcrPackageScriptsAsync(scripts, "이미 모든 외부 OCR이 설치되어 있습니다.");
+        }
+
+        private async void BtnUninstallAllOcrPackages_Click(object sender, RoutedEventArgs e)
+        {
+            var scripts = new List<(string ScriptFileName, string ActionLabel)>();
+            if (GetTesseractInstallationState().IsInstalled) scripts.Add(("Uninstall-Tesseract.bat", "Tesseract 삭제"));
+            if (GetPythonOcrInstallationState("EasyOcrPythonPath").IsInstalled) scripts.Add(("Uninstall-EasyOCR.bat", "EasyOCR 삭제"));
+            if (GetPythonOcrInstallationState("PaddleOcrPythonPath").IsInstalled) scripts.Add(("Uninstall-PaddleOCR.bat", "PaddleOCR 삭제"));
+            await RunOcrPackageScriptsAsync(scripts, "삭제할 외부 OCR이 없습니다.");
+        }
+    }
+
+    internal sealed class OcrPackageInstallationState
+    {
+        private OcrPackageInstallationState(bool isInstalled, string statusText)
+        {
+            IsInstalled = isInstalled;
+            StatusText = statusText ?? "";
+        }
+
+        public bool IsInstalled { get; }
+        public string StatusText { get; }
+
+        public static OcrPackageInstallationState Installed(string statusText)
+        {
+            return new OcrPackageInstallationState(true, statusText);
+        }
+
+        public static OcrPackageInstallationState NotInstalled(string statusText)
+        {
+            return new OcrPackageInstallationState(false, statusText);
         }
     }
 

--- a/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
+++ b/GameChatTranslator/Views/OptionSelector/OptionSelector.xaml.cs
@@ -475,10 +475,6 @@ namespace GameTranslator
             foreach ((string scriptFileName, string actionLabel) in scripts)
             {
                 await RunOcrPackageScriptAsync(scriptFileName, actionLabel);
-                if (_isOcrPackageOperationRunning)
-                {
-                    break;
-                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ GameChatTranslator는 OCR 엔진별로 필요한 설치 조건이 다릅니다.
 ```text
 - Install-Tesseract.bat
 - 설치가 끝나면 TesseractExePath를 config.ini에 자동 기록
+- Uninstall-Tesseract.bat
+- 제거 시 TesseractExePath를 config.ini에서 정리
 ```
 
 주의:
@@ -189,6 +191,8 @@ py -m pip install torch torchvision easyocr
 - Install-EasyOCR.bat
 - 현재 설치된 Python 3.8+를 사용
 - 전용 venv를 만든 뒤 EasyOcrPythonPath를 config.ini에 자동 기록
+- Uninstall-EasyOCR.bat
+- 제거 시 venv와 EasyOcrPythonPath를 함께 정리
 ```
 
 주의:
@@ -222,6 +226,8 @@ py -m pip install "paddleocr[all]"
 - Python 3.10 전용 venv 생성
 - paddlepaddle==3.2.0 / paddleocr==3.3.3 설치
 - PaddleOcrPythonPath를 config.ini에 자동 기록
+- Uninstall-PaddleOCR.bat
+- 제거 시 venv와 PaddleOcrPythonPath를 함께 정리
 ```
 
 주의:
@@ -240,6 +246,7 @@ py -m pip install "paddleocr[all]"
 
 미설치 언어가 있으면 `LangInstall.bat`를 관리자 권한으로 실행하고 재부팅한 뒤 다시 확인합니다.
 EasyOCR / PaddleOCR / Tesseract까지 한 번에 준비하려면 `Install-All-OCR.bat`를 사용할 수 있습니다.
+EasyOCR / PaddleOCR / Tesseract를 한 번에 정리하려면 `Uninstall-All-OCR.bat`를 사용할 수 있습니다. 이 스크립트에는 Windows OCR 언어팩 제거가 포함되지 않습니다.
 
 ### 2. 캡처 영역 지정
 


### PR DESCRIPTION
## 작업 내용
- 환경설정창에 외부 OCR 설치/삭제 UI 추가
  - Tesseract / EasyOCR / PaddleOCR 엔진별 설치 / 삭제 버튼
  - 전체 설치 / 전체 삭제 버튼
- config.ini의 [OCR] 경로 키와 실제 경로 존재 여부를 기준으로 설치 상태 감지
- 설치됨 -> 설치 버튼 비활성화 / 삭제 버튼 활성화
- 미설치 -> 설치 버튼 활성화 / 삭제 버튼 비활성화
- 작업 중에는 엔진별/전체 버튼 잠금
- 전체 설치/삭제 버튼은 필요한 엔진만 선택적으로 순차 실행
- Windows OCR 언어팩 제거는 별도 PR로 분리

## 검증
- git diff --check 통과
- dotnet build -c Release -p:EnableWindowsTargeting=true 성공
- dotnet test: 468 passed, 0 failed

## 주의
- 이 PR은 #196 위에 쌓인 stacked PR입니다.
- 스크립트 자체의 Windows 실실행 검증은 아직 못 했습니다. 일괄 테스트에서 확인 예정입니다.