### PR TITLE
feat: prevent duplicate app launches

### DIFF
--- a/GameChatTranslator/App.xaml.cs
+++ b/GameChatTranslator/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Windows;
 using GameTranslator;
 using Velopack;
@@ -12,6 +13,13 @@ namespace GameChatTranslator
     /// </summary>
     public partial class App : System.Windows.Application
     {
+        private const string SingleInstanceMutexName = @"Local\GameChatTranslator.SingleInstance";
+        private const string SingleInstanceActivationEventName = @"Local\GameChatTranslator.SingleInstance.Activate";
+
+        private static Mutex singleInstanceMutex;
+        private static EventWaitHandle singleInstanceActivationEvent;
+        private RegisteredWaitHandle activationWaitRegistration;
+
         /// <summary>
         /// Velopack 훅을 WPF 초기화보다 먼저 처리하는 사용자 지정 진입점입니다.
         /// 설치/업데이트 시 Velopack이 특수 인수로 메인 바이너리를 다시 실행하므로,
@@ -25,9 +33,21 @@ namespace GameChatTranslator
                 .SetAutoApplyOnStartup(false)
                 .Run();
 
-            App app = new App();
-            app.InitializeComponent();
-            app.Run();
+            if (!TryAcquireSingleInstance())
+            {
+                return;
+            }
+
+            try
+            {
+                App app = new App();
+                app.InitializeComponent();
+                app.Run();
+            }
+            finally
+            {
+                ReleaseSingleInstance();
+            }
         }
 
         /// <summary>
@@ -40,6 +60,116 @@ namespace GameChatTranslator
             GameTranslator.MainWindow window = new GameTranslator.MainWindow();
             MainWindow = window;
             window.Show();
+
+            if (singleInstanceActivationEvent != null)
+            {
+                activationWaitRegistration = ThreadPool.RegisterWaitForSingleObject(
+                    singleInstanceActivationEvent,
+                    OnSingleInstanceActivationRequested,
+                    null,
+                    Timeout.Infinite,
+                    false);
+            }
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            activationWaitRegistration?.Unregister(null);
+            activationWaitRegistration = null;
+            base.OnExit(e);
+        }
+
+        private static bool TryAcquireSingleInstance()
+        {
+            bool createdNew;
+            singleInstanceMutex = new Mutex(true, SingleInstanceMutexName, out createdNew);
+            if (!createdNew)
+            {
+                try
+                {
+                    singleInstanceMutex.Dispose();
+                }
+                catch
+                {
+                }
+
+                singleInstanceMutex = null;
+                TrySignalExistingInstance();
+                return false;
+            }
+
+            bool createdActivationEvent;
+            singleInstanceActivationEvent = new EventWaitHandle(
+                false,
+                EventResetMode.AutoReset,
+                SingleInstanceActivationEventName,
+                out createdActivationEvent);
+
+            return true;
+        }
+
+        private static void ReleaseSingleInstance()
+        {
+            try
+            {
+                singleInstanceActivationEvent?.Dispose();
+            }
+            catch
+            {
+            }
+            finally
+            {
+                singleInstanceActivationEvent = null;
+            }
+
+            if (singleInstanceMutex == null)
+            {
+                return;
+            }
+
+            try
+            {
+                singleInstanceMutex.ReleaseMutex();
+            }
+            catch (ApplicationException)
+            {
+            }
+            finally
+            {
+                singleInstanceMutex.Dispose();
+                singleInstanceMutex = null;
+            }
+        }
+
+        private static void TrySignalExistingInstance()
+        {
+            for (int attempt = 0; attempt < 5; attempt++)
+            {
+                try
+                {
+                    using EventWaitHandle existingInstanceEvent = EventWaitHandle.OpenExisting(SingleInstanceActivationEventName);
+                    existingInstanceEvent.Set();
+                    return;
+                }
+                catch (WaitHandleCannotBeOpenedException)
+                {
+                    Thread.Sleep(150);
+                }
+            }
+        }
+
+        private void OnSingleInstanceActivationRequested(object state, bool timedOut)
+        {
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                if (MainWindow is GameTranslator.MainWindow gameTranslatorMainWindow)
+                {
+                    gameTranslatorMainWindow.ActivateFromSingleInstanceRequest();
+                    return;
+                }
+
+                MainWindow?.Activate();
+            }));
         }
     }
 

--- a/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Lifecycle.cs
@@ -243,6 +243,31 @@ namespace GameTranslator
             settingsWindow.Activate();
         }
 
+        public void ActivateFromSingleInstanceRequest()
+        {
+            if (settingsWindow != null)
+            {
+                if (settingsWindow.WindowState == WindowState.Minimized)
+                {
+                    settingsWindow.WindowState = WindowState.Normal;
+                }
+
+                settingsWindow.Show();
+                settingsWindow.Activate();
+                return;
+            }
+
+            if (WindowState == WindowState.Minimized)
+            {
+                WindowState = WindowState.Normal;
+            }
+
+            Show();
+            Activate();
+            Topmost = false;
+            Topmost = true;
+        }
+
         /// <summary>
         /// 환경설정창에서 이동 잠금 전환을 요청할 때 사용하는 래퍼입니다.
         /// </summary>


### PR DESCRIPTION
## Summary\n- add single-instance guard at app startup using a named mutex\n- signal the existing instance to activate instead of opening a second process\n- restore and focus the settings window or main window on duplicate launch\n\n## Verification\n- git diff --check\n- ~/.dotnet/dotnet build GameChatTranslator/GameChatTranslator.csproj -c Release -p:EnableWindowsTargeting=true\n- ~/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true