### PR TITLE
chore: point release URLs to TailFox-Forge

### DIFF
--- a/GameChatTranslator/Views/MainWindow/MainWindow.Update.cs
+++ b/GameChatTranslator/Views/MainWindow/MainWindow.Update.cs
@@ -20,9 +20,9 @@ namespace GameTranslator
     /// </summary>
     public partial class MainWindow
     {
-        private const string GitHubRepoUrl = "https://github.com/SeoArin9142/GameChatTranslator";
-        private const string ReleaseListApiUrl = "https://api.github.com/repos/SeoArin9142/GameChatTranslator/releases?per_page=10";
-        private const string ReleasePageUrl = "https://github.com/SeoArin9142/GameChatTranslator/releases";
+        private const string GitHubRepoUrl = "https://github.com/TailFox-Forge/GameChatTranslator";
+        private const string ReleaseListApiUrl = "https://api.github.com/repos/TailFox-Forge/GameChatTranslator/releases?per_page=10";
+        private const string ReleasePageUrl = "https://github.com/TailFox-Forge/GameChatTranslator/releases";
 
         /// <summary>
         /// 업데이트 확인이 시작 시 자동으로 실행된 것인지, 사용자가 버튼으로 수동 실행한 것인지 구분합니다.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 최신 배포 파일:
 
-[GameChatTranslator v1.0.33-alpha 다운로드](https://github.com/SeoArin9142/GameChatTranslator/releases/download/v1.0.33-alpha/GameChatTranslator_v1.0.33-alpha.zip)
+[GameChatTranslator v1.0.33-alpha 다운로드](https://github.com/TailFox-Forge/GameChatTranslator/releases/download/v1.0.33-alpha/GameChatTranslator_v1.0.33-alpha.zip)
 
 릴리즈 페이지:
 
-https://github.com/SeoArin9142/GameChatTranslator/releases
+https://github.com/TailFox-Forge/GameChatTranslator/releases
 
 권장 배포 방식:
 


### PR DESCRIPTION
## Summary\n- update release and repository URLs to TailFox-Forge/GameChatTranslator\n- point the in-app update checker at the transferred repository\n- refresh README release links to the new canonical repository\n\n## Verification\n- git diff --check\n- ~/.dotnet/dotnet build GameChatTranslator/GameChatTranslator.csproj -c Release -p:EnableWindowsTargeting=true\n- ~/.dotnet/dotnet test GameChatTranslator.sln -p:EnableWindowsTargeting=true